### PR TITLE
Check for styleOverrides before attempting to parse

### DIFF
--- a/stencil-library/package.json
+++ b/stencil-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "JustiFi Web Components",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",

--- a/stencil-library/src/components.d.ts
+++ b/stencil-library/src/components.d.ts
@@ -22,7 +22,7 @@ export namespace Components {
     interface JustifiPaymentMethodForm {
         "paymentMethodFormType": 'card' | 'bankAccount';
         "paymentMethodFormValidationStrategy": 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
-        "paymentMethodStyleOverrides": Theme;
+        "paymentMethodStyleOverrides": Theme | undefined;
         "tokenize": (clientKey: string, paymentMethodMetadata: any, account?: string) => Promise<any>;
         "validate": () => Promise<any>;
     }
@@ -95,7 +95,7 @@ declare namespace LocalJSX {
         "onPaymentMethodFormTokenize"?: (event: JustifiPaymentMethodFormCustomEvent<{ data: any }>) => void;
         "paymentMethodFormType"?: 'card' | 'bankAccount';
         "paymentMethodFormValidationStrategy"?: 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
-        "paymentMethodStyleOverrides"?: Theme;
+        "paymentMethodStyleOverrides"?: Theme | undefined;
     }
     interface JustifiPaymentsList {
         "accountId"?: string;

--- a/stencil-library/src/components/bank-account-form/bank-account-form.tsx
+++ b/stencil-library/src/components/bank-account-form/bank-account-form.tsx
@@ -34,8 +34,10 @@ export class BankAccountForm {
 
   @Watch('styleOverrides')
   parseStyleOverrides() {
-    const parsedStyleOverrides = JSON.parse(this.styleOverrides);
-    this.internalStyleOverrides = parsedStyleOverrides;
+    if (this.styleOverrides) {
+      const parsedStyleOverrides = JSON.parse(this.styleOverrides);
+      this.internalStyleOverrides = parsedStyleOverrides;
+    }
   }
 
   private childRef?: HTMLJustifiPaymentMethodFormElement;

--- a/stencil-library/src/components/card-form/card-form.tsx
+++ b/stencil-library/src/components/card-form/card-form.tsx
@@ -34,8 +34,10 @@ export class CardForm {
 
   @Watch('styleOverrides')
   parseStyleOverrides() {
-    const parsedStyleOverrides = JSON.parse(this.styleOverrides);
-    this.internalStyleOverrides = parsedStyleOverrides;
+    if (this.styleOverrides) {
+      const parsedStyleOverrides = JSON.parse(this.styleOverrides);
+      this.internalStyleOverrides = parsedStyleOverrides;
+    }
   }
 
   private childRef?: HTMLJustifiPaymentMethodFormElement;

--- a/stencil-library/src/components/card-form/readme.md
+++ b/stencil-library/src/components/card-form/readme.md
@@ -103,6 +103,7 @@ The `style-overrides` attribute below requires type `string`, but should be a st
 
 <!-- Auto Generated Below -->
 
+
 ## Properties
 
 | Property             | Attribute             | Description | Type                                                           | Default     |

--- a/stencil-library/src/components/payment-method-form/payment-method-form.tsx
+++ b/stencil-library/src/components/payment-method-form/payment-method-form.tsx
@@ -10,7 +10,7 @@ import { Theme } from './theme';
 export class PaymentMethodForm {
   @Prop() paymentMethodFormType: 'card' | 'bankAccount';
   @Prop() paymentMethodFormValidationStrategy: 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
-  @Prop() paymentMethodStyleOverrides: Theme;
+  @Prop() paymentMethodStyleOverrides: Theme | undefined;
   @Event({ bubbles: true }) paymentMethodFormReady: EventEmitter;
   @Event({ bubbles: true }) paymentMethodFormTokenize: EventEmitter<{ data: any }>;
   @State() height: number = 55;


### PR DESCRIPTION
<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

**Guidelines:**

* Keep Pull Request titles short and to the point, ideally under 72 characters
* Provide as much context/info in the description as necessary to get the
  reviewer up to the same domain knowledge level as yourself
* Keep code changes as short as possible and implementing a single
  feature/fix/refactoring, when possible
-->

Type of Change
--------------

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->


Steps for Testing/QA
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

