### PR TITLE
Rename clientKey to clientId

### DIFF
--- a/stencil-library/docs.json
+++ b/stencil-library/docs.json
@@ -1,0 +1,487 @@
+{
+  "timestamp": "2023-03-10T17:22:15",
+  "compiler": {
+    "name": "@stencil/core",
+    "version": "2.20.0",
+    "typescriptVersion": "4.8.4"
+  },
+  "components": [
+    {
+      "filePath": "./src/components/bank-account-form/bank-account-form.tsx",
+      "encapsulation": "none",
+      "tag": "justifi-bank-account-form",
+      "readme": "# justifi-bank-account-form\n\n<img width=\"363\" alt=\"Screen Shot 2023-02-01 at 3 14 56 PM\" src=\"https://user-images.githubusercontent.com/3867103/216165019-022ee74d-16fe-44e3-a430-1a027a061805.png\">\n\n\n## Example\n```html\n<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"en\">\n\n<head>\n  <meta charset=\"utf-8\" />\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0\" />\n  <title>justifi-bank-account-form: Simple example</title>\n\n  <!--\n    If you are including the components via CDN the src should be the following:\n    https://unpkg.com/@justifi/webcomponents@<version>/dist/webcomponents/webcomponents.esm.js\n  -->\n  <script type=\"module\" src=\"/build/webcomponents.esm.js\"></script>\n  <script nomodule src=\"/build/webcomponents.js\"></script>\n</head>\n\n<body>\n  <h1>Bank Account Form</h1>\n  <hr>\n  <!--\n    The 'style-overrides' prop takes a stringified instance of Theme. The type and all optional\n    members for Theme can be found here:\n    https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/payment-method-form/theme.ts\n  -->\n  <justifi-bank-account-form style-overrides='{\n    \"layout\":{\n      \"padding\":\"0\",\n      \"formControlSpacingHorizontal\":\".5rem\",\n      \"formControlSpacingVertical\":\"1rem\"\n    },\n    \"formLabel\":{\n      \"fontWeight\":700,\n      \"fontFamily\":\"sans-serif\",\n      \"margin\":\"0 0 .5rem 0\"\n    },\n    \"formControl\":{\n      \"backgroundColor\":\"#F4F4F6\",\n      \"backgroundColorHover\":\"#EEEEF5\",\n      \"borderColor\":\"rgba(0, 0, 0, 0.42)\",\n      \"borderColorHover\":\"rgba(0, 0, 0, 0.62)\",\n      \"borderColorFocus\":\"#fccc32\",\n      \"borderColorError\":\"#C12727\",\n      \"borderWidth\":\"0px\",\n      \"borderBottomWidth\":\"1px\",\n      \"borderRadius\":\"4px 4px 0 0\",\n      \"borderStyle\":\"solid\",\n      \"boxShadowErrorFocus\":\"none\",\n      \"boxShadowFocus\":\"none\",\n      \"color\":\"#212529\",\n      \"fontSize\":\"1rem\",\n      \"fontWeight\":\"400\",\n      \"lineHeight\":\"2\",\n      \"margin\":\"0\",\n      \"padding\":\".5rem .875rem\"\n    },\n    \"errorMessage\":{\n      \"color\":\"#C12727\",\n      \"margin\":\".25rem 0 0 0\",\n      \"fontSize\":\".875rem\"\n    }\n  }'></justifi-bank-account-form>\n  <button type=\"submit\" id=\"bank-account-submit-button\">Tokenize</button>\n  <button type=\"submit\" id=\"bank-account-validate-button\">Validate</button>\n</body>\n\n<script>\n  (function () {\n    var bankAccountForm = document.querySelector('justifi-bank-account-form');\n    var bankAccountSubmitButton = document.querySelector('#bank-account-submit-button');\n    var bankAccountValidateButton = document.querySelector('#bank-account-validate-button');\n\n    bankAccountForm.addEventListener('bankAccountFormReady', function () {\n      console.log('justifi-bank-account-form ready');\n    });\n\n    bankAccountSubmitButton.addEventListener('click', (event) => {\n      console.log('bank account form tokenize button clicked');\n      // All of this information would come from your form instead of being hard coded\n      // Account / routing number are collected on our iframe\n      const paymentMethodData = {\n        name: 'John Doe', // can also pass account_owner_name\n        account_type: 'checking', // checking or savings\n        account_owner_type: 'individual' // individual or company\n      };\n      // ACCOUNT_ID is optional, currently required for platforms\n      // ACCOUNT_ID is the seller account for which you are tokenizing\n      bankAccountForm.tokenize('CLIENT_ID', paymentMethodData, 'ACCOUNT_ID')\n        .then((data) => {\n          // This is where you can submit the form and use the payment method token\n          // on your backend\n          console.log('justifi-bank-account-form tokenized: ', data);\n        })\n    });\n\n    bankAccountValidateButton.addEventListener('click', (event) => {\n      console.log('bank account validate button clicked');\n      bankAccountForm.validate()\n        .then((data) => {\n          console.log('justifi-bank-account-form validated. Is valid? ', data.isValid);\n        });\n    });\n  })();\n</script>\n\n</html>\n```\n\n## Styling\nThe `style-overrides` attribute below requires type `string`, but should be a stringified [`Theme`](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/payment-method-form/theme.ts)\n",
+      "docs": "<img width=\"363\" alt=\"Screen Shot 2023-02-01 at 3 14 56 PM\" src=\"https://user-images.githubusercontent.com/3867103/216165019-022ee74d-16fe-44e3-a430-1a027a061805.png\">",
+      "docsTags": [],
+      "usage": {},
+      "props": [
+        {
+          "name": "styleOverrides",
+          "type": "string",
+          "mutable": false,
+          "attr": "style-overrides",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": true,
+          "required": false
+        },
+        {
+          "name": "validationStrategy",
+          "type": "\"all\" | \"onBlur\" | \"onChange\" | \"onSubmit\" | \"onTouched\"",
+          "mutable": false,
+          "attr": "validation-strategy",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "value": "all",
+              "type": "string"
+            },
+            {
+              "value": "onBlur",
+              "type": "string"
+            },
+            {
+              "value": "onChange",
+              "type": "string"
+            },
+            {
+              "value": "onSubmit",
+              "type": "string"
+            },
+            {
+              "value": "onTouched",
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        }
+      ],
+      "methods": [
+        {
+          "name": "tokenize",
+          "returns": {
+            "type": "Promise<any>",
+            "docs": ""
+          },
+          "signature": "tokenize(clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "name": "validate",
+          "returns": {
+            "type": "Promise<any>",
+            "docs": ""
+          },
+          "signature": "validate() => Promise<any>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "events": [
+        {
+          "event": "bankAccountFormReady",
+          "detail": "any",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "event": "bankAccountFormTokenize",
+          "detail": "{ data: any; }",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "event": "bankAccountFormValidate",
+          "detail": "{ data: { isValid: boolean; }; }",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "listeners": [
+        {
+          "event": "paymentMethodFormReady",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "paymentMethodFormTokenize",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "paymentMethodFormValidate",
+          "capture": false,
+          "passive": false
+        }
+      ],
+      "styles": [],
+      "slots": [],
+      "parts": [],
+      "dependents": [],
+      "dependencies": [
+        "justifi-payment-method-form"
+      ],
+      "dependencyGraph": {
+        "justifi-bank-account-form": [
+          "justifi-payment-method-form"
+        ]
+      }
+    },
+    {
+      "filePath": "./src/components/card-form/card-form.tsx",
+      "encapsulation": "none",
+      "tag": "justifi-card-form",
+      "readme": "# justifi-card-form\n\n<img width=\"364\" alt=\"Screen Shot 2023-02-01 at 3 14 32 PM\" src=\"https://user-images.githubusercontent.com/3867103/216165095-5c9f8206-190e-4dff-91ea-a8583f2c011b.png\">\n\n\n## Examples\n```html\n<!DOCTYPE html>\n<html dir=\"ltr\" lang=\"en\">\n\n<head>\n  <meta charset=\"utf-8\" />\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0\" />\n  <title>justifi-card-form: Simple example</title>\n\n  <!--\n    If you are including the components via CDN the src should be the following:\n    https://unpkg.com/@justifi/webcomponents@<version>/dist/webcomponents/webcomponents.esm.js\n  -->\n  <script type=\"module\" src=\"/build/webcomponents.esm.js\"></script>\n  <script nomodule src=\"/build/webcomponents.js\"></script>\n</head>\n\n<body>\n  <h1>Card Form</h1>\n  <hr>\n  <!--\n    The 'style-overrides' prop takes a stringified instance of Theme. The type and all optional\n    members for Theme can be found here:\n    https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/payment-method-form/theme.ts\n  -->\n  <justifi-card-form style-overrides='{\n    \"layout\":{\n      \"padding\":\"0\",\n      \"formControlSpacingHorizontal\":\".5rem\",\n      \"formControlSpacingVertical\":\"1rem\"\n    },\n    \"formLabel\":{\n      \"fontWeight\":700,\n      \"fontFamily\":\"sans-serif\",\n      \"margin\":\"0 0 .5rem 0\"\n    },\n    \"formControl\":{\n      \"backgroundColor\":\"#F4F4F6\",\n      \"backgroundColorHover\":\"#EEEEF5\",\n      \"borderColor\":\"rgba(0, 0, 0, 0.42)\",\n      \"borderColorHover\":\"rgba(0, 0, 0, 0.62)\",\n      \"borderColorFocus\":\"#fccc32\",\n      \"borderColorError\":\"#C12727\",\n      \"borderWidth\":\"0px\",\n      \"borderBottomWidth\":\"1px\",\n      \"borderRadius\":\"4px 4px 0 0\",\n      \"borderStyle\":\"solid\",\n      \"boxShadowErrorFocus\":\"none\",\n      \"boxShadowFocus\":\"none\",\n      \"color\":\"#212529\",\n      \"fontSize\":\"1rem\",\n      \"fontWeight\":\"400\",\n      \"lineHeight\":\"2\",\n      \"margin\":\"0\",\n      \"padding\":\".5rem .875rem\"\n    },\n    \"errorMessage\":{\n      \"color\":\"#C12727\",\n      \"margin\":\".25rem 0 0 0\",\n      \"fontSize\":\".875rem\"\n    }\n  }'></justifi-card-form>\n  <button type=\"submit\" id=\"card-submit-button\">Tokenize</button>\n  <button type=\"submit\" id=\"card-validate-button\">Validate</button>\n</body>\n\n<script>\n  (function () {\n    var cardForm = document.querySelector('justifi-card-form');\n    var cardSubmitButton = document.querySelector('#card-submit-button');\n    var cardValidateButton = document.querySelector('#card-validate-button');\n\n    cardForm.addEventListener('cardFormReady', function () {\n      console.log('justifi-card-form ready');\n    });\n\n    cardSubmitButton.addEventListener('click', (event) => {\n      console.log('card form tokenize button clicked');\n      // All of this information would come from your form instead of being hard coded\n      // Card number, expiration and cvv are collected on our iframe\n      const paymentMethodData = {\n        name: 'John Doe',\n        address_line1: '123 Broadway', // optional\n        address_line2: '', // optional\n        address_city: 'Minneapolis', // optional\n        address_state: 'MN', // optional\n        address_postal_code: '55413', \n        address_country: 'US', // optional\n        metadata: { something: \"somevalue\" } // optional\n      };\n      // ACCOUNT_ID is optional, currently required for platforms\n      // ACCOUNT_ID is the seller account for which you are tokenizing\n      cardForm.tokenize('CLIENT_ID', paymentMethodData, 'ACCOUNT_ID')\n        .then((data) => {\n          // This is where you can submit the form and use the payment method token\n          // on your backend\n          console.log('justifi-card-form tokenized: ', data);\n        });\n    });\n\n    cardValidateButton.addEventListener('click', (event) => {\n      console.log('card validate button clicked');\n      cardForm.validate()\n        .then((data) => {\n          console.log('justifi-card-form validated. Is valid? ', data.isValid);\n        });\n    });\n  })();\n</script>\n\n</html>\n```\n\n## Styling\nThe `style-overrides` attribute below requires type `string`, but should be a stringified [`Theme`](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/payment-method-form/theme.ts)\n",
+      "docs": "<img width=\"364\" alt=\"Screen Shot 2023-02-01 at 3 14 32 PM\" src=\"https://user-images.githubusercontent.com/3867103/216165095-5c9f8206-190e-4dff-91ea-a8583f2c011b.png\">",
+      "docsTags": [],
+      "usage": {},
+      "props": [
+        {
+          "name": "styleOverrides",
+          "type": "string",
+          "mutable": false,
+          "attr": "style-overrides",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": true,
+          "required": false
+        },
+        {
+          "name": "validationStrategy",
+          "type": "\"all\" | \"onBlur\" | \"onChange\" | \"onSubmit\" | \"onTouched\"",
+          "mutable": false,
+          "attr": "validation-strategy",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "value": "all",
+              "type": "string"
+            },
+            {
+              "value": "onBlur",
+              "type": "string"
+            },
+            {
+              "value": "onChange",
+              "type": "string"
+            },
+            {
+              "value": "onSubmit",
+              "type": "string"
+            },
+            {
+              "value": "onTouched",
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        }
+      ],
+      "methods": [
+        {
+          "name": "tokenize",
+          "returns": {
+            "type": "Promise<any>",
+            "docs": ""
+          },
+          "signature": "tokenize(clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "name": "validate",
+          "returns": {
+            "type": "Promise<any>",
+            "docs": ""
+          },
+          "signature": "validate() => Promise<any>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "events": [
+        {
+          "event": "cardFormReady",
+          "detail": "any",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "event": "cardFormTokenize",
+          "detail": "{ data: any; }",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "event": "cardFormValidate",
+          "detail": "{ data: { isValid: boolean; }; }",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "listeners": [
+        {
+          "event": "paymentMethodFormReady",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "paymentMethodFormTokenize",
+          "capture": false,
+          "passive": false
+        },
+        {
+          "event": "paymentMethodFormValidate",
+          "capture": false,
+          "passive": false
+        }
+      ],
+      "styles": [],
+      "slots": [],
+      "parts": [],
+      "dependents": [],
+      "dependencies": [
+        "justifi-payment-method-form"
+      ],
+      "dependencyGraph": {
+        "justifi-card-form": [
+          "justifi-payment-method-form"
+        ]
+      }
+    },
+    {
+      "filePath": "./src/components/payment-method-form/payment-method-form.tsx",
+      "encapsulation": "none",
+      "tag": "justifi-payment-method-form",
+      "readme": "# justifi-payment-method-form\n\nThis component is intended for internal use by `justifi-card-form` and `justifi-bank-account-form`\n",
+      "docs": "This component is intended for internal use by `justifi-card-form` and `justifi-bank-account-form`",
+      "docsTags": [],
+      "usage": {},
+      "props": [
+        {
+          "name": "paymentMethodFormType",
+          "type": "\"bankAccount\" | \"card\"",
+          "mutable": false,
+          "attr": "payment-method-form-type",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "value": "bankAccount",
+              "type": "string"
+            },
+            {
+              "value": "card",
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
+          "name": "paymentMethodFormValidationStrategy",
+          "type": "\"all\" | \"onBlur\" | \"onChange\" | \"onSubmit\" | \"onTouched\"",
+          "mutable": false,
+          "attr": "payment-method-form-validation-strategy",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "value": "all",
+              "type": "string"
+            },
+            {
+              "value": "onBlur",
+              "type": "string"
+            },
+            {
+              "value": "onChange",
+              "type": "string"
+            },
+            {
+              "value": "onSubmit",
+              "type": "string"
+            },
+            {
+              "value": "onTouched",
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
+          "name": "paymentMethodStyleOverrides",
+          "type": "Theme",
+          "mutable": false,
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "Theme"
+            }
+          ],
+          "optional": false,
+          "required": false
+        }
+      ],
+      "methods": [
+        {
+          "name": "tokenize",
+          "returns": {
+            "type": "Promise<any>",
+            "docs": ""
+          },
+          "signature": "tokenize(clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "name": "validate",
+          "returns": {
+            "type": "Promise<any>",
+            "docs": ""
+          },
+          "signature": "validate() => Promise<any>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "events": [
+        {
+          "event": "paymentMethodFormReady",
+          "detail": "any",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        },
+        {
+          "event": "paymentMethodFormTokenize",
+          "detail": "{ data: any; }",
+          "bubbles": true,
+          "cancelable": true,
+          "composed": true,
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "listeners": [],
+      "styles": [],
+      "slots": [],
+      "parts": [],
+      "dependents": [
+        "justifi-bank-account-form",
+        "justifi-card-form"
+      ],
+      "dependencies": [],
+      "dependencyGraph": {
+        "justifi-bank-account-form": [
+          "justifi-payment-method-form"
+        ],
+        "justifi-card-form": [
+          "justifi-payment-method-form"
+        ]
+      }
+    },
+    {
+      "filePath": "./src/components/payments-list/payments-list.tsx",
+      "encapsulation": "shadow",
+      "tag": "justifi-payments-list",
+      "readme": "# justifi-payments-list\n\n\n",
+      "docs": "",
+      "docsTags": [],
+      "usage": {},
+      "props": [
+        {
+          "name": "accountId",
+          "type": "string",
+          "mutable": false,
+          "attr": "account-id",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
+          "name": "auth",
+          "type": "{ token?: string; }",
+          "mutable": false,
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "default": "{}",
+          "values": [
+            {
+              "type": "{ token?: string; }"
+            }
+          ],
+          "optional": false,
+          "required": false
+        }
+      ],
+      "methods": [],
+      "events": [],
+      "listeners": [],
+      "styles": [],
+      "slots": [],
+      "parts": [],
+      "dependents": [],
+      "dependencies": [],
+      "dependencyGraph": {}
+    }
+  ]
+}

--- a/stencil-library/src/components.d.ts
+++ b/stencil-library/src/components.d.ts
@@ -9,13 +9,13 @@ import { Theme } from "./components/payment-method-form/theme";
 export namespace Components {
     interface JustifiBankAccountForm {
         "styleOverrides"?: string;
-        "tokenize": (clientKey: string, paymentMethodMetadata: any, account?: string) => Promise<any>;
+        "tokenize": (clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>;
         "validate": () => Promise<any>;
         "validationStrategy": 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
     }
     interface JustifiCardForm {
         "styleOverrides"?: string;
-        "tokenize": (clientKey: string, paymentMethodMetadata: any, account?: string) => Promise<any>;
+        "tokenize": (clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>;
         "validate": () => Promise<any>;
         "validationStrategy": 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
     }
@@ -23,7 +23,7 @@ export namespace Components {
         "paymentMethodFormType": 'card' | 'bankAccount';
         "paymentMethodFormValidationStrategy": 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
         "paymentMethodStyleOverrides": Theme | undefined;
-        "tokenize": (clientKey: string, paymentMethodMetadata: any, account?: string) => Promise<any>;
+        "tokenize": (clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>;
         "validate": () => Promise<any>;
     }
     interface JustifiPaymentsList {

--- a/stencil-library/src/components/bank-account-form/readme.md
+++ b/stencil-library/src/components/bank-account-form/readme.md
@@ -137,7 +137,7 @@ The `style-overrides` attribute below requires type `string`, but should be a st
 
 ## Methods
 
-### `tokenize(clientKey: string, paymentMethodMetadata: any, account?: string) => Promise<any>`
+### `tokenize(clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>`
 
 
 

--- a/stencil-library/src/components/bank-account-form/test/bank-account-form.spec.tsx
+++ b/stencil-library/src/components/bank-account-form/test/bank-account-form.spec.tsx
@@ -36,7 +36,7 @@ describe('justifi-bank-account-form', () => {
     (bankAccountForm as any).childRef = { tokenize: () => { } };
     const childRefTokenizeSpy = jest.spyOn((bankAccountForm as any).childRef, 'tokenize');
 
-    bankAccountForm.tokenize('clientKey', { paymentMethod: 'metadata' }, 'accountId');
+    bankAccountForm.tokenize('clientId', { paymentMethod: 'metadata' }, 'accountId');
     expect(childRefTokenizeSpy).toHaveBeenCalled();
   });
 });

--- a/stencil-library/src/components/card-form/readme.md
+++ b/stencil-library/src/components/card-form/readme.md
@@ -142,7 +142,7 @@ The `style-overrides` attribute below requires type `string`, but should be a st
 
 ## Methods
 
-### `tokenize(clientKey: string, paymentMethodMetadata: any, account?: string) => Promise<any>`
+### `tokenize(clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>`
 
 
 

--- a/stencil-library/src/components/card-form/test/card-form.spec.tsx
+++ b/stencil-library/src/components/card-form/test/card-form.spec.tsx
@@ -36,7 +36,7 @@ describe('justifi-card-form', () => {
     (cardForm as any).childRef = { tokenize: () => { } };
     const childRefTokenizeSpy = jest.spyOn((cardForm as any).childRef, 'tokenize');
 
-    cardForm.tokenize('clientKey', { paymentMethod: 'metadata' }, 'accountId');
+    cardForm.tokenize('clientId', { paymentMethod: 'metadata' }, 'accountId');
     expect(childRefTokenizeSpy).toHaveBeenCalled();
   });
 });

--- a/stencil-library/src/components/payment-method-form/payment-method-form.tsx
+++ b/stencil-library/src/components/payment-method-form/payment-method-form.tsx
@@ -72,10 +72,10 @@ export class PaymentMethodForm {
   }
 
   @Method()
-  async tokenize(clientKey: string, paymentMethodMetadata: any, account?: string): Promise<any> {
+  async tokenize(clientId: string, paymentMethodMetadata: any, account?: string): Promise<any> {
     const eventType = MessageEventType[this.paymentMethodFormType].tokenize;
     const payload = {
-      clientKey: clientKey,
+      clientId: clientId,
       paymentMethodMetadata: paymentMethodMetadata,
       account: account
     };

--- a/stencil-library/src/components/payment-method-form/readme.md
+++ b/stencil-library/src/components/payment-method-form/readme.md
@@ -24,7 +24,7 @@ This component is intended for internal use by `justifi-card-form` and `justifi-
 
 ## Methods
 
-### `tokenize(clientKey: string, paymentMethodMetadata: any, account?: string) => Promise<any>`
+### `tokenize(clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>`
 
 
 

--- a/stencil-library/src/components/payment-method-form/test/payment-method-form.spec.tsx
+++ b/stencil-library/src/components/payment-method-form/test/payment-method-form.spec.tsx
@@ -17,15 +17,15 @@ describe('justifi-payment-method-form', () => {
   it('has a tokenize method which calls triggerTokenization', async () => {
     const paymentMethodForm = new PaymentMethodForm();
     expect(paymentMethodForm.tokenize).toBeDefined();
-    const clientKey = 'abc123';
+    const clientId = 'abc123';
     const paymentMethodMetadata = {};
     const accountId = 'def456';
     const triggerTokenizationSpy = jest.spyOn((paymentMethodForm as any), 'triggerTokenization');
 
-    paymentMethodForm.tokenize(clientKey, paymentMethodMetadata);
-    expect(triggerTokenizationSpy).toHaveBeenCalledWith(clientKey, paymentMethodMetadata, undefined);
+    paymentMethodForm.tokenize(clientId, paymentMethodMetadata);
+    expect(triggerTokenizationSpy).toHaveBeenCalledWith(clientId, paymentMethodMetadata, undefined);
 
-    paymentMethodForm.tokenize(clientKey, paymentMethodMetadata, accountId);
-    expect(triggerTokenizationSpy).toHaveBeenCalledWith(clientKey, paymentMethodMetadata, accountId);
+    paymentMethodForm.tokenize(clientId, paymentMethodMetadata, accountId);
+    expect(triggerTokenizationSpy).toHaveBeenCalledWith(clientId, paymentMethodMetadata, accountId);
   });
 });


### PR DESCRIPTION
Rename `clientKey` to `clientId`.

Solves: https://justifi-ai.atlassian.net/browse/FE-46

This change should not really break anything since the work `clientKey` is never actually used externally, just internally.

The call signature is `fn(clientKey, arg2, arg3)` so when calling it, it would always be used as `fn(<clientKey string>, arg2, arg3)`. No explicit use of the keyword `clientKey` or `clientId` (no named arguments as in an object).

Type of Change
--------------

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] [Potentially] Breaking change (would cause existing functionality to not work as expected)
* [x] This change requires a documentation update
* [x] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing