### PR TITLE
Create generic business-address component

### DIFF
--- a/react-library/src/components/stencil-generated/index.ts
+++ b/react-library/src/components/stencil-generated/index.ts
@@ -10,6 +10,7 @@ import { defineCustomElements } from '@justifi/webcomponents/loader';
 defineCustomElements();
 export const JustifiBankAccountForm = /*@__PURE__*/createReactComponent<JSX.JustifiBankAccountForm, HTMLJustifiBankAccountFormElement>('justifi-bank-account-form');
 export const JustifiBillingForm = /*@__PURE__*/createReactComponent<JSX.JustifiBillingForm, HTMLJustifiBillingFormElement>('justifi-billing-form');
+export const JustifiBusinessAddress = /*@__PURE__*/createReactComponent<JSX.JustifiBusinessAddress, HTMLJustifiBusinessAddressElement>('justifi-business-address');
 export const JustifiCardForm = /*@__PURE__*/createReactComponent<JSX.JustifiCardForm, HTMLJustifiCardFormElement>('justifi-card-form');
 export const JustifiPaymentForm = /*@__PURE__*/createReactComponent<JSX.JustifiPaymentForm, HTMLJustifiPaymentFormElement>('justifi-payment-form');
 export const JustifiPaymentMethodForm = /*@__PURE__*/createReactComponent<JSX.JustifiPaymentMethodForm, HTMLJustifiPaymentMethodFormElement>('justifi-payment-method-form');

--- a/stencil-library/docs.json
+++ b/stencil-library/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-05-15T18:11:05",
+  "timestamp": "2023-05-23T20:38:09",
   "compiler": {
     "name": "@stencil/core",
     "version": "2.20.0",
@@ -272,6 +272,45 @@
         ],
         "justifi-payment-form": [
           "justifi-billing-form"
+        ]
+      }
+    },
+    {
+      "filePath": "./src/components/business-address/business-address.tsx",
+      "encapsulation": "shadow",
+      "tag": "justifi-business-address",
+      "readme": "# justifi-business-address\n\n\n",
+      "docs": "",
+      "docsTags": [],
+      "usage": {},
+      "props": [],
+      "methods": [
+        {
+          "name": "submit",
+          "returns": {
+            "type": "Promise<{ isValid: boolean; values: BusinessAddressFormFields; }>",
+            "docs": ""
+          },
+          "signature": "submit() => Promise<{ isValid: boolean; values: BusinessAddressFormFields; }>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "events": [],
+      "listeners": [],
+      "styles": [],
+      "slots": [],
+      "parts": [],
+      "dependents": [],
+      "dependencies": [
+        "text-input",
+        "select-input"
+      ],
+      "dependencyGraph": {
+        "justifi-business-address": [
+          "text-input",
+          "select-input"
         ]
       }
     },
@@ -1030,11 +1069,15 @@
         }
       ],
       "dependents": [
-        "justifi-billing-form"
+        "justifi-billing-form",
+        "justifi-business-address"
       ],
       "dependencies": [],
       "dependencyGraph": {
         "justifi-billing-form": [
+          "select-input"
+        ],
+        "justifi-business-address": [
           "select-input"
         ]
       }
@@ -1135,11 +1178,15 @@
         }
       ],
       "dependents": [
-        "justifi-billing-form"
+        "justifi-billing-form",
+        "justifi-business-address"
       ],
       "dependencies": [],
       "dependencyGraph": {
         "justifi-billing-form": [
+          "text-input"
+        ],
+        "justifi-business-address": [
           "text-input"
         ]
       }

--- a/stencil-library/docs.json
+++ b/stencil-library/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-05-23T20:38:09",
+  "timestamp": "2023-05-24T05:18:07",
   "compiler": {
     "name": "@stencil/core",
     "version": "2.20.0",
@@ -298,7 +298,13 @@
         }
       ],
       "events": [],
-      "listeners": [],
+      "listeners": [
+        {
+          "event": "fieldReceivedInput",
+          "capture": false,
+          "passive": false
+        }
+      ],
       "styles": [],
       "slots": [],
       "parts": [],

--- a/stencil-library/src/components.d.ts
+++ b/stencil-library/src/components.d.ts
@@ -8,6 +8,7 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { CreatePaymentMethodResponse } from "./components/payment-method-form/payment-method-responses";
 import { BillingFormFields } from "./components/billing-form/billing-form-schema";
 import { ValidationError } from "yup";
+import { BusinessAddressFormFields } from "./components/business-address/business-address-schema";
 import { PaymentMethodTypes } from "./api";
 export namespace Components {
     interface JustifiBankAccountForm {
@@ -47,6 +48,9 @@ export namespace Components {
           * Run validation on the form
          */
         "validate": () => Promise<{ isValid: boolean; }>;
+    }
+    interface JustifiBusinessAddress {
+        "submit": () => Promise<{ isValid: boolean; values: BusinessAddressFormFields; }>;
     }
     interface JustifiCardForm {
         /**
@@ -152,6 +156,12 @@ declare global {
         prototype: HTMLJustifiBillingFormElement;
         new (): HTMLJustifiBillingFormElement;
     };
+    interface HTMLJustifiBusinessAddressElement extends Components.JustifiBusinessAddress, HTMLStencilElement {
+    }
+    var HTMLJustifiBusinessAddressElement: {
+        prototype: HTMLJustifiBusinessAddressElement;
+        new (): HTMLJustifiBusinessAddressElement;
+    };
     interface HTMLJustifiCardFormElement extends Components.JustifiCardForm, HTMLStencilElement {
     }
     var HTMLJustifiCardFormElement: {
@@ -197,6 +207,7 @@ declare global {
     interface HTMLElementTagNameMap {
         "justifi-bank-account-form": HTMLJustifiBankAccountFormElement;
         "justifi-billing-form": HTMLJustifiBillingFormElement;
+        "justifi-business-address": HTMLJustifiBusinessAddressElement;
         "justifi-card-form": HTMLJustifiCardFormElement;
         "justifi-payment-form": HTMLJustifiPaymentFormElement;
         "justifi-payment-method-form": HTMLJustifiPaymentMethodFormElement;
@@ -237,6 +248,8 @@ declare namespace LocalJSX {
           * (Optional) A label for the form.
          */
         "legend"?: string;
+    }
+    interface JustifiBusinessAddress {
     }
     interface JustifiCardForm {
         /**
@@ -312,6 +325,7 @@ declare namespace LocalJSX {
     interface IntrinsicElements {
         "justifi-bank-account-form": JustifiBankAccountForm;
         "justifi-billing-form": JustifiBillingForm;
+        "justifi-business-address": JustifiBusinessAddress;
         "justifi-card-form": JustifiCardForm;
         "justifi-payment-form": JustifiPaymentForm;
         "justifi-payment-method-form": JustifiPaymentMethodForm;
@@ -327,6 +341,7 @@ declare module "@stencil/core" {
         interface IntrinsicElements {
             "justifi-bank-account-form": LocalJSX.JustifiBankAccountForm & JSXBase.HTMLAttributes<HTMLJustifiBankAccountFormElement>;
             "justifi-billing-form": LocalJSX.JustifiBillingForm & JSXBase.HTMLAttributes<HTMLJustifiBillingFormElement>;
+            "justifi-business-address": LocalJSX.JustifiBusinessAddress & JSXBase.HTMLAttributes<HTMLJustifiBusinessAddressElement>;
             "justifi-card-form": LocalJSX.JustifiCardForm & JSXBase.HTMLAttributes<HTMLJustifiCardFormElement>;
             "justifi-payment-form": LocalJSX.JustifiPaymentForm & JSXBase.HTMLAttributes<HTMLJustifiPaymentFormElement>;
             "justifi-payment-method-form": LocalJSX.JustifiPaymentMethodForm & JSXBase.HTMLAttributes<HTMLJustifiPaymentMethodFormElement>;

--- a/stencil-library/src/components/business-address/business-address-schema.ts
+++ b/stencil-library/src/components/business-address/business-address-schema.ts
@@ -1,0 +1,25 @@
+import { object, string } from 'yup';
+
+export const RegExZip = /^\d{5}/;
+
+export interface BusinessAddressFormFields {
+  line1: string;
+  line2?: string;
+  city: string;
+  state: string;
+  postal_code: string;
+  country: string;
+}
+
+const BusinessAddressFormSchema = object({
+  line1: string().required('Enter street address'),
+  line2: string(),
+  city: string().required('Enter city'),
+  state: string().required('Choose state'),
+  postal_code: string()
+    .required('Enter ZIP')
+    .matches(RegExZip, 'Enter a valid ZIP')
+    .min(5, 'Enter a valid ZIP')
+});
+
+export default BusinessAddressFormSchema;

--- a/stencil-library/src/components/business-address/business-address.scss
+++ b/stencil-library/src/components/business-address/business-address.scss
@@ -1,0 +1,8 @@
+@import "reboot";
+@import "forms";
+@import "grid";
+
+:host {
+  @include host-base-styles;
+  display: block;
+}

--- a/stencil-library/src/components/business-address/business-address.tsx
+++ b/stencil-library/src/components/business-address/business-address.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, State, Method } from '@stencil/core';
+import { Component, Host, h, State, Method, Listen } from '@stencil/core';
 import { ValidationError } from 'yup';
 import StateOptions from '../billing-form/state-options';
 import BusinessAddressFormSchema, { BusinessAddressFormFields } from './business-address-schema';
@@ -19,13 +19,23 @@ export class BusinessAddress {
   };
   @State() businessAddressErrors: any = {};
 
+  @Listen('fieldReceivedInput')
+  setFormValue(event) {
+    const data = event.detail;
+    const businessAddressClone = { ...this.businessAddress };
+    if (data.name) {
+      businessAddressClone[data.name] = data.value;
+      this.businessAddress = businessAddressClone;
+    }
+  }
+
   @Method()
   async submit() {
     const newErrors = {};
     let isValid: boolean = true;
 
     try {
-      await BusinessAddressFormSchema.validate(this.businessAddress, { abortEarly: false })
+      await BusinessAddressFormSchema.validate(this.businessAddress, { abortEarly: false });
     } catch (err) {
       isValid = false;
       err.inner.map((item: ValidationError) => {

--- a/stencil-library/src/components/business-address/business-address.tsx
+++ b/stencil-library/src/components/business-address/business-address.tsx
@@ -1,0 +1,90 @@
+import { Component, Host, h, State, Method } from '@stencil/core';
+import { ValidationError } from 'yup';
+import StateOptions from '../billing-form/state-options';
+import BusinessAddressFormSchema, { BusinessAddressFormFields } from './business-address-schema';
+
+@Component({
+  tag: 'justifi-business-address',
+  styleUrl: 'business-address.scss',
+  shadow: true,
+})
+export class BusinessAddress {
+  @State() businessAddress: BusinessAddressFormFields = {
+    line1: '',
+    line2: '',
+    city: '',
+    state: '',
+    postal_code: '',
+    country: ''
+  };
+  @State() businessAddressErrors: any = {};
+
+  @Method()
+  async submit() {
+    const newErrors = {};
+    let isValid: boolean = true;
+
+    try {
+      await BusinessAddressFormSchema.validate(this.businessAddress, { abortEarly: false })
+    } catch (err) {
+      isValid = false;
+      err.inner.map((item: ValidationError) => {
+        newErrors[item.path] = item.message;
+      });
+    }
+
+    this.businessAddressErrors = newErrors;
+
+    return { isValid: isValid, values: this.businessAddress }
+  };
+
+  render() {
+    return (
+      <Host exportparts="label,input,input-invalid">
+        <div class="row gx-2 gy-2">
+          <div class="col-12">
+            <text-input
+              name="line1"
+              label="Street Address"
+              defaultValue={this.businessAddress?.line1}
+              error={this.businessAddressErrors?.line1} />
+          </div>
+
+          <div class="col-12">
+            <text-input
+              name="line2"
+              label="Apartment, Suite, etc. (optional)"
+              defaultValue={this.businessAddress?.line2}
+              error={this.businessAddressErrors?.line2} />
+          </div>
+
+          <div class="col-12">
+            <text-input
+              name="city"
+              label="City"
+              defaultValue={this.businessAddress?.city}
+              error={this.businessAddressErrors?.city} />
+          </div>
+
+          <div class="col-12">
+            <select-input
+              name="state"
+              label="State"
+              options={StateOptions}
+              defaultValue={this.businessAddress.state}
+              error={this.businessAddressErrors.state} />
+          </div>
+
+          <div class="col-12">
+            <text-input
+              name="postal_code"
+              label="Postal Code"
+              defaultValue={this.businessAddress?.postal_code}
+              error={this.businessAddressErrors?.postal_code} />
+          </div>
+        </div>
+      </Host>
+    );
+  }
+
+}

--- a/stencil-library/src/components/business-address/example.html
+++ b/stencil-library/src/components/business-address/example.html
@@ -16,8 +16,9 @@
     (() => {
       const addressForm = document.querySelector('justifi-business-address');
       const submitButton = document.getElementById('submit');
-      submitButton.addEventListener('click', () => {
-        addressForm.submit();
+      submitButton.addEventListener('click', async () => {
+        const form = await addressForm.submit();
+        console.log(form);
       });
     })()
   </script>

--- a/stencil-library/src/components/business-address/example.html
+++ b/stencil-library/src/components/business-address/example.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>JustiFi Bank Account Form</title>
+  <script type="module" src="../../build/webcomponents.esm.js"></script>
+  <script nomodule src="../../build/webcomponents.js"></script>
+</head>
+
+<body>
+  <justifi-business-address></justifi-business-address>
+  <button id="submit">Submit</button>
+  <script>
+    (() => {
+      const addressForm = document.querySelector('justifi-business-address');
+      const submitButton = document.getElementById('submit');
+      submitButton.addEventListener('click', () => {
+        addressForm.submit();
+      });
+    })()
+  </script>
+</body>
+
+</html>

--- a/stencil-library/src/components/business-address/readme.md
+++ b/stencil-library/src/components/business-address/readme.md
@@ -1,0 +1,38 @@
+# justifi-business-address
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Methods
+
+### `submit() => Promise<{ isValid: boolean; values: BusinessAddressFormFields; }>`
+
+
+
+#### Returns
+
+Type: `Promise<{ isValid: boolean; values: BusinessAddressFormFields; }>`
+
+
+
+
+## Dependencies
+
+### Depends on
+
+- [text-input](../text-input)
+- [select-input](../select-input)
+
+### Graph
+```mermaid
+graph TD;
+  justifi-business-address --> text-input
+  justifi-business-address --> select-input
+  style justifi-business-address fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/stencil-library/src/components/business-address/test/business-address.e2e.ts
+++ b/stencil-library/src/components/business-address/test/business-address.e2e.ts
@@ -1,0 +1,11 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('business-address', () => {
+  it('renders', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<business-address></business-address>');
+
+    const element = await page.find('business-address');
+    expect(element).toHaveClass('hydrated');
+  });
+});

--- a/stencil-library/src/components/business-address/test/business-address.spec.tsx
+++ b/stencil-library/src/components/business-address/test/business-address.spec.tsx
@@ -1,0 +1,18 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { BusinessAddress } from '../business-address';
+
+describe('business-address', () => {
+  it('renders', async () => {
+    const page = await newSpecPage({
+      components: [BusinessAddress],
+      html: `<business-address></business-address>`,
+    });
+    expect(page.root).toEqualHtml(`
+      <business-address>
+        <mock:shadow-root>
+          <slot></slot>
+        </mock:shadow-root>
+      </business-address>
+    `);
+  });
+});

--- a/stencil-library/src/components/select-input/readme.md
+++ b/stencil-library/src/components/select-input/readme.md
@@ -35,11 +35,13 @@
 ### Used by
 
  - [justifi-billing-form](../billing-form)
+ - [justifi-business-address](../business-address)
 
 ### Graph
 ```mermaid
 graph TD;
   justifi-billing-form --> select-input
+  justifi-business-address --> select-input
   style select-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/stencil-library/src/components/text-input/readme.md
+++ b/stencil-library/src/components/text-input/readme.md
@@ -34,11 +34,13 @@
 ### Used by
 
  - [justifi-billing-form](../billing-form)
+ - [justifi-business-address](../business-address)
 
 ### Graph
 ```mermaid
 graph TD;
   justifi-billing-form --> text-input
+  justifi-business-address --> text-input
   style text-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
Create a generic address form to be reused across business and identity components. This will not be included in storybook, it will provide value to other components and part of a larger widget. It's an internal component, so because of this it will not require a version bump, changelog entry, or docs.

- Markup the address form
- Add bootstrap styling
- Add submit method with validation
  - returns `isValid`
  - returns form values


Links
-----
https://justifi-ai.atlassian.net/browse/FE-185?atlOrigin=eyJpIjoiNDU0N2YwNzU4NmQ1NGNjMzlmNGRlYWQ0YmYyYzI2ZjAiLCJwIjoiaiJ9

Developer considerations
--------------

- [ ] Increment the version number for relevant packages
  - [ ] This is a new MAJOR version (incompatible API changes were made)
  - [ ] This is a new MINOR version (functionality was added in a backwards compatible manner)
  - [ ] This is a new PATCH version (backwards compatible bug fixes)
- [ ] Update the CHANGELOG.md with a summary of the changes
  - If this is a MAJOR version, what are the breaking API changes? Was anything added to the API?
  - If this is a MINOR version, what feature was added? Why would consumers want this new version?
  - If this is a PATCH version, what was fixed?
- [ ] Update the appropriate documentation. Keep in mind that this mono repository has README files at the repository, project, and component levels. We want developers to be able to find what they need from the main README, so make sure to add links to component documentation if adding something new.


Steps for Testing/QA
--------------------

Developer QA:
- Pull this branch
- Run `yarn start` from the `stencil-library` directory
- Go to http://localhost:3334/components/business-address/example.html
- Click "Submit". The form should show errors.
- Fix the errors and click "Submit", the errors should go away.
