### PR TITLE
FE-170 add unit and e2e tests to card-form component

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Spec Test Current File",
+      "cwd": "${workspaceFolder}/stencil-library",
+      "program": "${workspaceFolder}/stencil-library/node_modules/.bin/stencil",
+      "args": ["test", "--spec", "--", "${fileBasename}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "E2E Test Current File",
+      "cwd": "${workspaceFolder}/stencil-library",
+      "program": "${workspaceFolder}/stencil-library/node_modules/.bin/stencil",
+      "args": ["test", "--e2e", "--", "--maxWorkers=0", "${fileBasename}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Documentation
+
 - [Web component library](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library)
   - [justifi-bank-account-form](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/bank-account-form#justifi-bank-account-form)
   - [justifi-card-form](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/card-form#justifi-card-form)
- - React component library
-   - Docs for this are not in place yet, but feel free to check out [sample-react-app.zip](https://github.com/justifi-tech/web-component-library/files/11125233/sample-react-app.zip)
-
-
+- React component library
+  - Docs for this are not in place yet, but feel free to check out [sample-react-app.zip](https://github.com/justifi-tech/web-component-library/files/11125233/sample-react-app.zip)
 
 # For contributors:
 
@@ -14,5 +13,32 @@ Follow the semantic versioning guidelines found [here](https://semver.org/)
 In order for `react-library` to build, you must first create a yarn symlink to `stencil-library` because it is a dependency.
 
 To do this, do the following:
+
 - From the `stencil-library` directory, run `yarn link`
 - From the `react-library` run `yarn link "@justifi/webcomponents"`
+
+# Project Testing Guide
+
+## Getting Started
+
+This project uses the Stencil testing framework for unit and end-to-end (E2E) tests, along with Storybook for UI component testing and auto-changelog to maintain a changelog based on git metadata.
+
+Below are commands used for various testing and development scenarios.
+
+## test
+
+Runs unit tests using the Stencil's spec testing.
+
+`yarn run test`
+
+## test:watch
+
+Runs unit tests in watch mode. Good for development.
+
+`yarn run test:watch`
+
+## test:e2e
+
+Runs end-to-end tests using the Stencil's E2E testing.
+
+`yarn run test:e2e`

--- a/stencil-library/docs.json
+++ b/stencil-library/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-06-01T20:11:34",
+  "timestamp": "2023-06-02T22:41:32",
   "compiler": {
     "name": "@stencil/core",
     "version": "3.3.0",

--- a/stencil-library/package.json
+++ b/stencil-library/package.json
@@ -27,6 +27,7 @@
     "start-stencil": "stencil build --watch --serve --no-open",
     "test": "stencil test --spec",
     "test:watch": "stencil test --spec --watchAll",
+    "test:e2e": "stencil test --e2e",
     "generate": "stencil generate",
     "storybook": "storybook dev -p 6006 --quiet",
     "build-storybook": "storybook build -o ../docs"

--- a/stencil-library/src/components/card-form/test/card-form.e2e.tsx
+++ b/stencil-library/src/components/card-form/test/card-form.e2e.tsx
@@ -1,0 +1,19 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+describe('justifi-card-form', () => {
+  it('should emit "cardFormReady" event when "paymentMethodFormReady" event is fired', async () => {
+    const page = await newE2EPage();
+    await page.setContent('<justifi-card-form></justifi-card-form>');
+
+    const cardForm = await page.find('justifi-card-form');
+
+    const readyEventSpy = await cardForm.spyOnEvent('cardFormReady');
+
+    const paymentFormElement = await page.find('justifi-payment-method-form');
+    paymentFormElement.triggerEvent('paymentMethodFormReady');
+
+    await page.waitForChanges();
+
+    expect(readyEventSpy).toHaveReceivedEventTimes(1);
+  });
+});

--- a/stencil-library/src/components/card-form/test/card-form.spec.tsx
+++ b/stencil-library/src/components/card-form/test/card-form.spec.tsx
@@ -1,42 +1,70 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { CardForm } from '../card-form';
+import { PaymentMethodForm } from '../../payment-method-form/payment-method-form';
 
 describe('justifi-card-form', () => {
-  it('renders with justifi-payment-method-form as a child element', async () => {
+  it('should pass validationMode prop to justifi-payment-method-form', async () => {
     const page = await newSpecPage({
       components: [CardForm],
-      html: `<justifi-card-form></justifi-card-form>`,
+      html: '<justifi-card-form validation-mode="onChange" />',
     });
-    expect(page.root).toEqualHtml(`
-      <justifi-card-form>
-        <justifi-payment-method-form payment-method-form-type="card" payment-method-form-validation-strategy="onSubmit"></justifi-payment-method-form>
-      </justifi-card-form>
-    `);
+    const paymentMethodForm = page.root.querySelector('justifi-payment-method-form');
+    expect(paymentMethodForm.getAttribute('payment-method-form-validation-mode')).toBe('onChange');
   });
 
-  // it('passes iframe-origin down to justifi-payment-method-form', async () => {
-  //   const page = await newSpecPage({
-  //     components: [CardForm],
-  //     html: `
-  //     <justifi-card-form iframe-origin="https://www.test.com"></justifi-card-form>
-  //     `,
-  //   });
-  //   expect(page.root).toEqualHtml(`
-  //     <justifi-card-form iframe-origin="https://www.test.com">
-  //       <justifi-payment-method-form iframe-origin="https://www.test.com"></justifi-payment-method-form>
-  //     </justifi-card-form>
-  //   `);
-  // });
+  it('should pass iframeOrigin prop to justifi-payment-method-form', async () => {
+    const page = await newSpecPage({
+      components: [CardForm],
+      html: '<justifi-card-form iframe-origin="https://example.com" />',
+    });
 
-  it('has a tokenize method which calls tokenize on justifi-payment-method-form', async () => {
-    const cardForm = new CardForm();
-    expect(cardForm.tokenize).toBeDefined();
+    const paymentMethodForm = page.root.querySelector('justifi-payment-method-form');
+    expect(paymentMethodForm.getAttribute('iframe-origin')).toBe('https://example.com');
+  });
 
-    // mock childRef
-    (cardForm as any).childRef = { tokenize: () => {} };
-    const childRefTokenizeSpy = jest.spyOn((cardForm as any).childRef, 'tokenize');
+  it('should pass singleLine prop to justifi-payment-method-form', async () => {
+    const page = await newSpecPage({
+      components: [CardForm],
+      html: '<justifi-card-form single-line />',
+    });
+    const paymentMethodForm = page.root.querySelector('justifi-payment-method-form');
+    expect(paymentMethodForm.getAttribute('single-line')).toBe('');
+  });
 
-    cardForm.tokenize('clientId', { paymentMethod: 'metadata' }, 'accountId');
-    expect(childRefTokenizeSpy).toHaveBeenCalled();
+  it('should call the PaymentMethodForm validate method when invoked from the CardForm component', async () => {
+    const page = await newSpecPage({
+      components: [CardForm, PaymentMethodForm],
+      html: '<justifi-card-form></justifi-card-form>',
+    });
+
+    const component = page.rootInstance;
+
+    const validateMock = jest.fn();
+    component.childRef = { validate: validateMock } as any;
+
+    await component.validate();
+
+    expect(validateMock).toHaveBeenCalled();
+  });
+
+  it('should call the PaymentMethodForm tokenize method with the right arguments when invoked from the CardForm component', async () => {
+    const page = await newSpecPage({
+      components: [CardForm, PaymentMethodForm],
+      html: '<justifi-card-form></justifi-card-form>',
+    });
+
+    const component = page.rootInstance;
+
+    const tokenizeMock = jest.fn();
+    component.childRef = { tokenize: tokenizeMock } as any;
+
+    const clientId = 'clientId';
+    const paymentMethodMetadata = { paymentMethodType: 'card' };
+    const account = 'account';
+    const tokenizeArgs = [clientId, paymentMethodMetadata, account];
+
+    await component.tokenize(...tokenizeArgs);
+
+    expect(tokenizeMock).toHaveBeenCalledWith(...tokenizeArgs);
   });
 });

--- a/stencil-library/src/components/payment-method-form/test/payment-method-form.e2e.tsx
+++ b/stencil-library/src/components/payment-method-form/test/payment-method-form.e2e.tsx
@@ -1,0 +1,16 @@
+import { newE2EPage } from '@stencil/core/testing';
+
+it('should emit "paymentMethodFormReady" when conditions are met', async () => {
+  const page = await newE2EPage();
+  await page.setContent('<justifi-card-form></justifi-card-form>');
+
+  const cardFormElement = await page.find('justifi-card-form');
+  const paymentFormElement = await page.find('justifi-payment-method-form');
+
+  const readyEventSpy = await cardFormElement.spyOnEvent('cardFormReady');
+
+  paymentFormElement.triggerEvent('paymentMethodFormReady');
+  await page.waitForChanges();
+
+  expect(readyEventSpy).toHaveReceivedEventTimes(1);
+});


### PR DESCRIPTION
- adds unit tests for props and methods for the card-form web-component
- adds e2e test for the `cardFormReady` event

Developer considerations
--------------

- [ ] Increment the version number for relevant packages
  - [ ] This is a new MAJOR version (incompatible API changes were made)
  - [ ] This is a new MINOR version (functionality was added in a backwards compatible manner)
  - [ ] This is a new PATCH version (backwards compatible bug fixes)
- [ ] Update the CHANGELOG.md with a summary of the changes
  - If this is a MAJOR version, what are the breaking API changes? Was anything added to the API?
  - If this is a MINOR version, what feature was added? Why would consumers want this new version?
  - If this is a PATCH version, what was fixed?
- [X] Update the appropriate documentation. Keep in mind that this mono repository has README files at the repository, project, and component levels. We want developers to be able to find what they need from the main README, so make sure to add links to component documentation if adding something new.


Steps for Testing/QA
--------------------

