### PR TITLE
[FE-161][FE-162] improve some docs and add React page

### DIFF
--- a/stencil-library/.storybook/preview.jsx
+++ b/stencil-library/.storybook/preview.jsx
@@ -22,4 +22,10 @@ export const parameters = {
       date: /Date$/,
     },
   },
+  options: {
+    storySort: {
+      method: 'alphabetical',
+      order: ['Introduction', 'React', '*'],
+    },
+  },
 };

--- a/stencil-library/docs.json
+++ b/stencil-library/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-06-02T22:41:32",
+  "timestamp": "2023-06-07T22:29:50",
   "compiler": {
     "name": "@stencil/core",
     "version": "3.3.0",

--- a/stencil-library/storybook-pages/css-variables.tsx
+++ b/stencil-library/storybook-pages/css-variables.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Source } from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+
+const CSSVars = () => <Source
+  language='css'
+  dark
+  code={dedent`
+  /* layout */
+  --jfi-layout-padding
+  --jfi-layout-form-control-spacing-x
+  --jfi-layout-form-control-spacing-y
+
+  /* colors */
+  --jfi-primary-color
+
+  /* form control */
+  --jfi-form-control-background-color
+  --jfi-form-control-border-color
+  --jfi-form-control-border-color-focus
+  --jfi-form-control-border-color-error
+  --jfi-form-control-border-width
+  --jfi-form-control-border-bottom-width
+  --jfi-form-control-border-left-width
+  --jfi-form-control-border-right-width
+  --jfi-form-control-border-top-width
+  --jfi-form-control-border-radius
+  --jfi-form-control-border-style
+  --jfi-form-control-box-shadow
+  --jfi-form-control-box-shadow-error
+  --jfi-form-control-box-shadow-error-focus
+  --jfi-form-control-box-shadow-focus
+  --jfi-form-control-color
+  --jfi-form-control-color-focus
+  --jfi-form-control-font-size
+  --jfi-form-control-font-weight
+  --jfi-form-control-line-height
+  --jfi-form-control-margin
+  --jfi-form-control-padding
+
+  /* form label */
+  --jfi-form-label-color
+  --jfi-form-label-font-family
+  --jfi-form-label-font-size
+  --jfi-form-label-font-weight
+  --jfi-form-label-margin
+
+  /* validation messages */
+  --jfi-error-message-color
+  --jfi-error-message-margin
+  --jfi-error-message-font-size
+
+  /* Below only used in justifi-payment-form */
+  /* form radio group */
+  --jfi-radio-button-color
+  --jfi-radio-button-background-color
+  --jfi-radio-button-color-selected
+  --jfi-radio-button-background-color-selected
+  --jfi-radio-button-border-color
+  --jfi-radio-button-border-color-selected
+  --jfi-radio-button-padding
+  --jfi-radio-button-font-size
+  --jfi-radio-button-color-hover
+  --jfi-radio-button-color-selected-hover
+  --jfi-radio-button-background-color-hover
+  --jfi-radio-button-background-color-selected-hover
+  --jfi-radio-button-border-color-selected-hover
+  --jfi-radio-button-border-color-hover
+  --jfi-radio-button-group-width
+
+  /* submit button */
+  --jfi-submit-button-color
+  --jfi-submit-button-background-color
+  --jfi-submit-button-border-color
+  --jfi-submit-button-padding
+  --jfi-submit-button-font-size
+  --jfi-submit-button-border-radius
+  --jfi-submit-button-color-hover
+  --jfi-submit-button-background-color-hover
+  --jfi-submit-button-border-color-hover
+  --jfi-submit-button-color-focus
+  --jfi-submit-button-background-color-focus
+  --jfi-submit-button-border-color-focus
+  --jfi-submit-button-color-active
+  --jfi-submit-button-background-color-active
+  --jfi-submit-button-border-color-active
+  --jfi-submit-button-width
+  --jfi-submit-button-box-shadow
+  `}
+/>
+
+export default CSSVars;

--- a/stencil-library/storybook-pages/intro.stories.mdx
+++ b/stencil-library/storybook-pages/intro.stories.mdx
@@ -1,8 +1,8 @@
 import { Canvas, Meta, Story, Source } from '@storybook/addon-docs';
 import { Markdown } from '@storybook/blocks';
 import dedent from 'ts-dedent';
-import { extractVersionFromPackage } from './utils.tsx';
-import Changelog from '../CHANGELOG.md';
+import { extractVersionFromPackage, SummaryElement } from './utils.tsx';
+import CSSVars from './css-variables.tsx';
 
 <Meta title="Introduction" />
 
@@ -117,104 +117,23 @@ Then import it and use it as a normal React component, for a more in-depth expla
 `}
 />
 
+### For a detailed explanation of how to use the React components, [See the React page](/docs/react--docs)
+
 # Styling
 
 ## Styling components with variables
 
 The following components need to be styled by overriding `CSS variables`, since they are scoped within an iFrame:
 
-- [BankAccountForm](#)
-- [CardForm](#)
-- [PaymentForm](#)
+- [BankAccountForm](?path=/docs/components-bankaccountform--docs)
+- [CardForm](?path=/docs/components-cardform--docs)
+- [PaymentForm](?path=/docs/components-paymentform--docs)
 
 This is a complete list of variables as defined in this project's `root.scss`:
 
-<Source
-  language='css'
-  dark
-  code={dedent`
-  /* layout */
-  --jfi-layout-padding
-  --jfi-layout-form-control-spacing-x
-  --jfi-layout-form-control-spacing-y
-
-/_ colors _/
---jfi-primary-color
-
-/_ form control _/
---jfi-form-control-background-color
---jfi-form-control-border-color
---jfi-form-control-border-color-focus
---jfi-form-control-border-color-error
---jfi-form-control-border-width
---jfi-form-control-border-bottom-width
---jfi-form-control-border-left-width
---jfi-form-control-border-right-width
---jfi-form-control-border-top-width
---jfi-form-control-border-radius
---jfi-form-control-border-style
---jfi-form-control-box-shadow
---jfi-form-control-box-shadow-error
---jfi-form-control-box-shadow-error-focus
---jfi-form-control-box-shadow-focus
---jfi-form-control-color
---jfi-form-control-color-focus
---jfi-form-control-font-size
---jfi-form-control-font-weight
---jfi-form-control-line-height
---jfi-form-control-margin
---jfi-form-control-padding
-
-/_ form label _/
---jfi-form-label-color
---jfi-form-label-font-family
---jfi-form-label-font-size
---jfi-form-label-font-weight
---jfi-form-label-margin
-
-/_ validation messages _/
---jfi-error-message-color
---jfi-error-message-margin
---jfi-error-message-font-size
-
-/_ Below only used in justifi-payment-form _/
-/_ form radio group _/
---jfi-radio-button-color
---jfi-radio-button-background-color
---jfi-radio-button-color-selected
---jfi-radio-button-background-color-selected
---jfi-radio-button-border-color
---jfi-radio-button-border-color-selected
---jfi-radio-button-padding
---jfi-radio-button-font-size
---jfi-radio-button-color-hover
---jfi-radio-button-color-selected-hover
---jfi-radio-button-background-color-hover
---jfi-radio-button-background-color-selected-hover
---jfi-radio-button-border-color-selected-hover
---jfi-radio-button-border-color-hover
---jfi-radio-button-group-width
-
-/_ submit button _/
---jfi-submit-button-color
---jfi-submit-button-background-color
---jfi-submit-button-border-color
---jfi-submit-button-padding
---jfi-submit-button-font-size
---jfi-submit-button-border-radius
---jfi-submit-button-color-hover
---jfi-submit-button-background-color-hover
---jfi-submit-button-border-color-hover
---jfi-submit-button-color-focus
---jfi-submit-button-background-color-focus
---jfi-submit-button-border-color-focus
---jfi-submit-button-color-active
---jfi-submit-button-background-color-active
---jfi-submit-button-border-color-active
---jfi-submit-button-width
---jfi-submit-button-box-shadow
-`}
-/>
+<SummaryElement title="See full list of CSS variables available">
+  <CSSVars />
+</SummaryElement>
 
 ## Styling components with custom css
 

--- a/stencil-library/storybook-pages/react.stories.mdx
+++ b/stencil-library/storybook-pages/react.stories.mdx
@@ -1,0 +1,159 @@
+import { Meta, Source } from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import CSSVars from './css-variables.tsx';
+import { SummaryElement } from './utils.tsx';
+
+<Meta title="React" />
+
+# Justifi React web components
+
+# Index
+
+- [Usage](#usage)
+- [Usage details](#usage-details)
+  - [Props Names](#props-names)
+  - [Listening to events](#listening-to-events)
+  - [Calling methods](#calling-methods)
+- [Styling](#styling)
+  - [Components styled with variables](#components-styled-with-variables)
+  - [Styling exported parts](#styling-exported-parts)
+
+# Usage
+
+To use the React version of the web components, you need to install the package:
+
+<Source
+  language="bash"
+  dark
+  format={false}
+  code={dedent`
+    npm install --save @justifi/react-components
+  `}
+/>
+
+Then import it and use it as a normal React component, for a more in-depth explanation you can search the sidebar for the component you want to use:
+
+<Source
+  language='jsx'
+  dark
+  format={false}
+  code={dedent`
+    import { JustifiCardForm } from '@justifi/react-components';
+
+    <JustifiCardForm
+      ref={cardFormRef}
+      onCardFormReady={onPaymentMethodReady}
+    />
+  `}
+/>
+
+# Usage details
+
+## Props Names
+
+The same props listed on any components page are available, but where they are `hyphen-cased` for the vanilla HTML web components,
+they are `camelCased` in the React version.
+
+For example for `single-line` in the `justifi-card-form`, the React version would use the `singleLine` prop in `JustifiCardForm`.
+
+## Listening to events
+
+For components that list events in their docs page, you can listen to those events passing a callback as a value for that prop.
+
+The prop name is `on` plus the name of the event capitalized: for example, for `cardFormReady`, the component would allow a prop called `onCardFormReady`.
+
+<Source
+  language='jsx'
+  dark
+  format={false}
+  code={dedent`
+    import { JustifiCardForm } from '@justifi/react-components';
+
+    <JustifiCardForm
+      onCardFormReady={(event) => {
+        // CardForm is ready!
+        // Do stuff
+      }}
+    />
+  `}
+/>
+
+## Calling methods
+
+In order to call methods of the component, a React ref needs to be used.
+
+<Source
+  language='jsx'
+  dark
+  format={false}
+  code={dedent`
+    import { JustifiCardForm } from '@justifi/react-components';
+
+    const MyComponent = () => {
+      const justifiCardFormRef = useRef(null);
+
+      const onSomeEventHandler = () => {
+        // The ref needs to be typed as any
+        const cardForm = (cardFormRef as any).current;
+
+        const tokenizeResponse = await cardForm.tokenize(clientId, paymentMethodMetadata, subAccountID);
+        // Do stuff with the tokenized payment method, like submitting a payment
+      }
+
+      <JustifiCardForm
+        onSomeEvent={onSomeEventHandler}
+        ref={justifiCardFormRef}
+      />
+    }
+  `}
+/>
+
+# Styling
+
+Styling works similarly to the vanilla web components.
+
+## Components styled with variables
+
+The following components can only be styled through CSS variables:
+
+- [BankAccountForm](?path=/docs/components-bankaccountform--docs)
+- [CardForm](?path=/docs/components-cardform--docs)
+- [PaymentForm](?path=/docs/components-paymentform--docs)
+
+You can easily override the variables in a `<style>` tag in any place of your App, both in the `<head>` of your root `index.html` or at any component level.
+
+<Source
+  language='jsx'
+  dark
+  format={false}
+  code={dedent`
+    <YourComponent>
+      <style>
+        :root {
+          --jfi-variable: 'override value';
+        }
+      </style>
+
+      <JustifiPaymentForm />
+    </YourComponent>
+  `}
+/>
+
+<SummaryElement title="See full list of CSS variables available">
+  <CSSVars />
+</SummaryElement>
+
+## Styling exported parts
+
+For components that are not in an iFrame, you'll find a list of `exportedparts` on their docs page.
+
+<Source
+  language="css"
+  dark
+  code={dedent`
+    /* Given an exportedpart of "label" for example */
+    the-component-tag:part(label) {
+      /* Your custom css */
+    }
+  `}
+/>

--- a/stencil-library/storybook-pages/utils.tsx
+++ b/stencil-library/storybook-pages/utils.tsx
@@ -42,4 +42,23 @@ const ExportedPartUsage = ({ tag, component }: { tag: string; component: string 
   />
 );
 
-export { extractVersionFromPackage, filterDocsByTag, ExportedParts };
+const SummaryElement = ({ title, children }) =>
+  <details style={{
+    fontFamily: 'var(--bs-font-sans-serif)',
+    color: '#2E3438',
+    fontSize: '14px',
+    cursor: 'pointer'
+  }}>
+    <summary>
+      <b>{title}</b>
+    </summary>
+
+    {children}
+  </details>
+
+export {
+  extractVersionFromPackage,
+  filterDocsByTag,
+  ExportedParts,
+  SummaryElement
+};


### PR DESCRIPTION
Changes:
- Add a React page to docs.
- Include necessary details on usage for the React version of the components.
- Abstract away the CSS variables list to avoid duplicating code.
- Add a new Summary component to allow showing/hiding some content.
- Fix a few links to components from intro and react page in the styling with css variables section.

Solves:
- https://justifi-ai.atlassian.net/browse/FE-161
- https://justifi-ai.atlassian.net/browse/FE-162

Screenshots:
<img width="1089" alt="image" src="https://github.com/justifi-tech/web-component-library/assets/10523683/b183beaa-ec8c-4496-98aa-be9af8a6b24f">
<img width="1088" alt="image" src="https://github.com/justifi-tech/web-component-library/assets/10523683/5bdc7086-066e-4e07-bc41-d1282a42b334">
<img width="1085" alt="image" src="https://github.com/justifi-tech/web-component-library/assets/10523683/8538b725-0853-4ac2-91d2-6edd34a496ca">
<img width="1089" alt="image" src="https://github.com/justifi-tech/web-component-library/assets/10523683/10674d67-54ba-4dd7-8c7d-63ffc752ca91">



