### PR TITLE
FE-182: Add business-info component

### DIFF
--- a/react-library/src/components/stencil-generated/index.ts
+++ b/react-library/src/components/stencil-generated/index.ts
@@ -11,6 +11,7 @@ defineCustomElements();
 export const JustifiBankAccountForm = /*@__PURE__*/createReactComponent<JSX.JustifiBankAccountForm, HTMLJustifiBankAccountFormElement>('justifi-bank-account-form');
 export const JustifiBillingForm = /*@__PURE__*/createReactComponent<JSX.JustifiBillingForm, HTMLJustifiBillingFormElement>('justifi-billing-form');
 export const JustifiBusinessAddress = /*@__PURE__*/createReactComponent<JSX.JustifiBusinessAddress, HTMLJustifiBusinessAddressElement>('justifi-business-address');
+export const JustifiBusinessInfo = /*@__PURE__*/createReactComponent<JSX.JustifiBusinessInfo, HTMLJustifiBusinessInfoElement>('justifi-business-info');
 export const JustifiCardForm = /*@__PURE__*/createReactComponent<JSX.JustifiCardForm, HTMLJustifiCardFormElement>('justifi-card-form');
 export const JustifiPaymentForm = /*@__PURE__*/createReactComponent<JSX.JustifiPaymentForm, HTMLJustifiPaymentFormElement>('justifi-payment-form');
 export const JustifiPaymentMethodForm = /*@__PURE__*/createReactComponent<JSX.JustifiPaymentMethodForm, HTMLJustifiPaymentMethodFormElement>('justifi-payment-method-form');

--- a/stencil-library/docs.json
+++ b/stencil-library/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-06-02T22:41:32",
+  "timestamp": "2023-06-07T17:23:54",
   "compiler": {
     "name": "@stencil/core",
     "version": "3.3.0",
@@ -315,6 +315,97 @@
       ],
       "dependencyGraph": {
         "justifi-business-address": [
+          "text-input",
+          "select-input"
+        ]
+      }
+    },
+    {
+      "filePath": "./src/components/business-info/business-info.tsx",
+      "encapsulation": "shadow",
+      "tag": "justifi-business-info",
+      "readme": "# justifi-business-info\n\n\n",
+      "docs": "",
+      "docsTags": [
+        {
+          "name": "exportedPart",
+          "text": "label: Label for inputs"
+        },
+        {
+          "name": "exportedPart",
+          "text": "input: The input fields"
+        },
+        {
+          "name": "exportedPart",
+          "text": "input-invalid: Invalid state for inputfs"
+        }
+      ],
+      "usage": {},
+      "props": [
+        {
+          "name": "authToken",
+          "type": "string",
+          "mutable": false,
+          "attr": "auth-token",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
+          "name": "businessId",
+          "type": "string",
+          "mutable": false,
+          "attr": "business-id",
+          "reflectToAttr": false,
+          "docs": "",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": true,
+          "required": false
+        }
+      ],
+      "methods": [
+        {
+          "name": "submit",
+          "returns": {
+            "type": "Promise<void>",
+            "docs": ""
+          },
+          "signature": "submit(event: any) => Promise<void>",
+          "parameters": [],
+          "docs": "",
+          "docsTags": []
+        }
+      ],
+      "events": [],
+      "listeners": [
+        {
+          "event": "fieldReceivedInput",
+          "capture": false,
+          "passive": false
+        }
+      ],
+      "styles": [],
+      "slots": [],
+      "parts": [],
+      "dependents": [],
+      "dependencies": [
+        "text-input",
+        "select-input"
+      ],
+      "dependencyGraph": {
+        "justifi-business-info": [
           "text-input",
           "select-input"
         ]
@@ -1076,7 +1167,8 @@
       ],
       "dependents": [
         "justifi-billing-form",
-        "justifi-business-address"
+        "justifi-business-address",
+        "justifi-business-info"
       ],
       "dependencies": [],
       "dependencyGraph": {
@@ -1084,6 +1176,9 @@
           "select-input"
         ],
         "justifi-business-address": [
+          "select-input"
+        ],
+        "justifi-business-info": [
           "select-input"
         ]
       }
@@ -1185,7 +1280,8 @@
       ],
       "dependents": [
         "justifi-billing-form",
-        "justifi-business-address"
+        "justifi-business-address",
+        "justifi-business-info"
       ],
       "dependencies": [],
       "dependencyGraph": {
@@ -1193,6 +1289,9 @@
           "text-input"
         ],
         "justifi-business-address": [
+          "text-input"
+        ],
+        "justifi-business-info": [
           "text-input"
         ]
       }

--- a/stencil-library/docs.json
+++ b/stencil-library/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2023-06-07T17:23:54",
+  "timestamp": "2023-06-07T19:01:46",
   "compiler": {
     "name": "@stencil/core",
     "version": "3.3.0",

--- a/stencil-library/src/components.d.ts
+++ b/stencil-library/src/components.d.ts
@@ -62,6 +62,16 @@ export namespace Components {
     interface JustifiBusinessAddress {
         "submit": () => Promise<{ isValid: boolean; values: BusinessAddressFormFields; }>;
     }
+    /**
+     * @exportedPart label: Label for inputs
+     * @exportedPart input: The input fields
+     * @exportedPart input-invalid: Invalid state for inputfs
+     */
+    interface JustifiBusinessInfo {
+        "authToken": string;
+        "businessId"?: string;
+        "submit": (event: any) => Promise<void>;
+    }
     interface JustifiCardForm {
         /**
           * URL for the rendered iFrame. End-users need not use this.
@@ -177,6 +187,17 @@ declare global {
         prototype: HTMLJustifiBusinessAddressElement;
         new (): HTMLJustifiBusinessAddressElement;
     };
+    /**
+     * @exportedPart label: Label for inputs
+     * @exportedPart input: The input fields
+     * @exportedPart input-invalid: Invalid state for inputfs
+     */
+    interface HTMLJustifiBusinessInfoElement extends Components.JustifiBusinessInfo, HTMLStencilElement {
+    }
+    var HTMLJustifiBusinessInfoElement: {
+        prototype: HTMLJustifiBusinessInfoElement;
+        new (): HTMLJustifiBusinessInfoElement;
+    };
     interface HTMLJustifiCardFormElement extends Components.JustifiCardForm, HTMLStencilElement {
     }
     var HTMLJustifiCardFormElement: {
@@ -223,6 +244,7 @@ declare global {
         "justifi-bank-account-form": HTMLJustifiBankAccountFormElement;
         "justifi-billing-form": HTMLJustifiBillingFormElement;
         "justifi-business-address": HTMLJustifiBusinessAddressElement;
+        "justifi-business-info": HTMLJustifiBusinessInfoElement;
         "justifi-card-form": HTMLJustifiCardFormElement;
         "justifi-payment-form": HTMLJustifiPaymentFormElement;
         "justifi-payment-method-form": HTMLJustifiPaymentMethodFormElement;
@@ -270,6 +292,15 @@ declare namespace LocalJSX {
         "legend"?: string;
     }
     interface JustifiBusinessAddress {
+    }
+    /**
+     * @exportedPart label: Label for inputs
+     * @exportedPart input: The input fields
+     * @exportedPart input-invalid: Invalid state for inputfs
+     */
+    interface JustifiBusinessInfo {
+        "authToken"?: string;
+        "businessId"?: string;
     }
     interface JustifiCardForm {
         /**
@@ -346,6 +377,7 @@ declare namespace LocalJSX {
         "justifi-bank-account-form": JustifiBankAccountForm;
         "justifi-billing-form": JustifiBillingForm;
         "justifi-business-address": JustifiBusinessAddress;
+        "justifi-business-info": JustifiBusinessInfo;
         "justifi-card-form": JustifiCardForm;
         "justifi-payment-form": JustifiPaymentForm;
         "justifi-payment-method-form": JustifiPaymentMethodForm;
@@ -367,6 +399,12 @@ declare module "@stencil/core" {
              */
             "justifi-billing-form": LocalJSX.JustifiBillingForm & JSXBase.HTMLAttributes<HTMLJustifiBillingFormElement>;
             "justifi-business-address": LocalJSX.JustifiBusinessAddress & JSXBase.HTMLAttributes<HTMLJustifiBusinessAddressElement>;
+            /**
+             * @exportedPart label: Label for inputs
+             * @exportedPart input: The input fields
+             * @exportedPart input-invalid: Invalid state for inputfs
+             */
+            "justifi-business-info": LocalJSX.JustifiBusinessInfo & JSXBase.HTMLAttributes<HTMLJustifiBusinessInfoElement>;
             "justifi-card-form": LocalJSX.JustifiCardForm & JSXBase.HTMLAttributes<HTMLJustifiCardFormElement>;
             "justifi-payment-form": LocalJSX.JustifiPaymentForm & JSXBase.HTMLAttributes<HTMLJustifiPaymentFormElement>;
             "justifi-payment-method-form": LocalJSX.JustifiPaymentMethodForm & JSXBase.HTMLAttributes<HTMLJustifiPaymentMethodFormElement>;

--- a/stencil-library/src/components/business-info/business-info-schema.ts
+++ b/stencil-library/src/components/business-info/business-info-schema.ts
@@ -1,0 +1,126 @@
+import { object, string } from 'yup';
+
+export const RegExZip = /^\d{5}/;
+
+type BusinessType = 'for_profit' | 'non_profit' | 'government_entity' | 'individual' | '';
+type BusinessStructure = 'sole_proprietorship' |
+  'single_llc' |
+  'multi_llc' |
+  'private_partnership' |
+  'private_corporation' |
+  'unincorporated_association' |
+  'public_partnership' |
+  'public_corporation' |
+  'incorporated' |
+  'unincorporated' |
+  'government_unit' |
+  'government_instrumentality' |
+  'tax_exempt_government_instrumentality' |
+  '';
+
+export interface IBusinessInfo {
+  legal_name: string,
+  website_url: string,
+  email: string,
+  phone: string,
+  doing_business_as: string,
+  business_type: string,
+  business_structure: string,
+  industry: string,
+  metadata: any,
+}
+
+export const BusinessTypeOptions: { label: string, value: BusinessType }[] = [
+  {
+    label: 'Choose business type',
+    value: '',
+  },
+  {
+    label: 'Individual',
+    value: 'individual',
+  },
+  {
+    label: 'For Profit',
+    value: 'for_profit',
+  },
+  {
+    label: 'Non Profit',
+    value: 'non_profit',
+  },
+  {
+    label: 'Government Entity',
+    value: 'government_entity',
+  },
+];
+
+export const BusinessStructureOptions: { label: string, value: BusinessStructure }[] = [
+  {
+    label: 'Choose business structure',
+    value: '',
+  },
+  {
+    label: 'Sole Proprietorship',
+    value: 'sole_proprietorship',
+  },
+  {
+    label: 'LLC (Single)',
+    value: 'single_llc',
+  },
+  {
+    label: 'LLC (Multiple)',
+    value: 'multi_llc',
+  },
+  {
+    label: 'Private Partnership',
+    value: 'private_partnership',
+  },
+  {
+    label: 'Private Corporation',
+    value: 'private_corporation',
+  },
+  {
+    label: 'Unincorporated Association',
+    value: 'unincorporated_association',
+  },
+  {
+    label: 'Public Partnership',
+    value: 'public_partnership',
+  },
+  {
+    label: 'Public Corporation',
+    value: 'public_corporation',
+  },
+  {
+    label: 'Incorporated',
+    value: 'incorporated',
+  },
+  {
+    label: 'Unincorporated',
+    value: 'unincorporated',
+  },
+  {
+    label: 'Government Unit',
+    value: 'government_unit',
+  },
+  {
+    label: 'Government Instrumentality',
+    value: 'government_instrumentality',
+  },
+  {
+    label: 'Tax Exempt Government Instrumentality',
+    value: 'tax_exempt_government_instrumentality',
+  },
+];
+
+const BusinessInfoSchema = object({
+  legal_name: string().required('Enter legal name'),
+  website_url: string().url('Enter valid website url').required('Enter website url'),
+  email: string().email('Enter valid email').required('Enter email'),
+  phone: string().required('Enter phone number'),
+  doing_business_as: string().required('Enter doing business as'),
+  business_type: string().required('Select business type'),
+  business_structure: string().required('Select business structure'),
+  industry: string().required('Enter a business industry'),
+});
+
+export default BusinessInfoSchema;

--- a/stencil-library/src/components/business-info/business-info.scss
+++ b/stencil-library/src/components/business-info/business-info.scss
@@ -1,0 +1,8 @@
+@import "reboot";
+@import "buttons";
+@import "grid";
+
+:host {
+  @include host-base-styles;
+  display: block;
+}

--- a/stencil-library/src/components/business-info/business-info.tsx
+++ b/stencil-library/src/components/business-info/business-info.tsx
@@ -1,0 +1,161 @@
+import { Component, Host, h, Prop, State, Listen, Method } from '@stencil/core';
+import { ValidationError } from 'yup';
+import { Api } from '../../api';
+import BusinessInfoSchema, { BusinessStructureOptions, BusinessTypeOptions, IBusinessInfo } from './business-info-schema';
+
+
+/**
+ * @exportedPart label: Label for inputs
+ * @exportedPart input: The input fields
+ * @exportedPart input-invalid: Invalid state for inputfs
+ */
+@Component({
+  tag: 'justifi-business-info',
+  styleUrl: 'business-info.scss',
+  shadow: true,
+})
+export class BusinessInfo {
+  @Prop() authToken: string;
+  @Prop() businessId?: string;
+  @State() businessInfoPrefillData: any;
+  @State() businessInfo: IBusinessInfo = {
+    legal_name: '',
+    website_url: '',
+    email: '',
+    phone: '',
+    doing_business_as: '',
+    business_type: '',
+    business_structure: '',
+    industry: '',
+    metadata: {}
+  };
+  @State() businessInfoFieldsErrors: any = {};
+
+  private endpoint: string = 'entities/business';
+
+  componentDidMount() {
+    if (this.businessId) {
+      this.fetchBusinessInfo();
+    }
+  }
+
+  async fetchBusinessInfo(): Promise<void> {
+    // fetch data and pre-fill form
+    this.businessInfoPrefillData = await Api(this.authToken).get(`${this.endpoint}/${this.businessId}`);
+  };
+
+  async sendBusinessInfo(data): Promise<void> {
+    return Api(this.authToken).post(this.endpoint, data);
+  };
+
+  @Listen('fieldReceivedInput')
+  setFormValue(event) {
+    const data = event.detail;
+    const businessInfoClone = { ...this.businessInfo };
+    if (data.name) {
+      businessInfoClone[data.name] = data.value;
+      this.businessInfo = businessInfoClone;
+    }
+  }
+
+  @Method()
+  async submit(event) {
+    event.preventDefault();
+
+    const newErrors = {};
+    let isValid: boolean = true;
+
+    try {
+      await BusinessInfoSchema.validate(this.businessInfo, { abortEarly: false });
+    } catch (err) {
+      isValid = false;
+      err.inner.map((item: ValidationError) => {
+        newErrors[item.path] = item.message;
+      });
+    }
+
+    this.businessInfoFieldsErrors = newErrors;
+
+    if (!isValid) return;
+
+    const response = await this.sendBusinessInfo(this.businessInfo);
+    return response;
+  };
+
+  render() {
+    return (
+      <Host exportparts="label,input,input-invalid">
+        <h1>Business Information</h1>
+        <form>
+          <div class="row gy-3">
+            <div class="col-12">
+              <text-input
+                name="legal_name"
+                label="Legal Name"
+                defaultValue={this.businessInfoPrefillData?.legal_name}
+                error={this.businessInfoFieldsErrors.legal_name} />
+            </div>
+            <div class="col-12">
+              <text-input
+                name="doing_business_as"
+                label="Doing Business As (DBA)"
+                defaultValue={this.businessInfoPrefillData?.doing_business_as}
+                error={this.businessInfoFieldsErrors.doing_business_as} />
+            </div>
+            <div class="col-12">
+              <select-input
+                name="business_type"
+                label="Business Type"
+                options={BusinessTypeOptions}
+                defaultValue={this.businessInfoPrefillData?.business_type}
+                error={this.businessInfoFieldsErrors.business_type} />
+            </div>
+            <div class="col-12">
+              <select-input
+                name="business_structure"
+                label="Business Structure"
+                options={BusinessStructureOptions}
+                defaultValue={this.businessInfoPrefillData?.business_structure}
+                error={this.businessInfoFieldsErrors.business_structure} />
+            </div>
+            <div class="col-12">
+              <text-input
+                name="industry"
+                label="Industry"
+                defaultValue={this.businessInfoPrefillData?.industry}
+                error={this.businessInfoFieldsErrors.industry} />
+            </div>
+            <div class="col-12">
+              <text-input
+                name="website_url"
+                label="Website URL"
+                defaultValue={this.businessInfoPrefillData?.website_url}
+                error={this.businessInfoFieldsErrors.website_url} />
+            </div>
+            <div class="col-12">
+              <text-input
+                name="email"
+                label="Email Address"
+                defaultValue={this.businessInfoPrefillData?.email}
+                error={this.businessInfoFieldsErrors.email} />
+            </div>
+            <div class="col-12">
+              <text-input
+                name="phone"
+                label="Phone"
+                defaultValue={this.businessInfoPrefillData?.phone}
+                error={this.businessInfoFieldsErrors.phone} />
+            </div>
+            <div class="col-12">
+              <button
+                onClick={(event) => this.submit(event)}
+                class="btn btn-primary"
+                type="submit">Submit</button>
+            </div>
+          </div>
+        </form>
+      </Host>
+    );
+  }
+
+}

--- a/stencil-library/src/components/business-info/business-info.tsx
+++ b/stencil-library/src/components/business-info/business-info.tsx
@@ -86,7 +86,7 @@ export class BusinessInfo {
     return (
       <Host exportparts="label,input,input-invalid">
         <h1>Business Information</h1>
-        <form>
+        <form onSubmit={(event) => this.submit(event)}>
           <div class="row gy-3">
             <div class="col-12">
               <text-input
@@ -148,7 +148,6 @@ export class BusinessInfo {
             </div>
             <div class="col-12">
               <button
-                onClick={(event) => this.submit(event)}
                 class="btn btn-primary"
                 type="submit">Submit</button>
             </div>

--- a/stencil-library/src/components/business-info/example.html
+++ b/stencil-library/src/components/business-info/example.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
+  <title>JustiFi Bank Account Form</title>
+  <script type="module" src="../../build/webcomponents.esm.js"></script>
+  <script nomodule src="../../build/webcomponents.js"></script>
+</head>
+
+<body>
+  <justifi-business-info auth-token="" business-id=""></justifi-business-info>
+  <script>
+    (() => {
+      const businessInfoElement = document.querySelector('justifi-business-info');
+      businessInfoElement.addEventListener('submitted', async (data) => {
+        console.log(data);
+      });
+    })()
+  </script>
+</body>
+
+</html>

--- a/stencil-library/src/components/business-info/readme.md
+++ b/stencil-library/src/components/business-info/readme.md
@@ -1,0 +1,46 @@
+# justifi-business-info
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property     | Attribute     | Description | Type     | Default     |
+| ------------ | ------------- | ----------- | -------- | ----------- |
+| `authToken`  | `auth-token`  |             | `string` | `undefined` |
+| `businessId` | `business-id` |             | `string` | `undefined` |
+
+
+## Methods
+
+### `submit(event: any) => Promise<void>`
+
+
+
+#### Returns
+
+Type: `Promise<void>`
+
+
+
+
+## Dependencies
+
+### Depends on
+
+- [text-input](../text-input)
+- [select-input](../select-input)
+
+### Graph
+```mermaid
+graph TD;
+  justifi-business-info --> text-input
+  justifi-business-info --> select-input
+  style justifi-business-info fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION
This creates the base business-info component which will be expanded in follow-up PRs and released all at once upon completion. Therfore this PR does not include a version increment, changelog update, or documentation / storybook stories


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- [x] Increment the version number for relevant packages
  - [ ] This is a new MAJOR version (incompatible API changes were made)
  - [ ] This is a new MINOR version (functionality was added in a backwards compatible manner)
  - [ ] This is a new PATCH version (backwards compatible bug fixes)
- [x] Update the CHANGELOG.md with a summary of the changes
  - If this is a MAJOR version, what are the breaking API changes? Was anything added to the API?
  - If this is a MINOR version, what feature was added? Why would consumers want this new version?
  - If this is a PATCH version, what was fixed?
- [x] Update the appropriate documentation. Keep in mind that this mono repository has README files at the repository, project, and component levels. We want developers to be able to find what they need from the main README, so make sure to add links to component documentation if adding something new.


Steps for Testing/QA
--------------------
The business info component will receive full QA prior to release 

