### PR TITLE
Add disclaimers to Payment Component Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Documentation
 
-- [Web component library](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library)
-  - [justifi-bank-account-form](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/bank-account-form#justifi-bank-account-form)
-  - [justifi-card-form](https://github.com/justifi-tech/web-component-library/tree/main/stencil-library/src/components/card-form#justifi-card-form)
+- [JustiFi Web Component Documentation](https://storybook.justifi.ai/?path=/docs/introduction--docs)
 
 ## Getting Started
 

--- a/stencil-library/src/components/bank-account-form/Docs.stories.mdx
+++ b/stencil-library/src/components/bank-account-form/Docs.stories.mdx
@@ -6,6 +6,8 @@ import example from './example.js';
 <Title />
 Component to render the necessary fields to enter proper bank account information.
 
+> **Note**: While it's possible to implement the **CardForm**, **BankAccountForm** and **BillingForm** individually - the **[PaymentForm](/docs/components-paymentform--docs)** is preferred as it combines the three components together and handles validating and passing data between them, and ultimately takes less implementation time. For most use-cases: the JustiFi Team officially recommends that developers choose the **[PaymentForm](/docs/components-paymentform--docs)** component when implementing components for payment processing.
+
 # Index
 
 - [Props, events and methods](#props-events-and-methods)

--- a/stencil-library/src/components/billing-form/Docs.stories.mdx
+++ b/stencil-library/src/components/billing-form/Docs.stories.mdx
@@ -7,6 +7,9 @@ import example from './example.js';
 <Title />
 Component to render all the extra fields normally used with either a credit card form or bank account form.
 
+> **Note**: While it's possible to implement the **CardForm**, **BankAccountForm** and **BillingForm** individually - the **[PaymentForm](/docs/components-paymentform--docs)** is preferred as it combines the three components together and handles validating and passing data between them, and ultimately takes less implementation time. For most use-cases: the JustiFi Team officially recommends that developers choose the **[PaymentForm](/docs/components-paymentform--docs)** component when implementing components for payment processing.
+
+
 # Index
 
 - [Props, events and methods](#props-events-and-methods)

--- a/stencil-library/src/components/card-form/Docs.stories.mdx
+++ b/stencil-library/src/components/card-form/Docs.stories.mdx
@@ -6,6 +6,8 @@ import example from './example.js';
 <Title />
 Component to render the necessary fields to enter proper credit card information.
 
+> **Note**: While it's possible to implement the **CardForm**, **BankAccountForm** and **BillingForm** individually - the **[PaymentForm](/docs/components-paymentform--docs)** is preferred as it combines the three components together and handles validating and passing data between them, and ultimately takes less implementation time. For most use-cases: the JustiFi Team officially recommends that developers choose the **[PaymentForm](/docs/components-paymentform--docs)** component when implementing components for payment processing.
+
 # Index
 
 - [Props, events and methods](#props-events-and-methods)


### PR DESCRIPTION
### Add disclaimers to Payment Component Docs

This PR adds a disclaimer that tells the user that we recommend using the `PaymentForm` component - this disclaimer is added to the docs for `CardForm`, `BankAccountForm`, and `BillingForm`

Additionally, this PR updates the GH readme file to point to Storybook as our documentation for the components. 


Links
-----

Closes #242 

