### PR TITLE
Remove framework output targets and workspaces so publishing is not a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,7 @@
     "publish": "lerna publish from-package --yes"
   },
   "workspaces": [
-    "react-library",
-    "stencil-library",
-    "angular-library",
-    "vue-library"
+    "stencil-library"
   ],
   "os": [
     "darwin",

--- a/stencil-library/stencil.config.ts
+++ b/stencil-library/stencil.config.ts
@@ -1,10 +1,7 @@
 import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
-import { reactOutputTarget as react } from '@stencil/react-output-target';
 import dotenv from 'dotenv';
 import replace from 'rollup-plugin-replace';
-import { angularOutputTarget } from '@stencil/angular-output-target';
-import { vueOutputTarget } from '@stencil/vue-output-target';
 
 dotenv.config({ path: `.env.${process.env.NODE_ENV}` });
 
@@ -32,24 +29,6 @@ export const config: Config = {
     }),
   ],
   outputTargets: [
-    react({
-      componentCorePackage: '@justifi/webcomponents',
-      proxiesFile: '../react-library/src/components/stencil-generated/index.ts',
-      includeDefineCustomElements: true,
-    }),
-    {
-      type: 'dist',
-      esmLoaderPath: '../loader',
-    },
-    angularOutputTarget({
-      componentCorePackage: '@justifi/webcomponents',
-      directivesProxyFile: '../angular-library/projects/component-library/src/lib/stencil-generated/components.ts',
-      directivesArrayFile: '../angular-library/projects/component-library/src/lib/stencil-generated/index.ts',
-    }),
-    vueOutputTarget({
-      componentCorePackage: '@justifi/webcomponents',
-      proxiesFile: '../vue-library/lib/components.ts',
-    }),
     {
       type: 'dist-custom-elements',
     },


### PR DESCRIPTION
Remove the following output targets from the Stencil config and NPM workspaces:
- Vue library
- React library
- Angular library