### PR TITLE
Remove /dev flag from title attribute in Meta block for existing components

### DIFF
--- a/stencil-library/src/components/payment-details/Docs.stories.mdx
+++ b/stencil-library/src/components/payment-details/Docs.stories.mdx
@@ -3,7 +3,7 @@ import { filterDocsByTag, ExportedParts } from '../../../storybook-pages/utils.t
 import example from './example.js';
 
 <Meta
-  title="dev/Components/PaymentDetails"
+  title="Components/PaymentDetails"
   Components="justifi-payment-details"
 />
 

--- a/stencil-library/src/components/payments-list/Docs.stories.mdx
+++ b/stencil-library/src/components/payments-list/Docs.stories.mdx
@@ -3,7 +3,7 @@ import { filterDocsByTag, ExportedParts } from '../../../storybook-pages/utils.t
 import example from './example.js';
 
 <Meta
-  title="dev/Components/PaymentsList"
+  title="Components/PaymentsList"
   Components="justifi-payments-list"
 />
 

--- a/stencil-library/src/components/payout-details/Docs.stories.mdx
+++ b/stencil-library/src/components/payout-details/Docs.stories.mdx
@@ -3,7 +3,7 @@ import { filterDocsByTag, ExportedParts } from '../../../storybook-pages/utils.t
 import example from './example.js';
 
 <Meta
-  title="dev/Components/PayoutDetails"
+  title="Components/PayoutDetails"
   Components="justifi-payout-details"
 />
 

--- a/stencil-library/src/components/payouts-list/Docs.stories.mdx
+++ b/stencil-library/src/components/payouts-list/Docs.stories.mdx
@@ -3,7 +3,7 @@ import { filterDocsByTag, ExportedParts } from '../../../storybook-pages/utils.t
 import example from './example.js';
 
 <Meta
-  title="dev/Components/PayoutsList"
+  title="Components/PayoutsList"
   Components="justifi-payouts-list"
 />
 


### PR DESCRIPTION
### Remove /dev flag from title attribute in Meta block for existing components

Currently on production / main / storybook - Payment and Payout components are not showing their documentation as defined in their components' Docs.stories.mdx files. 

This PR removes the `/dev` path from the title attribute of the Meta block for the following components:
 - PaymentsList
 - PaymentDetail
 - PayoutsList
 - PayoutDetail

With this path/flag removed, the documentation appears as expected. 

Links
-----

closes #292 



