### PR TITLE
Update business docs to omit references to account-id since it does n…

### DIFF
--- a/.changeset/polite-ducks-kick.md
+++ b/.changeset/polite-ducks-kick.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Remove `account-id` from BusinessFormStepped. This is not a breaking change as the `account-id` does not have an impact on loading a business, and will not error if left as a prop after upgrading

--- a/apps/docs/stories/components/business-form-example.ts
+++ b/apps/docs/stories/components/business-form-example.ts
@@ -6,7 +6,10 @@ export default `<!DOCTYPE html>
 ${codeExampleHead('justifi-business-form')}
 
 <body>
-  <justifi-business-form></justifi-business-form>
+  <justifi-business-form
+    business-id="<BUSINESS_ID>"
+    auth-token="<WEBCOMPONENT_AUTH_TOKEN>">
+  </justifi-business-form>
 </body>
 
 </html>`;

--- a/apps/docs/stories/components/business-form-stepped-example.ts
+++ b/apps/docs/stories/components/business-form-stepped-example.ts
@@ -6,7 +6,10 @@ export default `<!DOCTYPE html>
 ${codeExampleHead('justifi-business-form-stepped')}
 
 <body>
-  <justifi-business-form-stepped></justifi-business-form-stepped>
+  <justifi-business-form-stepped
+    business-id="<BUSINESS_ID>"
+    auth-token="<WEBCOMPONENT_AUTH_TOKEN>">
+  </justifi-business-form-stepped>
 </body>
 
 </html>`;

--- a/apps/docs/stories/components/business-form-stepped.stories.tsx
+++ b/apps/docs/stories/components/business-form-stepped.stories.tsx
@@ -6,7 +6,7 @@ import '@justifi/webcomponents/dist/module/justifi-business-form-stepped';
 
 type Story = StoryObj;
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['auth-token', 'business-id']);
 
 const meta: Meta = {
   title: 'Components/BusinessFormStepped',
@@ -17,13 +17,6 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'business-id': {
-      type: 'string',
-      description: 'An optionally provided business ID for updating a business. If not provided, a new business will be created.',
-      control: {
-        type: 'text',
-      }
-    },
     'test-mode': {
       table: {
         disable: true

--- a/apps/docs/stories/components/business-form.stories.tsx
+++ b/apps/docs/stories/components/business-form.stories.tsx
@@ -6,7 +6,7 @@ import '@justifi/webcomponents/dist/module/justifi-business-form';
 
 type Story = StoryObj;
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['auth-token', 'business-id']);
 
 const meta: Meta = {
   title: 'Components/BusinessForm',
@@ -17,13 +17,6 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'business-id': {
-      type: 'string',
-      description: 'An optionally provided business ID for updating a business. If not provided, a new business will be created.',
-      control: {
-        type: 'text',
-      }
-    },
     'test-mode': {
       table: {
         disable: true

--- a/packages/webcomponents/src/components/business-form/business-form-stepped.tsx
+++ b/packages/webcomponents/src/components/business-form/business-form-stepped.tsx
@@ -25,7 +25,6 @@ const componentStepMapping = {
 })
 export class BusinessFormStepped {
   @Prop() authToken: string;
-  @Prop() accountId: string;
   @Prop() businessId?: string;
   @Prop() testMode: boolean = false;
   @Prop() hideErrors?: boolean;
@@ -105,15 +104,13 @@ export class BusinessFormStepped {
         const payload = parseForPatching(data);
         const response = await this.api.patch(
           `entities/business/${this.businessId}`,
-          JSON.stringify(payload),
-          { account_id: this.accountId }
+          JSON.stringify(payload)
         );
         this.handleResponse(response, onSuccess);
       } else {
         const response = await this.api.post(
           'entities/business',
-          JSON.stringify(data),
-          { account_id: this.accountId }
+          JSON.stringify(data)
         );
         this.handleResponse(response, onSuccess);
       }

--- a/packages/webcomponents/src/components/business-form/readme.md
+++ b/packages/webcomponents/src/components/business-form/readme.md
@@ -9,9 +9,9 @@
 
 | Property     | Attribute     | Description | Type      | Default     |
 | ------------ | ------------- | ----------- | --------- | ----------- |
-| `accountId`  | `account-id`  |             | `string`  | `undefined` |
 | `authToken`  | `auth-token`  |             | `string`  | `undefined` |
 | `businessId` | `business-id` |             | `string`  | `undefined` |
+| `hideErrors` | `hide-errors` |             | `boolean` | `undefined` |
 | `testMode`   | `test-mode`   |             | `boolean` | `false`     |
 
 


### PR DESCRIPTION
- Remove `account-id` from `BusinessFormStepped` - it has no impact and is not necessary
- Remove `account-id` from `BusinessForm` and `BusinessFormStepped` documentation in Storybook
- Update Storybook examples to show props being passed

Developer considerations
--------------

- On any task
  - [x] Previous unit and e2e tests are passing
  - [x] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart


Developer QA steps
--------------------
- [x] In Storybook `BusinessForm` docs show `auth-token` and `business-id` in the props table
- [x] In Storybook `BusinessForm` docs show `auth-token` and `business-id` props for the "Example Usage"
- [x] In Storybook `BusinessFormStepped` docs show `auth-token` and `business-id` in the props table
- [x] In Storybook `BusinessFormStepped` docs show `auth-token` and `business-id` props for the "Example Usage"
