### PR TITLE
BusinessForm "Country" input is disabled, required, and does not have a value

### DIFF
--- a/.changeset/gentle-pots-whisper.md
+++ b/.changeset/gentle-pots-whisper.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Default `BusinessForm` legal address country to 'USA', and update select option value to 'USA' instead of 'US'

--- a/packages/webcomponents/src/api/BusinessV2.ts
+++ b/packages/webcomponents/src/api/BusinessV2.ts
@@ -152,7 +152,7 @@ export class Business implements IBusiness {
     this.product_categories = business.product_categories;
 
     // Form sections
-    this.legal_address = business.legal_address || {};
+    this.legal_address = business.legal_address || { country: 'USA' };
     this.representative = business.representative || {};
     this.additional_questions = business.additional_questions || {};
     this.owners = business.owners;

--- a/packages/webcomponents/src/components/business-form/legal-address-form/legal-address-form.tsx
+++ b/packages/webcomponents/src/components/business-form/legal-address-form/legal-address-form.tsx
@@ -1,6 +1,5 @@
 import { Component, Host, Prop, State, h } from '@stencil/core';
 import { FormController } from '../../form/form';
-import countryOptions from '../../../utils/country-options';
 
 /**
  * @exportedPart label: Label for inputs

--- a/packages/webcomponents/src/components/business-form/legal-address-form/legal-address-form.tsx
+++ b/packages/webcomponents/src/components/business-form/legal-address-form/legal-address-form.tsx
@@ -97,7 +97,7 @@ export class LegalAddressForm {
               <form-control-select
                 name="country"
                 label="Country"
-                options={countryOptions}
+                options={[{ label: 'United States', value: 'USA' }]}
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.country}
                 error={this.errors?.legal_address?.country}


### PR DESCRIPTION
The `BusinessForm` requires a `business-id` for an existing business, which it will then load and pre-fill the form. However, when the form is pre-filled, the country is not being set.

This causes the form to not submit because country is required, disabled (because we only support USA as of now)  and has no value.

We should leave the validator and the disabled state and make sure the value of the select is set to the country saved in the loaded business, or defaults to "United States"

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart


Developer QA steps
--------------------
- Run the branch locally
- In Storybook go to "BusinessForm"
- [x] Under "Legal Address", the country selector is disabled and is displaying "United States"
- [x] Fill out / submit the form. The request data should contain `'USA'` for `legal_address.country`
