### PR TITLE
Prefill business generic info

### DIFF
--- a/.changeset/poor-moose-smash.md
+++ b/.changeset/poor-moose-smash.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix BusinessGeneric info prefill when business is loaded

--- a/packages/webcomponents/src/api/BusinessV2.ts
+++ b/packages/webcomponents/src/api/BusinessV2.ts
@@ -108,16 +108,16 @@ export class CoreBusinessInfo implements ICoreBusinessInfo {
   public email: string;
   public phone: string;
 
-  constructor(genericBusinessInfo: ICoreBusinessInfo) {
-    this.business_structure = genericBusinessInfo.business_structure;
-    this.business_type = genericBusinessInfo.business_type;
-    this.legal_name = genericBusinessInfo.legal_name;
-    this.doing_business_as = genericBusinessInfo.doing_business_as;
-    this.industry = genericBusinessInfo.industry;
-    this.tax_id = genericBusinessInfo.tax_id;
-    this.website_url = genericBusinessInfo.website_url;
-    this.email = genericBusinessInfo.email;
-    this.phone = genericBusinessInfo.phone;
+  constructor(coreBusinessInfo: ICoreBusinessInfo) {
+    this.business_structure = coreBusinessInfo.business_structure;
+    this.business_type = coreBusinessInfo.business_type;
+    this.legal_name = coreBusinessInfo.legal_name;
+    this.doing_business_as = coreBusinessInfo.doing_business_as;
+    this.industry = coreBusinessInfo.industry;
+    this.tax_id = coreBusinessInfo.tax_id;
+    this.website_url = coreBusinessInfo.website_url;
+    this.email = coreBusinessInfo.email;
+    this.phone = coreBusinessInfo.phone;
   }
 }
 

--- a/packages/webcomponents/src/api/BusinessV2.ts
+++ b/packages/webcomponents/src/api/BusinessV2.ts
@@ -85,6 +85,42 @@ export interface AdditionalQuestions {
   business_receivable_volume: string;
 }
 
+export interface ICoreBusinessInfo {
+  business_structure?: BusinessStructure;
+  business_type?: BusinessType;
+  legal_name?: string;
+  doing_business_as?: string;
+  industry?: string;
+  tax_id?: string;
+  website_url?: string;
+  email?: string;
+  phone?: string;
+}
+
+export class CoreBusinessInfo implements ICoreBusinessInfo {
+  public business_structure: BusinessStructure;
+  public business_type: BusinessType;
+  public legal_name: string;
+  public doing_business_as: string;
+  public industry: string;
+  public tax_id: string;
+  public website_url: string;
+  public email: string;
+  public phone: string;
+
+  constructor(genericBusinessInfo: ICoreBusinessInfo) {
+    this.business_structure = genericBusinessInfo.business_structure;
+    this.business_type = genericBusinessInfo.business_type;
+    this.legal_name = genericBusinessInfo.legal_name;
+    this.doing_business_as = genericBusinessInfo.doing_business_as;
+    this.industry = genericBusinessInfo.industry;
+    this.tax_id = genericBusinessInfo.tax_id;
+    this.website_url = genericBusinessInfo.website_url;
+    this.email = genericBusinessInfo.email;
+    this.phone = genericBusinessInfo.phone;
+  }
+}
+
 export interface IBusiness {
   additional_questions: AdditionalQuestions | {};
   business_structure: BusinessStructure;

--- a/packages/webcomponents/src/components/business-form/business-generic-info/business-generic-info.tsx
+++ b/packages/webcomponents/src/components/business-form/business-generic-info/business-generic-info.tsx
@@ -6,6 +6,7 @@ import {
 } from '../business-form-schema';
 import { FormController } from '../../form/form';
 import { PHONE_MASKS } from '../../../utils/phone-masks';
+import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../api/BusinessV2';
 
 /**
  *
@@ -24,12 +25,16 @@ import { PHONE_MASKS } from '../../../utils/phone-masks';
 export class BusinessGenericInfo {
   @Prop() formController: FormController;
   @State() errors: any = {};
+  @State() genericInfo: ICoreBusinessInfo = {};
 
   constructor() {
     this.inputHandler = this.inputHandler.bind(this);
   }
 
   componentDidLoad() {
+    this.formController.values.subscribe(
+      values => (this.genericInfo = { ...new CoreBusinessInfo(values) }),
+    );
     this.formController.errors.subscribe(errors => {
       this.errors = { ...errors };
     });


### PR DESCRIPTION
Core business information was not populating in the form when the business is loaded. This is because the form values were not being subscribed to in the `GenericBusinessInfo` sub form component.

Developer considerations
--------------

- On any task
  - [x] Previous unit and e2e tests are passing
  - [x] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart


Developer QA steps
--------------------
- Run the branch locally
- [x] When the form loads, it should prefill the top portion (core business info) of the form with saved values (can compare against the `entities/business/:businessId` response data)