### PR TITLE
Add unit-tests to the form-control-select

### DIFF
--- a/packages/webcomponents/src/components/form/form-control-select.tsx
+++ b/packages/webcomponents/src/components/form/form-control-select.tsx
@@ -39,6 +39,7 @@ export class SelectInput {
     const target = event.target;
     const name = target.getAttribute('name');
     this.inputHandler(name, target.value);
+    this.formControlInput.emit(target.value);
   }
 
   componentDidLoad() {
@@ -57,11 +58,11 @@ export class SelectInput {
           name={this.name}
           onInput={(event: any) => this.handleFormControlInput(event)}
           onBlur={() => this.formControlBlur.emit()}
-          part={`input ${this.error && 'input-invalid'}`}
+          part={`input ${this.error ? 'input-invalid' : ''}`}
           class={this.error ? 'form-select is-invalid' : 'form-select'}
           disabled={this.disabled}
         >
-          {this.options.map(option => (
+          {this.options?.length && this.options.map(option => (
             <option value={option.value}>{option.label}</option>
           ))}
         </select>

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-select.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-select.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form-control-select renders with default props 1`] = `
+<form-control-select exportparts="label,input,input-invalid" label="Test Select" name="test">
+  <mock:shadow-root>
+    <label class="form-label" htmlfor="test" part="label">
+      Test Select
+    </label>
+    <select class="form-select" id="test" name="test" part="input "></select>
+  </mock:shadow-root>
+</form-control-select>
+`;

--- a/packages/webcomponents/src/components/form/test/form-control-select.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-select.spec.tsx
@@ -1,0 +1,105 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { SelectInput } from '../form-control-select';
+
+describe('form-control-select', () => {
+  it('renders with default props', async () => {
+    const page = await newSpecPage({
+      components: [SelectInput],
+      html: `<form-control-select label="Test Select" name="test"></form-control-select>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+    expect(page.rootInstance.label).toBe('Test Select');
+    expect(page.rootInstance.name).toBe('test');
+  });
+
+  it('populates options correctly and handles selection', async () => {
+    const options = [
+      { label: 'Option 1', value: '1' },
+      { label: 'Option 2', value: '2' }
+    ];
+    const page = await newSpecPage({
+      components: [SelectInput],
+      html: `<form-control-select></form-control-select>`,
+    });
+    page.rootInstance.options = options;
+    await page.waitForChanges();
+
+    const selectElement = page.root.shadowRoot.querySelector('select');
+    expect(selectElement.children.length).toBe(options.length);
+    expect(selectElement.children[0].textContent).toBe(options[0].label);
+
+    selectElement.value = options[1].value;
+    expect(selectElement.value).toBe('2');
+  });
+
+  it('shows error and applies error styling when error prop is provided', async () => {
+    const page = await newSpecPage({
+      components: [SelectInput],
+      html: `<form-control-select error="This field is required."></form-control-select>`,
+    });
+
+    const shadowRoot = page.root.shadowRoot;
+    expect(shadowRoot.querySelector('.invalid-feedback').textContent).toBe('This field is required.');
+    expect(shadowRoot.querySelector('.form-select').classList.contains('is-invalid')).toBeTruthy();
+  });
+
+  it('emits formControlInput event on input', async () => {
+    const page = await newSpecPage({
+      components: [SelectInput],
+      html: `<form-control-select></form-control-select>`,
+    });
+
+    page.rootInstance.inputHandler = jest.fn();
+
+    const inputEventSpy = jest.fn();
+    page.root.addEventListener('formControlInput', inputEventSpy);
+
+    const selectElement = page.root.shadowRoot.querySelector('select');
+    selectElement.value = '1';
+    selectElement.dispatchEvent(new Event('input', { bubbles: true, composed: true }));
+
+    await page.waitForChanges();
+    expect(inputEventSpy).toHaveBeenCalled();
+  });
+
+  it('emits formControlBlur event on blur', async () => {
+    const page = await newSpecPage({
+      components: [SelectInput],
+      html: `<form-control-select></form-control-select>`,
+    });
+
+    const blurEventSpy = jest.fn();
+    page.root.addEventListener('formControlBlur', blurEventSpy);
+
+    const selectElement = page.root.shadowRoot.querySelector('select');
+    selectElement.dispatchEvent(new Event('blur'));
+
+    expect(blurEventSpy).toHaveBeenCalled();
+  });
+
+  it('disables select when disabled prop is true', async () => {
+    const page = await newSpecPage({
+      components: [SelectInput],
+      html: `<form-control-select disabled="true"></form-control-select>`,
+    });
+
+    const selectElement = page.root.shadowRoot.querySelector('select');
+
+    // This is weird, but the value of the disabled 
+    // attribute is an empty string on Stencil mock DOM
+    expect(selectElement.attributes.getNamedItem('disabled').value).toBe('');
+  });
+
+  it('handles empty options array', async () => {
+    const page = await newSpecPage({
+      components: [SelectInput],
+      html: `<form-control-select></form-control-select>`,
+    });
+    page.rootInstance.options = [];
+    await page.waitForChanges();
+
+    const selectElement = page.root.shadowRoot.querySelector('select');
+    expect(selectElement.children.length).toBe(0);
+  });
+});


### PR DESCRIPTION
This adds unit tests to the `form-control-select` component

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

