### PR TITLE
Add form-control-number unit tests

### DIFF
--- a/packages/webcomponents/src/components/form/form-control-number.tsx
+++ b/packages/webcomponents/src/components/form/form-control-number.tsx
@@ -44,6 +44,7 @@ export class NumberInput {
     const target = event.target;
     const name = target.getAttribute('name');
     this.inputHandler(name, target.value);
+    this.formControlInput.emit({ name, value: target.value });
   }
 
   componentDidLoad() {

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-number.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-number.spec.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form-control-number handles the disabled state 1`] = `
+<form-control-number disabled="" exportparts="label,input,input-invalid" label="Age">
+  <mock:shadow-root>
+    <label class="form-label" part="label">
+      Age
+    </label>
+    <input class="form-control" disabled="" part="input undefined" type="number" value="">
+  </mock:shadow-root>
+</form-control-number>
+`;
+
+exports[`form-control-number renders with an error message 1`] = `
+<form-control-number error="Invalid input" exportparts="label,input,input-invalid" label="Age">
+  <mock:shadow-root>
+    <label class="form-label" part="label">
+      Age
+    </label>
+    <input class="form-control is-invalid" part="input input-invalid" type="number" value="">
+    <div class="invalid-feedback">
+      Invalid input
+    </div>
+  </mock:shadow-root>
+</form-control-number>
+`;
+
+exports[`form-control-number renders with default props 1`] = `
+<form-control-number exportparts="label,input,input-invalid" label="Age">
+  <mock:shadow-root>
+    <label class="form-label" part="label">
+      Age
+    </label>
+    <input class="form-control" part="input undefined" type="number" value="">
+  </mock:shadow-root>
+</form-control-number>
+`;

--- a/packages/webcomponents/src/components/form/test/form-control-number.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-number.spec.tsx
@@ -1,0 +1,94 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { NumberInput } from "../form-control-number";
+
+describe('form-control-number', () => {
+  it('renders with default props', async () => {
+    const page = await newSpecPage({
+      components: [NumberInput],
+      html: `<form-control-number label="Age"></form-control-number>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('renders with an error message', async () => {
+    const page = await newSpecPage({
+      components: [NumberInput],
+      html: `<form-control-number label="Age" error="Invalid input"></form-control-number>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('handles the disabled state', async () => {
+    const page = await newSpecPage({
+      components: [NumberInput],
+      html: `<form-control-number label="Age" disabled></form-control-number>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('updates the input value when defaultValue changes', async () => {
+    const page = await newSpecPage({
+      components: [NumberInput],
+      html: `<form-control-number label="Age"></form-control-number>`,
+    });
+    let input = page.root.shadowRoot.querySelector('input');
+    expect(input.value).toBe(''); // Default should be empty
+
+    page.root.defaultValue = '30';
+    await page.waitForChanges();
+
+    input = page.root.shadowRoot.querySelector('input');
+    expect(input.value).toBe('30');
+  });
+
+  it('calls inputHandler on user input', async () => {
+    const inputHandlerMock = jest.fn();
+    const page = await newSpecPage({
+      components: [NumberInput],
+      html: `<form-control-number name="age"></form-control-number>`,
+    });
+
+    page.rootInstance.inputHandler = inputHandlerMock;
+    await page.waitForChanges();
+
+    const input = page.root.shadowRoot.querySelector('input');
+    input.value = '25';
+    await input.dispatchEvent(new Event('input', { bubbles: true }));
+
+    expect(inputHandlerMock).toHaveBeenCalledWith('age', '25');
+  });
+
+  it('emits formControlBlur on input blur', async () => {
+    const page = await newSpecPage({
+      components: [NumberInput],
+      html: `<form-control-number></form-control-number>`,
+    });
+    const blurSpy = jest.fn();
+    page.win.addEventListener('formControlBlur', blurSpy);
+
+    const input = page.root.shadowRoot.querySelector('input');
+    await input.dispatchEvent(new CustomEvent('blur'));
+
+    expect(blurSpy).toHaveBeenCalled();
+  });
+
+  it('emits formControlInput on input', async () => {
+    const page = await newSpecPage({
+      components: [NumberInput],
+      html: `<form-control-number name="age"></form-control-number>`,
+    });
+    page.rootInstance.inputHandler = jest.fn();
+    await page.waitForChanges();
+
+    const inputSpy = jest.fn();
+    page.win.addEventListener('formControlInput', inputSpy);
+
+    const input = page.root.shadowRoot.querySelector('input');
+    input.value = '25';
+    const mockEvent = new Event('input', { bubbles: true });
+    Object.defineProperty(mockEvent, 'target', { value: input, enumerable: true });
+    await input.dispatchEvent(mockEvent);
+
+    expect(inputSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This adds some unit tests to the form-control-number component

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

https://github.com/justifi-tech/web-component-library/issues/322

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
- [ ] Previous unit and e2e tests are passing
  