### PR TITLE
Add form-control-monetary unit-tests

### DIFF
--- a/packages/webcomponents/src/components/form/form-control-monetary.tsx
+++ b/packages/webcomponents/src/components/form/form-control-monetary.tsx
@@ -16,7 +16,7 @@ import IMask, { InputMask } from 'imask';
 })
 export class MonetaryInput {
   @Prop() label: string;
-  @Prop() name: any;
+  @Prop() name: string;
   @Prop() error: string;
   @Prop() defaultValue: string;
   @Prop() inputHandler: (name: string, value: string) => void;
@@ -34,30 +34,33 @@ export class MonetaryInput {
   }
 
   componentDidLoad() {
-    if (this.textInput) {
-      this.imask = IMask(this.textInput, {
-        mask: Number,
-        scale: 2,
-        thousandsSeparator: ',',
-        padFractionalZeros: true,
-        normalizeZeros: true,
-        radix: '.',
-      });
-
-      this.imask.on('accept', () => {
-        const rawValue = this.imask.unmaskedValue;
-        this.inputHandler(this.name, rawValue);
-      });
-
-      this.textInput.addEventListener('blur', () => {
-        this.formControlBlur.emit();
-      });
-    }
+    this.initializeIMask();
     this.updateInput(this.defaultValue);
   }
 
   disconnectedCallback() {
     this.imask?.destroy();
+  }
+
+  private initializeIMask() {
+    if (!this.textInput) return;
+
+    this.imask = IMask(this.textInput, {
+      mask: Number,
+      scale: 2,
+      thousandsSeparator: ',',
+      padFractionalZeros: true,
+      normalizeZeros: true,
+      radix: '.',
+    });
+
+    this.imask.on('accept', () => {
+      const rawValue = this.imask.unmaskedValue;
+      this.inputHandler(this.name, rawValue);
+      this.formControlInput.emit({ name: this.name, value: rawValue });
+    });
+
+    this.textInput.addEventListener('blur', () => this.formControlBlur.emit());
   }
 
   updateInput(newValue: any) {

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form-control-monetary renders correctly with default props 1`] = `
+<form-control-monetary exportparts="label,input,input-invalid">
+  <mock:shadow-root>
+    <label class="form-label" part="label"></label>
+    <input class="form-control" part="input undefined" type="text">
+  </mock:shadow-root>
+</form-control-monetary>
+`;

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`form-control-monetary displays error message when error prop is set 1`] = `
+<form-control-monetary error="Invalid amount" exportparts="label,input,input-invalid">
+  <mock:shadow-root>
+    <label class="form-label" part="label"></label>
+    <input class="form-control is-invalid" part="input input-invalid" type="text">
+    <div class="invalid-feedback">
+      Invalid amount
+    </div>
+  </mock:shadow-root>
+</form-control-monetary>
+`;
+
 exports[`form-control-monetary renders correctly with default props 1`] = `
 <form-control-monetary exportparts="label,input,input-invalid">
   <mock:shadow-root>

--- a/packages/webcomponents/src/components/form/test/form-control-monetary.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-monetary.spec.tsx
@@ -1,0 +1,73 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { MonetaryInput } from "../form-control-monetary";
+
+describe('form-control-monetary', () => {
+  it('renders correctly with default props', async () => {
+    const page = await newSpecPage({
+      components: [MonetaryInput],
+      html: `<form-control-monetary></form-control-monetary>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('handles props correctly', async () => {
+    const page = await newSpecPage({
+      components: [MonetaryInput],
+      html: `
+      <form-control-monetary
+        label="Amount"
+        name="amount"
+        error="Invalid amount"  
+        defaultValue="1000"
+      ></form-control-monetary>
+    `,
+    });
+    await page.waitForChanges();
+
+    const label = page.root.shadowRoot.querySelector('label');
+    const input = page.root.shadowRoot.querySelector('input');
+    const errorDiv = page.root.shadowRoot.querySelector('.invalid-feedback');
+
+    expect(label.textContent).toBe('Amount');
+    expect(input.getAttribute('name')).toBe('amount');
+    expect(errorDiv.textContent).toBe('Invalid amount');
+  });
+
+  it('calls inputHandler and emits formControlInput on user input', async () => {
+    const inputHandlerMock = jest.fn();
+    const page = await newSpecPage({
+      components: [MonetaryInput],
+      html: `<form-control-monetary></form-control-monetary>`,
+    });
+
+    page.rootInstance.inputHandler = inputHandlerMock;
+    await page.waitForChanges();
+
+    const inputSpy = jest.fn();
+    page.win.addEventListener('formControlInput', inputSpy);
+
+    const input = page.root.shadowRoot.querySelector('input');
+    input.value = '1234.56';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await page.waitForChanges();
+
+    expect(inputHandlerMock).toHaveBeenCalled();
+    expect(inputSpy).toHaveBeenCalled();
+  });
+
+  it('emits formControlBlur on input blur', async () => {
+    const page = await newSpecPage({
+      components: [MonetaryInput],
+      html: `<form-control-monetary></form-control-monetary>`,
+    });
+
+    const blurSpy = jest.fn();
+    page.win.addEventListener('formControlBlur', blurSpy);
+
+    const input = page.root.shadowRoot.querySelector('input');
+    input.dispatchEvent(new Event('blur', { bubbles: true }));
+    await page.waitForChanges();
+
+    expect(blurSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/webcomponents/src/components/form/test/form-control-monetary.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-monetary.spec.tsx
@@ -70,4 +70,15 @@ describe('form-control-monetary', () => {
 
     expect(blurSpy).toHaveBeenCalled();
   });
+
+  it('displays error message when error prop is set', async () => {
+    const page = await newSpecPage({
+      components: [MonetaryInput],
+      html: `<form-control-monetary error="Invalid amount"></form-control-monetary>`,
+    });
+
+    const errorDiv = page.root.shadowRoot.querySelector('.invalid-feedback');
+    expect(errorDiv.textContent).toBe('Invalid amount');
+    expect(page.root).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
This adds unit tests to the `form-control-monetary` component.

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

https://github.com/justifi-tech/web-component-library/issues/322

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
- [ ] Previous unit and e2e tests are passing
  
