### PR TITLE
Add form-control-datepart unit tests

### DIFF
--- a/packages/webcomponents/src/components/form/form-control-datepart.tsx
+++ b/packages/webcomponents/src/components/form/form-control-datepart.tsx
@@ -19,7 +19,7 @@ export class DatePartInput {
   @Prop() name: string;
   @Prop() error: string;
   @Prop() defaultValue: string;
-  @Prop() type: 'day' | 'month' | 'year';
+  @Prop() type: 'day' | 'month' | 'year' = 'day';
   @Prop() inputHandler: (name: string, value: string) => void;
   @Prop() disabled: boolean;
 
@@ -36,50 +36,55 @@ export class DatePartInput {
   }
 
   componentDidLoad() {
-    if (this.textInput) {
-      let maskOptions;
+    this.initializeMask();
+    this.updateInput(this.defaultValue);
+  }
 
-      switch (this.type) {
-        case 'day':
-          maskOptions = { mask: Number, min: 1, max: 31 };
-          break;
-        case 'month':
-          maskOptions = { mask: Number, min: 1, max: 12 };
-          break;
-        case 'year':
-          maskOptions = {
-            mask: Number,
-            min: 1900,
-            max: new Date().getFullYear(),
-          };
-          break;
-        default:
-          throw new Error('Invalid type prop');
-      }
+  disconnectedCallback() {
+    this.imask?.destroy();
+  }
 
-      this.imask = IMask(this.textInput, maskOptions);
-
-      this.imask.on('accept', () => {
-        const rawValue = this.imask.unmaskedValue;
-        this.inputHandler(this.name, rawValue);
-      });
-
-      this.textInput.addEventListener('blur', () => {
-        this.formControlBlur.emit();
-      });
-
-      this.updateInput(this.defaultValue);
+  private initializeMask() {
+    if (!this.textInput) {
+      return;
     }
+
+    let maskOptions;
+
+    switch (this.type) {
+      default:
+      case 'day':
+        maskOptions = { mask: Number, min: 1, max: 31 };
+        break;
+      case 'month':
+        maskOptions = { mask: Number, min: 1, max: 12 };
+        break;
+      case 'year':
+        maskOptions = {
+          mask: Number,
+          min: 1900,
+          max: new Date().getFullYear(),
+        };
+        break;
+    }
+
+    this.imask = IMask(this.textInput, maskOptions);
+
+    this.imask.on('accept', () => {
+      const rawValue = this.imask.unmaskedValue;
+      this.inputHandler(this.name, rawValue);
+      this.formControlInput.emit({ name: this.name, value: rawValue });
+    });
+
+    this.textInput.addEventListener('blur', () => {
+      this.formControlBlur.emit();
+    });
   }
 
   updateInput(newValue: any) {
     if (this.imask) {
       this.imask.value = String(newValue);
     }
-  }
-
-  disconnectedCallback() {
-    this.imask?.destroy();
   }
 
   render() {

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-datepart.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-datepart.spec.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form-control-datepart displays error message correctly 1`] = `
+<form-control-datepart error="Error message" exportparts="label,input,input-invalid">
+  <mock:shadow-root>
+    <label class="form-label" part="label"></label>
+    <input class="form-control is-invalid" part="input input-invalid" type="text">
+    <div class="invalid-feedback">
+      Error message
+    </div>
+  </mock:shadow-root>
+</form-control-datepart>
+`;
+
+exports[`form-control-datepart renders correctly with default props 1`] = `
+<form-control-datepart exportparts="label,input,input-invalid" label="Date Part" name="datepart">
+  <mock:shadow-root>
+    <label class="form-label" htmlfor="datepart" part="label">
+      Date Part
+    </label>
+    <input class="form-control" id="datepart" name="datepart" part="input undefined" type="text">
+  </mock:shadow-root>
+</form-control-datepart>
+`;

--- a/packages/webcomponents/src/components/form/test/form-control-datepart.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-datepart.spec.tsx
@@ -1,0 +1,110 @@
+import { newSpecPage } from "@stencil/core/testing";
+import { DatePartInput } from "../form-control-datepart";
+import * as IMaskPackage from 'imask';
+
+jest.mock('imask', () => ({
+  default: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    destroy: jest.fn(),
+    value: '',
+    unmaskedValue: '',
+  })),
+}));
+
+const IMaskSpy = jest.spyOn(IMaskPackage, 'default');
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('form-control-datepart', () => {
+  it('renders correctly with default props', async () => {
+    const page = await newSpecPage({
+      components: [DatePartInput],
+      html: `<form-control-datepart label="Date Part" name="datepart"></form-control-datepart>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('should initialize IMask with correct options for "day" type', async () => {
+    await newSpecPage({
+      components: [DatePartInput],
+      html: '<form-control-datepart type="day"></form-control-datepart>',
+    });
+
+    expect(IMaskSpy).toHaveBeenCalled();
+    expect(IMaskSpy.mock.calls[0][1]).toEqual({ mask: Number, min: 1, max: 31 });
+  });
+
+  it('should initialize IMask with correct options for "month" type', async () => {
+    // Clear mocks to reset the calls count
+    jest.clearAllMocks();
+
+    await newSpecPage({
+      components: [DatePartInput],
+      html: '<form-control-datepart type="month"></form-control-datepart>',
+    });
+
+    expect(IMaskSpy).toHaveBeenCalled();
+    expect(IMaskSpy.mock.calls[0][1]).toEqual({ mask: Number, min: 1, max: 12 });
+  });
+
+  it('should initialize IMask with correct options for "year" type', async () => {
+    // Clear mocks to reset the calls count
+    jest.clearAllMocks();
+
+    await newSpecPage({
+      components: [DatePartInput],
+      html: '<form-control-datepart type="year"></form-control-datepart>',
+    });
+
+    expect(IMaskSpy).toHaveBeenCalled();
+    expect(IMaskSpy.mock.calls[0][1]).toEqual({ mask: Number, min: 1900, max: new Date().getFullYear() });
+  });
+
+  it('emits formControlBlur on input blur', async () => {
+    const page = await newSpecPage({
+      components: [DatePartInput],
+      html: `<form-control-datepart></form-control-datepart>`,
+    });
+
+    const blurSpy = jest.fn();
+    page.win.addEventListener('formControlBlur', blurSpy);
+
+    const input = page.root.shadowRoot.querySelector('input');
+    input.dispatchEvent(new Event('blur', { bubbles: true }));
+    await page.waitForChanges();
+
+    expect(blurSpy).toHaveBeenCalled();
+  });
+
+  it('calls inputHandler and emits formControlInput on user input', async () => {
+    const inputHandlerMock = jest.fn();
+    const page = await newSpecPage({
+      components: [DatePartInput],
+      html: `<form-control-datepart type="day" name="day"></form-control-datepart>`,
+    });
+
+    page.rootInstance.inputHandler = inputHandlerMock;
+    await page.waitForChanges();
+
+    const inputSpy = jest.fn();
+    page.win.addEventListener('formControlInput', inputSpy);
+
+    const input = page.root.shadowRoot.querySelector('input');
+    input.value = '15'; // Assuming 'day' type for simplicity
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await page.waitForChanges();
+
+    expect(inputHandlerMock).toHaveBeenCalledWith('day', '15');
+    expect(inputSpy).toHaveBeenCalled();
+  });
+
+  it('displays error message correctly', async () => {
+    const page = await newSpecPage({
+      components: [DatePartInput],
+      html: `<form-control-datepart error="Error message"></form-control-datepart>`,
+    });
+    expect(page.root).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This adds unit tests to the `form-control-datepart` component

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

https://github.com/justifi-tech/web-component-library/issues/322

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
- [ ] Previous unit and e2e tests are passing
  

