### PR TITLE
add tokenExpired event to payments list

### DIFF
--- a/apps/docs/stories/components/payments-list-example.ts
+++ b/apps/docs/stories/components/payments-list-example.ts
@@ -25,5 +25,9 @@ export const codeExampleEventHandling = (`
     const getMoreEntityDetails = justifiAPI(entityID);
     <entity-details-component data={getMoreEntityDetails} />
   })
+
+  window.addEventListener('token-expired', (data) => {
+    console.log(data)
+  })
 </script>
 `);

--- a/apps/docs/stories/components/payments-list.stories.tsx
+++ b/apps/docs/stories/components/payments-list.stories.tsx
@@ -16,10 +16,22 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'payment-row-clicked': {
+      description: 'Emitted when a row is clicked.',
+      table: {
+        category: 'events',
+      },
+    },
+    'token-expired': {
+      description: 'Emitted when the token is expired.',
+      table: {
+        category: 'events',
+      },
+    },
   },
   parameters: {
     actions: {
-      handles: ['payment-row-clicked'],
+      handles: ['payment-row-clicked', 'tokenExpired'],
     },
   },
   decorators: [

--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -2,12 +2,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { PagingInfo } from './Pagination';
 
 export interface IApiResponse<T> {
-  data: T;
+  data?: T;
   error?: IErrorObject | IServerError;
   page_info?: PagingInfo;
   errors?: string[];
-  id: number;
-  type: string;
+  id?: number;
+  type?: string;
 }
 
 export type IServerError = string;

--- a/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
@@ -19,6 +19,7 @@ export class PaymentsListCore {
 
     bubbles: true,
   }) rowClicked: EventEmitter<Payment>;
+  @Event() errorEvent: EventEmitter<string>;
 
   componentWillLoad() {
     if (this.getPayments) {
@@ -55,6 +56,7 @@ export class PaymentsListCore {
         this.loading = false;
       },
       onError: (errorMessage) => {
+        this.errorEvent.emit(errorMessage);
         this.errorMessage = errorMessage;
         this.loading = false;
       },

--- a/packages/webcomponents/src/components/payments-list/payments-list.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list.tsx
@@ -1,7 +1,8 @@
-import { Component, h, Prop, State, Watch } from '@stencil/core';
+import { Component, Event, EventEmitter, h, Prop, State, Watch } from '@stencil/core';
 import { PaymentService } from '../../api/services/payment.service';
 import { makeGetPayments } from './get-payments';
 import { ErrorState } from '../details/utils';
+import { API_ERRORS } from '../../api/shared';
 
 /**
   * @exportedPart table-head: Table head
@@ -34,6 +35,8 @@ export class PaymentsList {
   @State() getPayments: Function;
   @State() errorMessage: string = null;
 
+  @Event() tokenExpired: EventEmitter<any>;
+
   componentWillLoad() {
     this.initializeGetPayments();
   }
@@ -56,6 +59,12 @@ export class PaymentsList {
     }
   }
 
+  handleErrorEvent = (event) => {
+    if (event.detail === API_ERRORS.NOT_AUTHENTICATED) {
+      this.tokenExpired.emit();
+    }
+  };
+
   render() {
 
     if (this.errorMessage) {
@@ -64,6 +73,7 @@ export class PaymentsList {
     return (
       <payments-list-core
         getPayments={this.getPayments}
+        onErrorEvent={this.handleErrorEvent}
       ></payments-list-core>
     );
   }

--- a/packages/webcomponents/src/components/payments-list/test/__snapshots__/payments-list.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payments-list/test/__snapshots__/payments-list.spec.tsx.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`payments-list emit tokenExpired event when the authToken has expired 1`] = `
+<justifi-payments-list account-id="abc" auth-token="abc">
+  <mock:shadow-root>
+    <payments-list-core>
+      <justifi-table error-message="Not Authenticated" exportparts="
+table-head,table-head-row,table-head-cell,table-body,table-row,table-row-even,
+table-row-odd,table-cell,loading-state-cell,loading-state-spinner,error-state,
+empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-button-text
+">
+        <mock:shadow-root>
+          <div class="table-wrapper">
+            <table class="table table-hover">
+              <thead class="sticky-top table-head" part="table-head">
+                <tr class="table-light text-nowrap" part="table-head-row">
+                  <th part="table-head-cell" scope="col" title="The date and time each payment was made">
+                    Made On
+                  </th>
+                  <th part="table-head-cell" scope="col" title="The dollar amount of each payment">
+                    Amount
+                  </th>
+                  <th part="table-head-cell" scope="col" title="The payment description, if you provided one">
+                    Description
+                  </th>
+                  <th part="table-head-cell" scope="col" title="The name associated with the payment method">
+                    Cardholder
+                  </th>
+                  <th part="table-head-cell" scope="col" title="The brand and last 4 digits of the payment method">
+                    Payment Method
+                  </th>
+                  <th part="table-head-cell" scope="col" title="The current status of each payment">
+                    Status
+                  </th>
+                  <th part="table-head-cell" scope="col" title="The unique identifier of each payment">
+                    Payment ID
+                  </th>
+                </tr>
+              </thead>
+              <tbody class="table-body" part="table-body">
+                <tr>
+                  <td class="error-state" colspan="7" data-test-id="table-error-state" part="error-state" style="text-align: center;">
+                    An unexpected error occurred: Not Authenticated
+                  </td>
+                </tr>
+              </tbody>
+              <tfoot class="sticky-bottom">
+                <tr class="align-middle table-light">
+                  <td colspan="7" part="pagination-bar">
+                    <pagination-menu></pagination-menu>
+                  </td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+        </mock:shadow-root>
+      </justifi-table>
+    </payments-list-core>
+  </mock:shadow-root>
+</justifi-payments-list>
+`;
+
 exports[`payments-list renders an error message when accountId and authToken are not provided 1`] = `
 <justifi-payments-list>
   <mock:shadow-root>

--- a/packages/webcomponents/src/components/payments-list/test/payments-list.spec.tsx
+++ b/packages/webcomponents/src/components/payments-list/test/payments-list.spec.tsx
@@ -1,6 +1,9 @@
+import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
 import { PaymentsList } from "../payments-list";
 import { PaymentsListCore } from "../payments-list-core";
+import { Table } from "../../table/table";
+import { PaymentService } from "../../../api/services/payment.service";
 
 describe('payments-list', () => {
   it('renders an error message when accountId and authToken are not provided', async () => {
@@ -28,5 +31,29 @@ describe('payments-list', () => {
     });
     await page.waitForChanges();
     expect(page.root).toMatchSnapshot();
+  });
+
+  it('emit tokenExpired event when the authToken has expired', async () => {
+    const fetchPaymentsMock = jest.spyOn(PaymentService.prototype, 'fetchPayments' as keyof PaymentService);
+
+    fetchPaymentsMock.mockResolvedValue({
+      "error": {
+        "code": "not_authenticated",
+        "message": "Not Authenticated"
+      }
+    });
+
+    const spy = jest.fn();
+
+    const page = await newSpecPage({
+      components: [PaymentsList, PaymentsListCore, Table],
+      template: () => <justifi-payments-list account-id="abc" auth-token="abc" onTokenExpired={spy} />,
+    });
+
+    await page.waitForChanges();
+
+    expect(page.root).toMatchSnapshot();
+
+    expect(spy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This adds the expiredToken event to the `justifi-payments-lis` component.
It's emitted when `payments-list-core` emits error-event with the error "Not Authenticated`.

Also added the `row-clicked` event to the Storybook actions tab

Links
-----
https://github.com/justifi-tech/web-component-library/issues/424

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests


Developer QA steps
--------------------

Expired token: `eyJraWQiOiJqdXN0aWZpLTQxNTczZmIyNjU0MDVmNDY0Y2UyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2F1dGguanVzdGlmaS1zdGFnaW5nLmNvbS8iLCJhenAiOiJ3Y3RfNVNKckZPWTI0YXJ5bUJRc2xTY3hvRiIsInN1YiI6IndjdF81U0pyRk9ZMjRhcnltQlFzbFNjeG9GQHNlc3Npb25zIiwiYXVkIjoiaHR0cHM6Ly9hcGkuanVzdGlmaS5haS92MSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyIsInBlcm1pc3Npb25zIjpbIndyaXRlOmFjY291bnQ6YWNjXzMzTzlESWdJZVMzOTFMSUxIRVIxZmYiLCJ3cml0ZTpidXNpbmVzczpiaXpfNm02VDlESUFtaW1WRlFZd2FoT2xQQiJdLCJleHAiOjE3MTA3OTc1MjksImlhdCI6MTcxMDc5MzkyOSwicGxhdGZvcm1fYWNjb3VudF9pZCI6ImFjY18zRklibDNUSWhUVUJoWGt3YVRYNTlaIn0.XTIyf8YsbqRKeSOPGj-LS-W2HC8D1QoXVOo7TMeRM6fE-TA2n1xc5naF1v57ddTvbg8MKqTBG0ssPsBvgk0db7WVtMNgM_WPSMje-0vRokJAH9aCyhYgKDA9IBhEAZ4ibbJiXMw11gwiB8Xi89952r-j01Qt-4kTVK2_pyeWvjnDdANM5w-nkgFdKffeIdc-C1P7Yvze3auiRZSR7PvGBJVgrO7U9L7T9EeyLer0xj26hlgIX-45AucSN3NVr7WZkjrX95ikC2fKhw5XG6U6yCD8MUFJ5wT4WO-yh4Ma7qdJg-ZK7gie1RiWF57ve4W8M3_uFOb8xrCz1AKqXjcugA`

[ ] - When trying to load payments list with an expired token, you should see in the actions tab on Storybook that an expiredToken event was logged.
[ ] - When loading payments list with a valid token, actions tab should be clear
[ ] - When clicked a row, the action should appear in actions tab


