### PR TITLE
add tokenExpired event to payout details

### DIFF
--- a/apps/docs/stories/components/payout-details-example.ts
+++ b/apps/docs/stories/components/payout-details-example.ts
@@ -10,5 +10,15 @@ ${codeExampleHead('justifi-payout-details')}
   <justifi-payout-details payout-id="123" auth-token="your-auth-token"></justifi-payout-details>
 </body>
 
+<script>
+  (function() {
+    var payoutDetails = document.querySelector('justifi-payout-details');
+
+    payoutDetails.addEventListener('tokenExpired', (data) => {
+      console.log(data);
+    });
+  })()
+</script>
+
 </html>
 `);

--- a/apps/docs/stories/components/payout-details.stories.tsx
+++ b/apps/docs/stories/components/payout-details.stories.tsx
@@ -16,6 +16,19 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'token-expired': {
+      description: 'Emitted when the token is expired.',
+      table: {
+        category: 'events'
+      }
+    }
+  },
+  parameters: {
+    actions: {
+      handles: [
+        'tokenExpired',
+      ]
+    }
   },
   decorators: [
     customStoryDecorator,

--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -2,12 +2,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { PagingInfo } from './Pagination';
 
 export interface IApiResponse<T> {
-  data: T;
+  data?: T;
   error?: IErrorObject | IServerError;
   page_info?: PagingInfo;
   errors?: string[];
-  id: number;
-  type: string;
+  id?: number;
+  type?: string;
 }
 
 export type IServerError = string;

--- a/packages/webcomponents/src/components/payout-details/get-payout-details.ts
+++ b/packages/webcomponents/src/components/payout-details/get-payout-details.ts
@@ -12,12 +12,9 @@ export const makeGetPayoutDetails =
 
         onSuccess(payout);
       } else {
-        const responseError = getErrorMessage(response.error);
-        const errorMessage = `Error fetching payout details: ${responseError}`;
-        onError(errorMessage);
+        onError(getErrorMessage(response.error));
       }
     } catch (error) {
-      const errorMessage = `Error fetching payout details: ${error}`;
-      onError(errorMessage);
+      onError(error.message || error);
     }
   };

--- a/packages/webcomponents/src/components/payout-details/payout-details-core.tsx
+++ b/packages/webcomponents/src/components/payout-details/payout-details-core.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, State, Watch } from '@stencil/core';
+import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { IPayout, Payout } from '../../api';
 import { MapPayoutStatusToBadge, formatCurrency, formatDate, formatTime } from '../../utils/utils';
 import { CodeBlock, DetailItem, DetailSectionTitle, EntityHeadInfo, EntityHeadInfoItem, ErrorState, LoadingState } from '../details/utils';
@@ -10,9 +10,12 @@ import { CodeBlock, DetailItem, DetailSectionTitle, EntityHeadInfo, EntityHeadIn
 
 export class PayoutDetailsCore {
   @Prop() getPayout: Function;
+
   @State() payout: Payout;
   @State() loading: boolean = true;
   @State() errorMessage: string = null;
+
+  @Event() errorEvent: EventEmitter<string>;
 
   componentWillLoad() {
     if (this.getPayout) {
@@ -35,6 +38,7 @@ export class PayoutDetailsCore {
         this.loading = false;
       },
       onError: (errorMessage) => {
+        this.errorEvent.emit(errorMessage);
         this.errorMessage = errorMessage;
         console.error(this.errorMessage);
         this.loading = false;

--- a/packages/webcomponents/src/components/payout-details/payout-details.tsx
+++ b/packages/webcomponents/src/components/payout-details/payout-details.tsx
@@ -1,7 +1,8 @@
-import { Component, h, Prop, Watch, State } from '@stencil/core';
+import { Component, h, Prop, Watch, State, Event, EventEmitter } from '@stencil/core';
 import { PayoutService } from '../../api/services/payout.service';
 import { makeGetPayoutDetails } from './get-payout-details';
 import { ErrorState } from '../details/utils';
+import { API_ERRORS } from '../../api/shared';
 
 @Component({
   tag: 'justifi-payout-details',
@@ -11,8 +12,11 @@ import { ErrorState } from '../details/utils';
 export class PayoutDetails {
   @Prop() payoutId: string;
   @Prop() authToken: string;
+
   @State() getPayout: Function;
   @State() errorMessage: string = null;
+
+  @Event() tokenExpired: EventEmitter<any>;
 
   componentWillLoad() {
     this.initializeGetPayout();
@@ -36,13 +40,19 @@ export class PayoutDetails {
     }
   }
 
+  handleError = (event) => {
+    if (event.detail === API_ERRORS.NOT_AUTHENTICATED) {
+      this.tokenExpired.emit();
+    }
+  }
+
   render() {
     if (this.errorMessage) {
       return ErrorState(this.errorMessage);
     }
 
     return (
-      <payout-details-core getPayout={this.getPayout}></payout-details-core>
+      <payout-details-core getPayout={this.getPayout} onErrorEvent={this.handleError} />
     );
   }
 }

--- a/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details-core.spec.tsx.snap
@@ -148,7 +148,7 @@ exports[`payout-details-core handles fetch payout error correctly 1`] = `
 <payout-details-core>
   <main class="d-flex justify-content-center p-4 text-center" part="detail-empty-state" style="font-size: 1.2rem;">
     <div>
-      Error fetching payout details: Error: Fetch error
+      Fetch error
     </div>
   </main>
 </payout-details-core>

--- a/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
+++ b/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
@@ -34,7 +34,7 @@ describe('getPayout', () => {
   });
 
   it('should call onError with an error message on API failure', async () => {
-    const mockError = new Error('Error fetching payout');
+    const mockError = 'Error fetching payout';
     const onSuccess = jest.fn();
     const onError = jest.fn();
 
@@ -48,13 +48,11 @@ describe('getPayout', () => {
     await getPayout({ onSuccess, onError });
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith(
-      `Error fetching payout details: ${mockError}`
-    );
+    expect(onError).toHaveBeenCalledWith(mockError);
   });
 
   it('should call onError with an error message on API failure with error message', async () => {
-    const mockError = new Error('Error fetching payout');
+    const mockError = 'Error fetching payout';
     const onSuccess = jest.fn();
     const onError = jest.fn();
 
@@ -68,8 +66,6 @@ describe('getPayout', () => {
     await getPayout({ onSuccess, onError });
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith(
-      `Error fetching payout details: ${mockError}`
-    );
+    expect(onError).toHaveBeenCalledWith(mockError);
   });
 });

--- a/packages/webcomponents/src/components/payout-details/test/payout-details.spec.tsx
+++ b/packages/webcomponents/src/components/payout-details/test/payout-details.spec.tsx
@@ -1,14 +1,38 @@
+import { h } from '@stencil/core';
 import { newSpecPage } from "@stencil/core/testing";
 import { PayoutDetails } from "../payout-details";
 import { PayoutDetailsCore } from "../payout-details-core";
+import { PayoutService } from '../../../api/services/payout.service';
 
 describe('payout-details', () => {
   it('renders error state when no payoutId or authToken', async () => {
     const page = await newSpecPage({
       components: [PayoutDetails, PayoutDetailsCore],
-      html: '<justifi-payout-details></justifi-payout-details>',
+      template: () => <justifi-payout-details />,
     });
     await page.waitForChanges();
     expect(page.root).toMatchSnapshot();
+  });
+
+  it('emits tokenExpired when passed an expired token', async () => {
+    const fetchPayoutMock = jest.spyOn(PayoutService.prototype, 'fetchPayout');
+
+    fetchPayoutMock.mockResolvedValue({
+      "error": {
+        "code": "not_authenticated",
+        "message": "Not Authenticated"
+      }
+    });
+
+    const eventSpy = jest.fn();
+
+    const page = await newSpecPage({
+      components: [PayoutDetails, PayoutDetailsCore],
+      template: () => <justifi-payout-details authToken='123' payoutId='123' onTokenExpired={eventSpy} />
+    })
+
+    await page.waitForChanges();
+
+    expect(eventSpy).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This adds the expiredToken event to the `justifi-payout-details` component.
It's emitted when `payout-details-core` emits error-event with the error "Not Authenticated`.

Links
-----
https://github.com/justifi-tech/web-component-library/issues/424

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests


Developer QA steps
--------------------

Expired token: `eyJraWQiOiJqdXN0aWZpLTQxNTczZmIyNjU0MDVmNDY0Y2UyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2F1dGguanVzdGlmaS1zdGFnaW5nLmNvbS8iLCJhenAiOiJ3Y3RfNVNKckZPWTI0YXJ5bUJRc2xTY3hvRiIsInN1YiI6IndjdF81U0pyRk9ZMjRhcnltQlFzbFNjeG9GQHNlc3Npb25zIiwiYXVkIjoiaHR0cHM6Ly9hcGkuanVzdGlmaS5haS92MSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyIsInBlcm1pc3Npb25zIjpbIndyaXRlOmFjY291bnQ6YWNjXzMzTzlESWdJZVMzOTFMSUxIRVIxZmYiLCJ3cml0ZTpidXNpbmVzczpiaXpfNm02VDlESUFtaW1WRlFZd2FoT2xQQiJdLCJleHAiOjE3MTA3OTc1MjksImlhdCI6MTcxMDc5MzkyOSwicGxhdGZvcm1fYWNjb3VudF9pZCI6ImFjY18zRklibDNUSWhUVUJoWGt3YVRYNTlaIn0.XTIyf8YsbqRKeSOPGj-LS-W2HC8D1QoXVOo7TMeRM6fE-TA2n1xc5naF1v57ddTvbg8MKqTBG0ssPsBvgk0db7WVtMNgM_WPSMje-0vRokJAH9aCyhYgKDA9IBhEAZ4ibbJiXMw11gwiB8Xi89952r-j01Qt-4kTVK2_pyeWvjnDdANM5w-nkgFdKffeIdc-C1P7Yvze3auiRZSR7PvGBJVgrO7U9L7T9EeyLer0xj26hlgIX-45AucSN3NVr7WZkjrX95ikC2fKhw5XG6U6yCD8MUFJ5wT4WO-yh4Ma7qdJg-ZK7gie1RiWF57ve4W8M3_uFOb8xrCz1AKqXjcugA`

[ ] - When trying to load payout details with an expired token, you should see in the actions tab on Storybook that an expiredToken event was logged.
[ ] - When loading payout details with a valid token, actions tab should be clear



