### PR TITLE
add tokenExpired event to payouts list

### DIFF
--- a/apps/docs/stories/components/payouts-list-example.ts
+++ b/apps/docs/stories/components/payouts-list-example.ts
@@ -9,4 +9,13 @@ ${codeExampleHead('justifi-payouts-list')}
   <justifi-payouts-list></justifi-payouts-list>
 </body>
 
+<script>
+  (function() {
+    var payoutsList = document.querySelector('justifi-payouts-list');
+    payoutsList.addEventListener('tokenExpired', (data) => {
+      console.log(data)
+    });
+  })();
+</script>
+
 </html>`;

--- a/apps/docs/stories/components/payouts-list.stories.tsx
+++ b/apps/docs/stories/components/payouts-list.stories.tsx
@@ -16,10 +16,22 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'payout-row-clicked': {
+      description: 'Event emitted when a row is clicked',
+      table: {
+        category: 'Events',
+      },
+    },
+    'token-expired': {
+      description: 'Event emitted when the token is expired',
+      table: {
+        category: 'Events',
+      },
+    },
   },
   parameters: {
     actions: {
-      handles: ['payout-row-clicked'],
+      handles: ['payout-row-clicked', 'tokenExpired'],
     },
   },
   decorators: [

--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -2,12 +2,12 @@ import { v4 as uuidv4 } from 'uuid';
 import { PagingInfo } from './Pagination';
 
 export interface IApiResponse<T> {
-  data: T;
+  data?: T;
   error?: IErrorObject | IServerError;
   page_info?: PagingInfo;
   errors?: string[];
-  id: number;
-  type: string;
+  id?: number;
+  type?: string;
 }
 
 export type IServerError = string;

--- a/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
@@ -16,15 +16,18 @@ import { tableExportedParts } from '../table/exported-parts';
 
 export class PayoutsListCore {
   @Prop() getPayouts: Function;
+
   @State() payouts: Payout[] = [];
   @State() loading: boolean = true;
   @State() errorMessage: string;
   @State() paging: PagingInfo = pagingDefaults;
   @State() params: any
+
   @Event({
     eventName: 'payout-row-clicked',
     bubbles: true,
   }) rowClicked: EventEmitter<Payout>;
+  @Event() errorEvent: EventEmitter<string>;
 
   componentWillLoad() {
     if (this.getPayouts) {
@@ -78,6 +81,7 @@ export class PayoutsListCore {
         this.loading = false;
       },
       onError: (errorMessage) => {
+        this.errorEvent.emit(errorMessage);
         this.errorMessage = errorMessage;
         this.loading = false;
       },

--- a/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
@@ -1,8 +1,9 @@
-import { Component, Host, h, Prop, State, Watch } from '@stencil/core';
+import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { tableExportedParts } from '../table/exported-parts';
 import { PayoutService } from '../../api/services/payout.service';
 import { makeGetPayouts } from './get-payouts';
 import { ErrorState } from '../details/utils';
+import { API_ERRORS } from '../../api/shared';
 
 /**
   * @exportedPart table-head: Table head
@@ -35,6 +36,8 @@ export class PayoutsList {
   @State() getPayouts: Function;
   @State() errorMessage: string = null;
 
+  @Event() tokenExpired: EventEmitter<void>;
+
   componentWillLoad() {
     this.initializeGetPayouts();
   }
@@ -57,6 +60,12 @@ export class PayoutsList {
     }
   }
 
+  handleError = (event) => {
+    if (event.detail === API_ERRORS.NOT_AUTHENTICATED) {
+      this.tokenExpired.emit();
+    }
+  }
+
   render() {
     if (this.errorMessage) {
       return ErrorState(this.errorMessage);
@@ -64,7 +73,7 @@ export class PayoutsList {
 
     return (
       <Host exportedparts={tableExportedParts}>
-        <payouts-list-core getPayouts={this.getPayouts} />
+        <payouts-list-core getPayouts={this.getPayouts} onErrorEvent={this.handleError} />
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
@@ -1,3 +1,4 @@
+import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { Table } from '../../table/table';
 import { PaginationMenu } from '../../pagination-menu/pagination-menu';
@@ -13,22 +14,17 @@ describe('payouts-list-core', () => {
     const mockPayoutService = {
       fetchPayouts: jest.fn().mockResolvedValue(mockPayoutsResponse),
     };
-    const page = await newSpecPage({
-      components: [PayoutsListCore, Table, PaginationMenu],
-      html: `
-        <payouts-list-core></payouts-list-core>
-      `,
-    });
-
-    page.rootInstance.componentWillLoad = () => { };
-
-    page.rootInstance.getPayouts = makeGetPayouts({
+    const getPayouts = makeGetPayouts({
       id: '123',
       authToken: '123',
       service: mockPayoutService
-    });
+    })
 
-    page.rootInstance.fetchData();
+    const page = await newSpecPage({
+      components: [PayoutsListCore, Table, PaginationMenu],
+      template: () =>
+        <payouts-list-core getPayouts={getPayouts} />
+    });
 
     await page.waitForChanges();
 
@@ -55,14 +51,8 @@ describe('payouts-list-core', () => {
 
     const page = await newSpecPage({
       components: [PayoutsListCore, Table, PaginationMenu],
-      html: '<payouts-list-core></payouts-list-core>',
+      template: () => <payouts-list-core getPayouts={getPayouts} />,
     });
-
-    page.rootInstance.componentWillLoad = () => { };
-
-    page.rootInstance.getPayouts = getPayouts;
-
-    page.rootInstance.fetchData();
 
     await page.waitForChanges();
 
@@ -80,20 +70,16 @@ describe('payouts-list-core', () => {
       fetchPayouts: jest.fn().mockResolvedValue(mockPayoutsResponse),
     };
 
-    const page = await newSpecPage({
-      components: [PayoutsListCore, Table, PaginationMenu],
-      html: '<payouts-list-core></payouts-list-core>',
-    });
-
-    page.rootInstance.componentWillLoad = () => { };
-
-    page.rootInstance.getPayouts = makeGetPayouts({
+    const getPayouts = makeGetPayouts({
       id: '123',
       authToken: '123',
       service: mockPayoutService
     });
 
-    page.rootInstance.fetchData();
+    const page = await newSpecPage({
+      components: [PayoutsListCore, Table, PaginationMenu],
+      template: () => <payouts-list-core getPayouts={getPayouts} />,
+    });
 
     await page.waitForChanges();
 
@@ -110,35 +96,53 @@ describe('payouts-list-core', () => {
     }
   });
 
-
   it('updates params and refetches data on pagination interaction', async () => {
     const mockPayoutService = {
       fetchPayouts: jest.fn().mockResolvedValue(mockPayoutsResponse),
     };
 
-    const page = await newSpecPage({
-      components: [PayoutsListCore, Table, PaginationMenu],
-      html: `<payouts-list-core></payouts-list-core>`,
-    });
-
-    page.rootInstance.componentWillLoad = () => { };
-
-    page.rootInstance.getPayouts = makeGetPayouts({
+    const getPayouts = makeGetPayouts({
       id: '123',
       authToken: '123',
       service: mockPayoutService
     });
 
-    page.rootInstance.fetchData();
+    const page = await newSpecPage({
+      components: [PayoutsListCore, Table, PaginationMenu],
+      template: () => <payouts-list-core getPayouts={getPayouts} />,
+    });
 
     await page.waitForChanges();
 
     page.rootInstance.handleClickNext('nextCursor');
     await page.waitForChanges();
 
-    // The mock function should be called 3 times: once for the initial load, twice for when mockGetPayouts is set and later after the pagination interaction
-    expect(mockPayoutService.fetchPayouts).toHaveBeenCalledTimes(3);
+    // The mock function should be called 2 times: once for the initial load, and after the pagination interaction
+    expect(mockPayoutService.fetchPayouts).toHaveBeenCalledTimes(2);
     const updatedParams = page.rootInstance.params;
     expect(updatedParams.after_cursor).toBe('nextCursor');
+  });
+
+  it('emits errorEvent when fetchPayouts fails', async () => {
+    const mockPayoutService = {
+      fetchPayouts: jest.fn().mockRejectedValue(new Error('Fetch error'))
+    };
+
+    const getPayouts = makeGetPayouts({
+      id: 'some-id',
+      authToken: 'some-auth-token',
+      service: mockPayoutService
+    });
+
+    const errorEventHandler = jest.fn();
+
+    const page = await newSpecPage({
+      components: [PayoutsListCore, Table, PaginationMenu],
+      template: () => <payouts-list-core getPayouts={getPayouts} onErrorEvent={errorEventHandler} />,
+    });
+
+    await page.waitForChanges();
+
+    expect(errorEventHandler).toHaveBeenCalled();
   });
 });

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
@@ -1,12 +1,14 @@
+import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
 import { PayoutsList } from "../payouts-list";
 import { PayoutsListCore } from "../payouts-list-core";
+import { PayoutService } from "../../../api/services/payout.service";
 
 describe('payouts-list', () => {
   it('renders an error message when accountId and authToken are not provided', async () => {
     const page = await newSpecPage({
       components: [PayoutsList, PayoutsListCore],
-      html: '<justifi-payouts-list></justifi-payouts-list>',
+      template: () => <justifi-payouts-list />,
     });
     await page.waitForChanges();
     expect(page.root).toMatchSnapshot();
@@ -15,7 +17,7 @@ describe('payouts-list', () => {
   it('renders an error message when accountId is not provided', async () => {
     const page = await newSpecPage({
       components: [PayoutsList, PayoutsListCore],
-      html: '<justifi-payouts-list auth-token="abc"></justifi-payouts-list>',
+      template: () => <justifi-payouts-list auth-token="abc" />,
     });
     await page.waitForChanges();
     expect(page.root).toMatchSnapshot();
@@ -24,9 +26,31 @@ describe('payouts-list', () => {
   it('renders an error message when authToken is not provided', async () => {
     const page = await newSpecPage({
       components: [PayoutsList, PayoutsListCore],
-      html: '<justifi-payouts-list account-id="abc"></justifi-payouts-list>',
+      template: () => <justifi-payouts-list account-id="abc" />,
     });
     await page.waitForChanges();
     expect(page.root).toMatchSnapshot();
+  });
+
+  it('emits tokenExpired when the token is expired', async () => {
+    const tokenExpired = jest.fn();
+
+    const fetchPayoutsMock = jest.spyOn(PayoutService.prototype, 'fetchPayouts' as keyof PayoutService);
+
+    fetchPayoutsMock.mockResolvedValue({
+      "error": {
+        "code": "not_authenticated",
+        "message": "Not Authenticated"
+      }
+    });
+
+    const page = await newSpecPage({
+      components: [PayoutsList, PayoutsListCore],
+      template: () => <justifi-payouts-list account-id="abc" auth-token="abc" onTokenExpired={tokenExpired} />,
+    });
+
+    await page.waitForChanges();
+
+    expect(tokenExpired).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
This adds the expiredToken event to the `justifi-payouts-lis` component.
It's emitted when `payouts-list-core` emits error-event with the error "Not Authenticated`.

Also added the `row-clicked` event to the Storybook actions tab

Links
-----
https://github.com/justifi-tech/web-component-library/issues/424

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests


Developer QA steps
--------------------

Expired token: `eyJraWQiOiJqdXN0aWZpLTQxNTczZmIyNjU0MDVmNDY0Y2UyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2F1dGguanVzdGlmaS1zdGFnaW5nLmNvbS8iLCJhenAiOiJ3Y3RfNVNKckZPWTI0YXJ5bUJRc2xTY3hvRiIsInN1YiI6IndjdF81U0pyRk9ZMjRhcnltQlFzbFNjeG9GQHNlc3Npb25zIiwiYXVkIjoiaHR0cHM6Ly9hcGkuanVzdGlmaS5haS92MSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyIsInBlcm1pc3Npb25zIjpbIndyaXRlOmFjY291bnQ6YWNjXzMzTzlESWdJZVMzOTFMSUxIRVIxZmYiLCJ3cml0ZTpidXNpbmVzczpiaXpfNm02VDlESUFtaW1WRlFZd2FoT2xQQiJdLCJleHAiOjE3MTA3OTc1MjksImlhdCI6MTcxMDc5MzkyOSwicGxhdGZvcm1fYWNjb3VudF9pZCI6ImFjY18zRklibDNUSWhUVUJoWGt3YVRYNTlaIn0.XTIyf8YsbqRKeSOPGj-LS-W2HC8D1QoXVOo7TMeRM6fE-TA2n1xc5naF1v57ddTvbg8MKqTBG0ssPsBvgk0db7WVtMNgM_WPSMje-0vRokJAH9aCyhYgKDA9IBhEAZ4ibbJiXMw11gwiB8Xi89952r-j01Qt-4kTVK2_pyeWvjnDdANM5w-nkgFdKffeIdc-C1P7Yvze3auiRZSR7PvGBJVgrO7U9L7T9EeyLer0xj26hlgIX-45AucSN3NVr7WZkjrX95ikC2fKhw5XG6U6yCD8MUFJ5wT4WO-yh4Ma7qdJg-ZK7gie1RiWF57ve4W8M3_uFOb8xrCz1AKqXjcugA`

[ ] - When trying to load payments list with an expired token, you should see in the actions tab on Storybook that an expiredToken event was logged.
[ ] - When loading payments list with a valid token, actions tab should be clear
[ ] - When clicked a row, the action should appear in actions tab


