### PR TITLE
Implement new identity form into business form

### DIFF
--- a/packages/webcomponents/src/api/Business.ts
+++ b/packages/webcomponents/src/api/Business.ts
@@ -1,3 +1,4 @@
+import { Identity } from './Identity';
 import { BankAccount } from './shared';
 
 export enum BusinessStructure {
@@ -76,66 +77,6 @@ export interface Document {
   presigned_url: string | null;
   status: string;
   updated_at: string;
-}
-
-export interface Identity {
-  address?: IAddress;
-  created_at?: string;
-  dob_day?: string;
-  dob_month?: string;
-  dob_year?: string;
-  documents?: Document[];
-  email?: string;
-  id?: string;
-  business_id?: string;
-  is_owner?: boolean;
-  metadata?: any;
-  name?: string;
-  phone?: string;
-  platform_account_id?: string;
-  ssn_last4?: string;
-  title?: string;
-  updated_at?: string;
-}
-
-export class Owner implements Identity {
-  public address?: Address;
-  public created_at?: string;
-  public dob_day?: string;
-  public dob_month?: string;
-  public dob_year?: string;
-  public documents?: Document[];
-  public email?: string;
-  public id?: string;
-  public business_id?: string;
-  public is_owner?: boolean;
-  public metadata?: any;
-  public name?: string;
-  public phone?: string;
-  public platform_account_id?: string;
-  public ssn_last4?: string;
-  public title?: string;
-  public updated_at?: string;
-
-  constructor(owner: Identity) {
-    this.address = { ...new Address(owner.address || {}) }
-    this.created_at = owner.created_at;
-    this.dob_day = owner.dob_day;
-    this.dob_month = owner.dob_month;
-    this.dob_year = owner.dob_year;
-    this.documents = owner.documents;
-    this.email = owner.email;
-    this.id = owner.id;
-    this.business_id = owner.business_id;
-    this.is_owner = owner.is_owner;
-    this.metadata = owner.metadata;
-    this.name = owner.name;
-    this.phone = owner.phone;
-    this.platform_account_id = owner.platform_account_id;
-    this.ssn_last4 = owner.ssn_last4;
-    this.title = owner.title;
-    this.updated_at = owner.updated_at;
-  }
 }
 
 export interface ProductCategories {

--- a/packages/webcomponents/src/api/Identity.ts
+++ b/packages/webcomponents/src/api/Identity.ts
@@ -1,0 +1,101 @@
+import { Address, IAddress } from "./Business";
+
+export interface Identity {
+  address?: IAddress;
+  created_at?: string;
+  dob_day?: string;
+  dob_month?: string;
+  dob_year?: string;
+  documents?: Document[];
+  email?: string;
+  id?: string;
+  business_id?: string;
+  is_owner?: boolean;
+  metadata?: any;
+  name?: string;
+  phone?: string;
+  platform_account_id?: string;
+  ssn_last4?: string;
+  title?: string;
+  updated_at?: string;
+}
+
+export class Owner implements Identity {
+  public address?: Address;
+  public created_at?: string;
+  public dob_day?: string;
+  public dob_month?: string;
+  public dob_year?: string;
+  public documents?: Document[];
+  public email?: string;
+  public id?: string;
+  public business_id?: string;
+  public is_owner?: boolean;
+  public metadata?: any;
+  public name?: string;
+  public phone?: string;
+  public platform_account_id?: string;
+  public ssn_last4?: string;
+  public title?: string;
+  public updated_at?: string;
+
+  constructor(owner: Identity) {
+    this.address = { ...new Address(owner.address || {}) }
+    this.created_at = owner.created_at;
+    this.dob_day = owner.dob_day;
+    this.dob_month = owner.dob_month;
+    this.dob_year = owner.dob_year;
+    this.documents = owner.documents;
+    this.email = owner.email;
+    this.id = owner.id;
+    this.business_id = owner.business_id;
+    this.is_owner = owner.is_owner;
+    this.metadata = owner.metadata;
+    this.name = owner.name;
+    this.phone = owner.phone;
+    this.platform_account_id = owner.platform_account_id;
+    this.ssn_last4 = owner.ssn_last4;
+    this.title = owner.title;
+    this.updated_at = owner.updated_at;
+  }
+}
+
+export class Representative implements Identity {
+  public address?: Address;
+  public created_at?: string;
+  public dob_day?: string;
+  public dob_month?: string;
+  public dob_year?: string;
+  public documents?: Document[];
+  public email?: string;
+  public id?: string;
+  public business_id?: string;
+  public is_owner?: boolean;
+  public metadata?: any;
+  public name?: string;
+  public phone?: string;
+  public platform_account_id?: string;
+  public ssn_last4?: string;
+  public title?: string;
+  public updated_at?: string;
+
+  constructor(representative: Identity) {
+    this.address = { ...new Address(representative.address || {}) }
+    this.created_at = representative.created_at;
+    this.dob_day = representative.dob_day;
+    this.dob_month = representative.dob_month;
+    this.dob_year = representative.dob_year;
+    this.documents = representative.documents;
+    this.email = representative.email;
+    this.id = representative.id;
+    this.business_id = representative.business_id;
+    this.is_owner = representative.is_owner;
+    this.metadata = representative.metadata;
+    this.name = representative.name;
+    this.phone = representative.phone;
+    this.platform_account_id = representative.platform_account_id;
+    this.ssn_last4 = representative.ssn_last4;
+    this.title = representative.title;
+    this.updated_at = representative.updated_at;
+  }
+}

--- a/packages/webcomponents/src/components/business-details/owner-details/owner-details.tsx
+++ b/packages/webcomponents/src/components/business-details/owner-details/owner-details.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 import { DetailSection, DetailItem } from '../../details/utils';
 import { formatMediumDate } from '../../../utils/utils';
-import { Identity } from '../../../api/Business';
+import { Identity } from '../../../api/Identity';
 
 /**
  *

--- a/packages/webcomponents/src/components/business-details/representative-details/representative-details.tsx
+++ b/packages/webcomponents/src/components/business-details/representative-details/representative-details.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 import { DetailSection, DetailItem } from '../../details/utils';
 import { formatMediumDate } from '../../../utils/utils';
-import { Identity } from '../../../api/Business';
+import { Identity } from '../../../api/Identity';
 
 /**
  *

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
@@ -19,7 +19,7 @@ export class BusinessFormStepped {
   @State() formLoading: boolean = false;
   @State() errorMessage: string = '';
   @State() currentStep: number = 0;
-  @State() totalSteps: number = 4;
+  @State() totalSteps: number = 5;
   @Event() clickEvent: EventEmitter<BusinessFormClickEvent>;
 
   get showErrors() {

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
@@ -30,43 +30,43 @@ export class BusinessFormStepped {
     return `entities/business/${this.businessId}`
   }
 
-  // private coreInfoRef: any;
-  // private legalAddressRef: any;
-  // private additionalQuestionsRef: any;
-  // private representativeRef: any;
+  private coreInfoRef: any;
+  private legalAddressRef: any;
+  private additionalQuestionsRef: any;
+  private representativeRef: any;
   private ownersRef: any;
   private refs = [];
 
   componentStepMapping = {
-    // 0: () => <justifi-business-core-info-form-step
-    //             businessId={this.businessId}
-    //             authToken={this.authToken}
-    //             ref={(el) => this.refs[0] = el}
-    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
-    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
-    //           />,
-    // 1: () => <justifi-legal-address-form-step
-    //             businessId={this.businessId}
-    //             authToken={this.authToken}
-    //             ref={(el) => this.refs[1] = el}
-    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
-    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
-    //           />,
-    // 2: () => <justifi-additional-questions-form-step
-    //             businessId={this.businessId}
-    //             authToken={this.authToken}
-    //             ref={(el) => this.refs[2] = el}
-    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
-    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
-    //           />,
-    // 3: () => <justifi-business-representative-form-step
-    //             businessId={this.businessId}
-    //             authToken={this.authToken}
-    //             ref={(el) => this.refs[3] = el}
-    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
-    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
-    //           />,
-    0: () => <justifi-business-owners-form-step
+    0: () => <justifi-business-core-info-form-step
+                businessId={this.businessId}
+                authToken={this.authToken}
+                ref={(el) => this.refs[0] = el}
+                onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+                onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+              />,
+    1: () => <justifi-legal-address-form-step
+                businessId={this.businessId}
+                authToken={this.authToken}
+                ref={(el) => this.refs[1] = el}
+                onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+                onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+              />,
+    2: () => <justifi-additional-questions-form-step
+                businessId={this.businessId}
+                authToken={this.authToken}
+                ref={(el) => this.refs[2] = el}
+                onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+                onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+              />,
+    3: () => <justifi-business-representative-form-step
+                businessId={this.businessId}
+                authToken={this.authToken}
+                ref={(el) => this.refs[3] = el}
+                onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+                onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+              />,
+    4: () => <justifi-business-owners-form-step
                 businessId={this.businessId}
                 authToken={this.authToken}
                 ref={(el) => this.refs[0] = el}
@@ -81,8 +81,7 @@ export class BusinessFormStepped {
     if (!this.authToken) console.error(missingAuthTokenMessage);
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
-    // this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef];
-    this.refs = [this.ownersRef]
+    this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef];
     this.totalSteps = Object.keys(this.componentStepMapping).length - 1;
   }
 

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
@@ -69,7 +69,7 @@ export class BusinessFormStepped {
     4: () => <justifi-business-owners-form-step
                 businessId={this.businessId}
                 authToken={this.authToken}
-                ref={(el) => this.refs[0] = el}
+                ref={(el) => this.refs[4] = el}
                 onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
                 onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
               />,

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-form-stepped.tsx
@@ -30,41 +30,49 @@ export class BusinessFormStepped {
     return `entities/business/${this.businessId}`
   }
 
-  private coreInfoRef: any;
-  private legalAddressRef: any;
-  private additionalQuestionsRef: any;
-  private representativeRef: any;
+  // private coreInfoRef: any;
+  // private legalAddressRef: any;
+  // private additionalQuestionsRef: any;
+  // private representativeRef: any;
+  private ownersRef: any;
   private refs = [];
 
   componentStepMapping = {
-    0: () => <justifi-business-core-info-form-step
+    // 0: () => <justifi-business-core-info-form-step
+    //             businessId={this.businessId}
+    //             authToken={this.authToken}
+    //             ref={(el) => this.refs[0] = el}
+    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+    //           />,
+    // 1: () => <justifi-legal-address-form-step
+    //             businessId={this.businessId}
+    //             authToken={this.authToken}
+    //             ref={(el) => this.refs[1] = el}
+    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+    //           />,
+    // 2: () => <justifi-additional-questions-form-step
+    //             businessId={this.businessId}
+    //             authToken={this.authToken}
+    //             ref={(el) => this.refs[2] = el}
+    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+    //           />,
+    // 3: () => <justifi-business-representative-form-step
+    //             businessId={this.businessId}
+    //             authToken={this.authToken}
+    //             ref={(el) => this.refs[3] = el}
+    //             onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
+    //             onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
+    //           />,
+    0: () => <justifi-business-owners-form-step
                 businessId={this.businessId}
                 authToken={this.authToken}
                 ref={(el) => this.refs[0] = el}
                 onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
                 onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
               />,
-    1: () => <justifi-legal-address-form-step
-                businessId={this.businessId}
-                authToken={this.authToken}
-                ref={(el) => this.refs[1] = el}
-                onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
-                onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
-              />,
-    2: () => <justifi-additional-questions-form-step
-                businessId={this.businessId}
-                authToken={this.authToken}
-                ref={(el) => this.refs[2] = el}
-                onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
-                onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
-              />,
-    3: () => <justifi-business-representative-form-step
-                businessId={this.businessId}
-                authToken={this.authToken}
-                ref={(el) => this.refs[3] = el}
-                onFormLoading={(e: CustomEvent) => this.handleFormLoading(e)}
-                onServerError={(e: CustomEvent) => this.handleServerErrors(e)}
-              />
   };
 
   componentWillLoad() {
@@ -73,7 +81,8 @@ export class BusinessFormStepped {
     if (!this.authToken) console.error(missingAuthTokenMessage);
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
-    this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef];
+    // this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef];
+    this.refs = [this.ownersRef]
     this.totalSteps = Object.keys(this.componentStepMapping).length - 1;
   }
 

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
@@ -1,8 +1,9 @@
-import { Component, Host, h, Prop, State, Event, EventEmitter } from '@stencil/core';
+import { Component, Host, h, Prop, State, Event, EventEmitter, Method } from '@stencil/core';
 import { IBusiness } from '../../../../api/Business';
 import { BusinessFormServerErrorEvent, BusinessFormServerErrors } from '../../utils/business-form-types';
 import { Api, IApiResponse } from '../../../../api';
 import { config } from '../../../../../config';
+import { Owner } from '../../../../api/Identity';
 
 /**
  * @exportedPart label: Label for inputs
@@ -17,7 +18,7 @@ import { config } from '../../../../../config';
 export class BusinessOwnersFormStep {
   @Prop() authToken: string;
   @Prop() businessId: string;
-  @State() ownerIds: string[] = [];
+  @State() owners: Owner[] = [];
   @Event() formLoading: EventEmitter<boolean>;
   @Event() serverError: EventEmitter<BusinessFormServerErrorEvent>;
 
@@ -31,13 +32,20 @@ export class BusinessOwnersFormStep {
     this.formLoading.emit(true);
     try {
       const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
-      this.ownerIds = response.data.owners.map((owner) => owner.id);
+      this.owners = response.data.owners;
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
     } finally {
       this.formLoading.emit(false);
     }
   }
+
+
+  private ownerRef1: any;
+  private ownerRef2: any;
+  private ownerRef3: any;
+  // private ownerRef4: any;
+  private refs = [];
 
   componentWillLoad() {
     const missingAuthTokenMessage = 'Warning: Missing auth-token. The form will not be functional without it.';
@@ -47,6 +55,7 @@ export class BusinessOwnersFormStep {
 
     this.api = Api(this.authToken, config.proxyApiOrigin);
     this.fetchData();
+    this.refs = [this.ownerRef1, this.ownerRef2, this.ownerRef3];
   }
 
   // addOwner(event: MouseEvent): void {
@@ -66,19 +75,40 @@ export class BusinessOwnersFormStep {
   //   });
   // }
 
+  private submitAll = async () => {
+    const refSubmissions = this.refs.map(ref => ref.submit());
+    Promise.all(refSubmissions)
+  };
+
+
+  @Method()
+  async validateAndSubmit({ onSuccess }) {
+    const refValidations = this.refs.map(ref => ref.validate());
+    Promise.all(refValidations)
+      .then(values => {
+        if (values.every(value => value === true)) {
+          this.submitAll();
+          onSuccess();
+        }
+      });
+  };
+
   render() {
       
     return (
       <Host exportparts="label,input,input-invalid">
-       {this.ownerIds.map((ownerId) => {
-          return (
-            <justifi-owner-form 
-              authToken={this.authToken} 
-              businessId={this.businessId} 
-              ownerId={ownerId}
-            />
-          );
-       })}
+        <div class='col-12'>
+          {this.owners.map((owner, index) => {
+            return (
+              <justifi-owner-form 
+                authToken={this.authToken} 
+                businessId={this.businessId} 
+                ownerId={owner.id}
+                ref={(ref) => this.refs[index] = ref}
+              />
+            );
+          })}
+        </div>
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
@@ -19,8 +19,15 @@ export class BusinessOwnersFormStep {
   @Prop() authToken: string;
   @Prop() businessId: string;
   @State() owners: Owner[] = [];
+  @State() refs = [];
   @Event() formLoading: EventEmitter<boolean>;
   @Event() serverError: EventEmitter<BusinessFormServerErrorEvent>;
+
+  constructor() {
+    this.removeOwner = this.removeOwner.bind(this);
+    this.submitAll = this.submitAll.bind(this);
+    this.initializeRefs = this.initializeRefs.bind(this);
+  }
 
   private api: any;
 
@@ -37,15 +44,24 @@ export class BusinessOwnersFormStep {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
     } finally {
       this.formLoading.emit(false);
+      // this.initializeRefs();
     }
   }
 
+  
+  
+  private initializeRefs() {
+    console.log('fired')
+    const ownerRefs = [this.ownerRef1, this.ownerRef2, this.ownerRef3, this.ownerRef4];
+    this.refs = ownerRefs.slice(this.owners.length);
+    console.log('this.refs', this.refs);
+    console.log('this.owners', this.owners);
+  }
 
   private ownerRef1: any;
   private ownerRef2: any;
   private ownerRef3: any;
-  // private ownerRef4: any;
-  private refs = [];
+  private ownerRef4: any;
 
   componentWillLoad() {
     const missingAuthTokenMessage = 'Warning: Missing auth-token. The form will not be functional without it.';
@@ -55,8 +71,12 @@ export class BusinessOwnersFormStep {
 
     this.api = Api(this.authToken, config.proxyApiOrigin);
     this.fetchData();
-    this.refs = [this.ownerRef1, this.ownerRef2, this.ownerRef3];
   }
+
+  // @Watch('owners')
+  // watchOwners() {
+  //   this.initializeRefs();
+  // }
 
   // addOwner(event: MouseEvent): void {
   //   event.preventDefault();
@@ -67,13 +87,15 @@ export class BusinessOwnersFormStep {
   //   });
   // }
 
-  // removeOwner(event: MouseEvent, index: number): void {
-  //   event.preventDefault();
-  //   this.formController.setValues({
-  //     ...this.formController.values.getValue(),
-  //     owners: this.owners.filter((_owner, i) => i !== index),
-  //   });
-  // }
+  private removeOwner = (id: string) => {
+    const ownerIndex = this.owners.findIndex(owner => owner.id === id);
+    if (ownerIndex !== -1) {
+      this.owners = this.owners.filter((_, index) => index !== ownerIndex);
+      this.refs = this.refs.filter((_, index) => index !== ownerIndex);
+    }
+    console.log('this.owners', this.owners);
+    console.log('this.refs', this.refs);
+  };
 
   private submitAll = async () => {
     const refSubmissions = this.refs.map(ref => ref.submit());
@@ -99,12 +121,15 @@ export class BusinessOwnersFormStep {
       <Host exportparts="label,input,input-invalid">
         <div class='col-12'>
           {this.owners.map((owner, index) => {
+            console.log(owner, index)
             return (
               <justifi-owner-form 
+                key={owner.id}
                 authToken={this.authToken} 
                 businessId={this.businessId} 
                 ownerId={owner.id}
-                ref={(ref) => this.refs[index] = ref}
+                removeOwner={this.removeOwner}
+                // ref={(ref) => this.refs[index] = ref}
               />
             );
           })}

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
@@ -57,7 +57,7 @@ export class BusinessOwnersFormStep {
       this.refs[ownerIndex] = ref;
     }
   }
-
+  
   private fetchData = async () => {
     this.formLoading.emit(true);
     try {
@@ -69,6 +69,7 @@ export class BusinessOwnersFormStep {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
     } finally {
       this.formLoading.emit(false);
+      this.manageRefs();
     }
   }
 

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
@@ -1,20 +1,8 @@
-import { Component, Host, h, Prop, State } from '@stencil/core';
-import { FormController } from '../../../form/form';
-import { PHONE_MASKS } from '../../../../utils/form-input-masks';
-
-class BusinessOwner {
-  name: string = '';
-  title: string = '';
-  email: string = '';
-  phone: string = '';
-  dob_day: string = '';
-  dob_month: string = '';
-  dob_year: string = '';
-  identification_number: string = '';
-  is_owner: boolean = true;
-  metadata: any = {};
-  address: any = {};
-}
+import { Component, Host, h, Prop, State, Event, EventEmitter } from '@stencil/core';
+import { IBusiness } from '../../../../api/Business';
+import { BusinessFormServerErrorEvent, BusinessFormServerErrors } from '../../utils/business-form-types';
+import { Api, IApiResponse } from '../../../../api';
+import { config } from '../../../../../config';
 
 /**
  * @exportedPart label: Label for inputs
@@ -27,294 +15,70 @@ class BusinessOwner {
   shadow: false,
 })
 export class BusinessOwnersFormStep {
-  @Prop() formController: FormController;
-  @State() errors: any[] = [];
-  @State() owners: BusinessOwner[] = [];
+  @Prop() authToken: string;
+  @Prop() businessId: string;
+  @State() ownerIds: string[] = [];
+  @Event() formLoading: EventEmitter<boolean>;
+  @Event() serverError: EventEmitter<BusinessFormServerErrorEvent>;
 
-  get disabledState() {
-    return !!this.formController.getInitialValues().owners && !!this.formController.getInitialValues().owners.length;
+  private api: any;
+
+  get businessEndpoint() {
+    return `entities/business/${this.businessId}`
   }
 
-  constructor() {
-    this.inputHandler = this.inputHandler.bind(this);
-    this.addOwner = this.addOwner.bind(this);
-    this.removeOwner = this.removeOwner.bind(this);
+  private fetchData = async () => {
+    this.formLoading.emit(true);
+    try {
+      const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
+      this.ownerIds = response.data.owners.map((owner) => owner.id);
+    } catch (error) {
+      this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
+    } finally {
+      this.formLoading.emit(false);
+    }
   }
 
-  componentDidLoad() {
-    this.formController.errors.subscribe(errors => {
-      this.errors = errors?.owners || [];
-    });
-    this.formController.values.subscribe(
-      values => (this.owners = values?.owners || []),
-    );
+  componentWillLoad() {
+    const missingAuthTokenMessage = 'Warning: Missing auth-token. The form will not be functional without it.';
+    const missingBusinessIdMessage = 'Warning: Missing business-id. The form requires an existing business-id to function.';
+    if (!this.authToken) console.error(missingAuthTokenMessage);
+    if (!this.businessId) console.error(missingBusinessIdMessage);
+
+    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.fetchData();
   }
 
-  inputHandler(name: string, value: string, index: number): void {
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      owners: this.owners.map((owner, i) => {
-        if (i === index) {
-          return {
-            ...owner,
-            [name]: value,
-          };
-        }
-        return owner;
-      }),
-    });
-  }
+  // addOwner(event: MouseEvent): void {
+  //   event.preventDefault();
 
-  addressInputHandler(name: string, value: string, index: number): void {
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      owners: this.owners.map((owner, i) => {
-        if (i === index) {
-          return {
-            ...owner,
-            address: {
-              ...owner.address,
-              [name]: value,
-            },
-          };
-        }
-        return owner;
-      }),
-    });
-  }
+  //   this.formController.setValues({
+  //     ...this.formController.values.getValue(),
+  //     owners: [...this.owners, { ...new BusinessOwner() }],
+  //   });
+  // }
 
-  addOwner(event: MouseEvent): void {
-    event.preventDefault();
-
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      owners: [...this.owners, { ...new BusinessOwner() }],
-    });
-  }
-
-  removeOwner(event: MouseEvent, index: number): void {
-    event.preventDefault();
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      owners: this.owners.filter((_owner, i) => i !== index),
-    });
-  }
+  // removeOwner(event: MouseEvent, index: number): void {
+  //   event.preventDefault();
+  //   this.formController.setValues({
+  //     ...this.formController.values.getValue(),
+  //     owners: this.owners.filter((_owner, i) => i !== index),
+  //   });
+  // }
 
   render() {
-    const ownersDefaultValue =
-      this.formController.values.getValue().owners || [];
       
     return (
       <Host exportparts="label,input,input-invalid">
-        <fieldset>
-          <legend>Owners</legend>
-          <hr />
-          {this.owners.map((_owner: BusinessOwner, index: number) => {
-            return (
-              <div class="row gx-2 gy-2 mb-4">
-                <div class="col-12">
-                  <div class="row mb-3">
-                    <div class="col-12 col-md-6">
-                      <form-control-text
-                        name="name"
-                        label="Full Name"
-                        defaultValue={ownersDefaultValue[index]?.name}
-                        error={this.errors[index]?.name}
-                        inputHandler={(name, value) =>
-                          this.inputHandler(name, value, index)
-                        }
-                        disabled={this.disabledState}
-                      />
-                    </div>
-                    <div class="col-12 col-md-6">
-                      <form-control-text
-                        name="title"
-                        label="Title"
-                        defaultValue={ownersDefaultValue[index]?.title}
-                        error={this.errors[index]?.title}
-                        inputHandler={(name, value) =>
-                          this.inputHandler(name, value, index)
-                        }
-                        disabled={this.disabledState}
-                      />
-                    </div>
-                  </div>
-
-                  <div class="row mb-3">
-                    <div class="col-12 col-md-6">
-                      <form-control-text
-                        name="email"
-                        label="Email"
-                        defaultValue={ownersDefaultValue[index]?.email}
-                        error={this.errors[index]?.email}
-                        inputHandler={(name, value) =>
-                          this.inputHandler(name, value, index)
-                        }
-                        disabled={this.disabledState}
-                      />
-                    </div>
-                    <div class="col-12 col-md-6">
-                      <form-control-number-masked
-                        name="phone"
-                        label="Phone"
-                        defaultValue={ownersDefaultValue[index]?.phone}
-                        error={this.errors[index]?.phone}
-                        inputHandler={(name, value) =>
-                          this.inputHandler(name, value, index)
-                        }
-                        mask={PHONE_MASKS.US}
-                        disabled={this.disabledState}
-                      />
-                    </div>
-                  </div>
-
-                  <div class="row mb-3">
-                    <div class="col-12 col-md-4">
-                      <form-control-datepart
-                        name="dob_day"
-                        label="Date of Birth - Day"
-                        defaultValue={ownersDefaultValue[index]?.dob_day}
-                        error={this.errors[index]?.dob_day}
-                        inputHandler={(name, value) =>
-                          this.inputHandler(name, value, index)
-                        }
-                        type="day"
-                        disabled={this.disabledState}
-                      />
-                    </div>
-                    <div class="col-12 col-md-4">
-                      <form-control-datepart
-                        name="dob_month"
-                        label="Date of Birth - Month"
-                        defaultValue={ownersDefaultValue[index]?.dob_month}
-                        error={this.errors[index]?.dob_month}
-                        inputHandler={(name, value) =>
-                          this.inputHandler(name, value, index)
-                        }
-                        type="month"
-                        disabled={this.disabledState}
-                      />
-                    </div>
-                    <div class="col-12 col-md-4">
-                      <form-control-datepart
-                        name="dob_year"
-                        label="Date of Birth - Year"
-                        defaultValue={ownersDefaultValue[index]?.dob_year}
-                        error={this.errors[index]?.dob_year}
-                        inputHandler={(name, value) =>
-                          this.inputHandler(name, value, index)
-                        }
-                        type="year"
-                        disabled={this.disabledState}
-                      />
-                    </div>
-                  </div>
-
-                  <div class="mb-3">
-                    <form-control-number
-                      name="identification_number"
-                      label="Identification Number"
-                      defaultValue={
-                        ownersDefaultValue[index]?.identification_number
-                      }
-                      error={this.errors[index]?.identification_number}
-                      inputHandler={(name, value) =>
-                        this.inputHandler(name, value, index)
-                      }
-                      disabled={this.disabledState}
-                    />
-                  </div>
-
-                  <div class="grid gap-3">
-                    <legend class="mb-3">Owner Address:</legend>
-
-                    <div class="row mb-3">
-                      <div class="col-12 col-md-6">
-                        <form-control-text
-                          name="line1"
-                          label="Street Address"
-                          defaultValue={
-                            ownersDefaultValue[index]?.address?.line1
-                          }
-                          error={this.errors[index]?.address?.line1}
-                          inputHandler={(name, value) =>
-                            this.addressInputHandler(name, value, index)
-                          }
-                          disabled={this.disabledState}
-                        />
-                      </div>
-                      <div class="col-12 col-md-6">
-                        <form-control-text
-                          name="city"
-                          label="City"
-                          defaultValue={
-                            ownersDefaultValue[index]?.address?.city
-                          }
-                          error={this.errors[index]?.address?.city}
-                          inputHandler={(name, value) =>
-                            this.addressInputHandler(name, value, index)
-                          }
-                          disabled={this.disabledState}
-                        />
-                      </div>
-                    </div>
-
-                    <div class="row mb-3">
-                      <div class="col-12 col-md-6">
-                        <form-control-text
-                          name="state"
-                          label="State"
-                          defaultValue={
-                            ownersDefaultValue[index]?.address?.state
-                          }
-                          error={this.errors[index]?.address?.state}
-                          inputHandler={(name, value) =>
-                            this.addressInputHandler(name, value, index)
-                          }
-                          disabled={this.disabledState}
-                        />
-                      </div>
-                      <div class="col-12 col-md-6">
-                        <form-control-number
-                          name="postal_code"
-                          label="Postal Code"
-                          defaultValue={
-                            ownersDefaultValue[index]?.address?.postal_code
-                          }
-                          error={this.errors[index]?.address?.postal_code}
-                          inputHandler={(name, value) =>
-                            this.addressInputHandler(name, value, index)
-                          }
-                          disabled={this.disabledState}
-                        />
-                      </div>
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    class="btn btn-outline-danger"
-                    onClick={event => this.removeOwner(event, index)}
-                    disabled={this.disabledState}
-                  >
-                    Remove owner
-                  </button>
-                </div>
-              </div>
-            )
-          })}
-          <div class="row gy-3">
-            <div class="col-12">
-              <button
-                type="button"
-                class="btn btn-outline-primary"
-                onClick={event => this.addOwner(event)}
-                disabled={this.disabledState}
-              >
-                Add an owner
-              </button>
-            </div>
-          </div>
-        </fieldset>
+       {this.ownerIds.map((ownerId) => {
+          return (
+            <justifi-owner-form 
+              authToken={this.authToken} 
+              businessId={this.businessId} 
+              ownerId={ownerId}
+            />
+          );
+       })}
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-owners/business-owners-form-step.tsx
@@ -18,7 +18,7 @@ import { Owner } from '../../../../api/Identity';
 export class BusinessOwnersFormStep {
   @Prop() authToken: string;
   @Prop() businessId: string;
-  @State() owners: Owner[] = [{ ...new Owner({}) }];
+  @State() owners: Owner[] = [];
   @State() newFormOpen: boolean;
   @State() refs = [];
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
@@ -33,10 +33,6 @@ export class BusinessOwnersFormStep {
 
   get showAddOwnerButton() {
     return this.owners.length < 4 && !this.newFormOpen;
-  }
-
-  get showRemoveOwnerButton() {
-    return this.owners.length > 1;
   }
 
   private manageRefs() {
@@ -64,6 +60,8 @@ export class BusinessOwnersFormStep {
       const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
       if (response.data.owners.length) {
         this.owners = response.data.owners.map(owner => owner);
+      } else {
+        this.addOwnerForm();
       }
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
@@ -126,6 +124,7 @@ export class BusinessOwnersFormStep {
 
   private removeOwnerForm = (id: string) => {
     this.owners = this.owners.filter(owner => owner.id !== id);
+    this.newFormOpen ? this.newFormOpen = false : null;
   };
 
   @Watch('owners')
@@ -158,7 +157,8 @@ export class BusinessOwnersFormStep {
                 businessId={this.businessId} 
                 ownerId={owner.id}
                 removeOwner={this.removeOwnerForm}
-                showRemoveOwnerButton={this.showRemoveOwnerButton}
+                newFormOpen={this.newFormOpen}
+                ownersLength={this.owners.length}
                 onSubmitted={(e: CustomEvent) => this.handleOwnerSubmit(e)}
                 onFormLoading={(e: CustomEvent) => this.formLoading.emit(e.detail)}
                 ref={(ref) => {this.matchRef(ref, owner.id)}}

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/legal-address-form/legal-address-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/legal-address-form/legal-address-form-step.tsx
@@ -36,7 +36,7 @@ export class LegalAddressFormStep {
     this.formLoading.emit(true);
     try {
       const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
-      this.legal_address = new Address(response.data.legal_address);
+      this.legal_address = new Address(response.data.legal_address || {});
       this.formController.setInitialValues({ ...this.legal_address });
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.scss
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.scss
@@ -1,6 +1,7 @@
 @import 'reboot';
 @import 'grid';
 @import 'buttons';
+@import 'bootstrap-utilities';
 
 :host {
   @include host-base-styles;

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -157,116 +157,116 @@ export class BusinessOwnerForm {
         <form onSubmit={this.validateAndSubmit}>
           <fieldset>
             <legend>{this.formTitle}</legend>
-            <div class='row gx-2 gy-2 mb-4'>
-                  <div class="col-12 col-md-6">
-                    <form-control-text
-                      name="name"
-                      label="Full Name"
-                      defaultValue={ownerDefaultValue?.name}
-                      error={this.errors.name}
-                      inputHandler={this.inputHandler}
-                    />
-                  </div>
-                  <div class="col-12 col-md-4">
-                    <form-control-select
-                      name="title"
-                      label="Prefix"
-                      defaultValue={ownerDefaultValue?.title}
-                      options={[
-                        { label: 'Select Prefix', value: '' },
-                        { label: 'Mrs.', value: 'Mrs.' },
-                      ]}
-                      error={this.errors.title}
-                      inputHandler={this.inputHandler}
-                    />
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <form-control-text
-                      name="email"
-                      label="Email Address"
-                      defaultValue={ownerDefaultValue?.email}
-                      error={this.errors.email}
-                      inputHandler={this.inputHandler}
-                    />
-                  </div>
-                  <div class="col-12 col-md-6">
-                    <form-control-number-masked
-                      name="phone"
-                      label="Phone Number"
-                      defaultValue={ownerDefaultValue?.phone}
-                      error={this.errors.phone}
-                      inputHandler={this.inputHandler}
-                      mask={PHONE_MASKS.US}
-                    />
-                  </div>
-                  <div class="col-12">
-                    <label part="label" class="form-label">
-                      Birth Date
-                    </label>
-                  </div>
-                  <div class="col-12 col-md-4">
-                    <form-control-datepart
-                      name="dob_day"
-                      label="Day"
-                      defaultValue={ownerDefaultValue?.dob_day}
-                      error={this.errors.dob_day}
-                      inputHandler={this.inputHandler}
-                      type="day"
-                    />
-                  </div>
-                  <div class="col-12 col-md-4">
-                    <form-control-datepart
-                      name="dob_month"
-                      label="Month"
-                      defaultValue={ownerDefaultValue?.dob_month}
-                      error={this.errors.dob_month}
-                      inputHandler={this.inputHandler}
-                      type="month"
-                    />
-                  </div>
-                  <div class="col-12 col-md-4">
-                    <form-control-datepart
-                      name="dob_year"
-                      label="Year"
-                      defaultValue={ownerDefaultValue?.dob_year}
-                      error={this.errors.dob_year}
-                      inputHandler={this.inputHandler}
-                      type="year"
-                    />
-                  </div>
-                  <div class="col-12">
-                    <form-control-number
-                      name="identification_number"
-                      label="EIN/SSN"
-                      defaultValue={ownerDefaultValue?.identification_number}
-                      error={this.errors.identification_number}
-                      inputHandler={this.inputHandler}
-                    />
-                  </div>
-                  <div class="col-12">
-                    <justifi-business-address-form
-                      errors={this.errors.address}
-                      defaultValues={ownerDefaultValue?.address}
-                      handleFormUpdate={values => this.onAddressFormUpdate(values)}
-                    />
-                  </div>
-                  <div class="d-flex gap-2">
-                    <button
-                      type="submit"
-                      class={`btn btn-primary jfi-submit-button${this.isLoading ? ' jfi-submit-button-loading' : ''}`}
-                      disabled={this.isLoading}>
-                      {this.isLoading ? LoadingSpinner() : this.submitButtonText}
-                    </button>
-                  {this.showRemoveOwnerButton &&
-                    <button
-                      type="button"
-                      class="btn btn-outline-danger"
-                      onClick={() => this.removeOwner(this.ownerId)}>
-                      Remove owner
-                    </button>}
-                  </div>
-                </div>
-                <hr />
+            <div class='row gy-3'>
+              <div class="col-12 col-md-6">
+                <form-control-text
+                  name="name"
+                  label="Full Name"
+                  defaultValue={ownerDefaultValue?.name}
+                  error={this.errors.name}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-4">
+                <form-control-select
+                  name="title"
+                  label="Prefix"
+                  defaultValue={ownerDefaultValue?.title}
+                  options={[
+                    { label: 'Select Prefix', value: '' },
+                    { label: 'Mrs.', value: 'Mrs.' },
+                  ]}
+                  error={this.errors.title}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-6">
+                <form-control-text
+                  name="email"
+                  label="Email Address"
+                  defaultValue={ownerDefaultValue?.email}
+                  error={this.errors.email}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-6">
+                <form-control-number-masked
+                  name="phone"
+                  label="Phone Number"
+                  defaultValue={ownerDefaultValue?.phone}
+                  error={this.errors.phone}
+                  inputHandler={this.inputHandler}
+                  mask={PHONE_MASKS.US}
+                />
+              </div>
+              <div class="col-12">
+                <label part="label" class="form-label">
+                  Birth Date
+                </label>
+              </div>
+              <div class="col-12 col-md-4">
+                <form-control-datepart
+                  name="dob_day"
+                  label="Day"
+                  defaultValue={ownerDefaultValue?.dob_day}
+                  error={this.errors.dob_day}
+                  inputHandler={this.inputHandler}
+                  type="day"
+                />
+              </div>
+              <div class="col-12 col-md-4">
+                <form-control-datepart
+                  name="dob_month"
+                  label="Month"
+                  defaultValue={ownerDefaultValue?.dob_month}
+                  error={this.errors.dob_month}
+                  inputHandler={this.inputHandler}
+                  type="month"
+                />
+              </div>
+              <div class="col-12 col-md-4">
+                <form-control-datepart
+                  name="dob_year"
+                  label="Year"
+                  defaultValue={ownerDefaultValue?.dob_year}
+                  error={this.errors.dob_year}
+                  inputHandler={this.inputHandler}
+                  type="year"
+                />
+              </div>
+              <div class="col-12">
+                <form-control-number
+                  name="identification_number"
+                  label="EIN/SSN"
+                  defaultValue={ownerDefaultValue?.identification_number}
+                  error={this.errors.identification_number}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12">
+                <justifi-business-address-form
+                  errors={this.errors.address}
+                  defaultValues={ownerDefaultValue?.address}
+                  handleFormUpdate={values => this.onAddressFormUpdate(values)}
+                />
+              </div>
+              <div class="container d-flex gap-2">
+                <button
+                  type="submit"
+                  class={`btn btn-primary jfi-submit-button${this.isLoading ? ' jfi-submit-button-loading' : ''}`}
+                  disabled={this.isLoading}>
+                  {this.isLoading ? LoadingSpinner() : this.submitButtonText}
+                </button>
+                {this.showRemoveOwnerButton &&
+                  <button
+                    type="button"
+                    class="btn btn-danger"
+                    onClick={() => this.removeOwner(this.ownerId)}>
+                    Remove owner
+                  </button>}
+              </div>
+            </div>
+            <hr />
           </fieldset>
         </form>
       </Host>

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -18,6 +18,7 @@ export class BusinessOwnerForm {
   @Prop() authToken: string;
   @Prop() ownerId?: string;
   @Prop() businessId?: string;
+  @Prop() removeOwner: (id: string) => void;
   @State() isLoading: boolean = false;
   @State() formController: FormController;
   @State() errors: any = {};
@@ -241,6 +242,12 @@ export class BusinessOwnerForm {
                       class={`btn btn-primary jfi-submit-button${this.isLoading ? ' jfi-submit-button-loading' : ''}`}
                       disabled={this.isLoading}>
                       {this.isLoading ? LoadingSpinner() : this.submitButtonText}
+                    </button>
+                    <button
+                      type="button"
+                      class="btn btn-outline-danger"
+                      onClick={() => this.removeOwner(this.ownerId)}>
+                      Remove owner
                     </button>
                   </div>
                 </div>

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -1,4 +1,4 @@
-import { Component, Host, h, Prop, State, Event, EventEmitter } from '@stencil/core';
+import { Component, Host, h, Prop, State, Event, EventEmitter, Method } from '@stencil/core';
 import { FormController } from '../../form/form';
 import { PHONE_MASKS } from '../../../utils/form-input-masks';
 import { Api, IApiResponse } from '../../../api';
@@ -21,7 +21,7 @@ export class BusinessOwnerForm {
   @State() isLoading: boolean = false;
   @State() formController: FormController;
   @State() errors: any = {};
-  @State() owner: any = {};
+  @State() owner: Owner = {};
   @Event({ bubbles: true }) submitted: EventEmitter<OwnerFormSubmitEvent>;
   @Event() serverError: EventEmitter<OwnerFormServerErrorEvent>;
 
@@ -116,10 +116,20 @@ export class BusinessOwnerForm {
       }
     });
   }
-  
-  private validateAndSubmit(event: any) {
+
+  @Method()
+  async validate() {
+    return this.formController.validate();
+  }
+
+  @Method()
+  async submit() {
+    this.sendData();
+  }
+
+  async validateAndSubmit(event: any) {
     event.preventDefault();
-    this.formController.validateAndSubmit(this.sendData);
+    return this.formController.validateAndSubmit(this.sendData);
   }
 
   render() {
@@ -132,109 +142,109 @@ export class BusinessOwnerForm {
         <form onSubmit={this.validateAndSubmit}>
           <fieldset>
             <legend>{this.formTitle}</legend>
-            <hr />
-            <div class="row gy-3">
-              <div class="col-12 col-md-8">
-                <form-control-text
-                  name="name"
-                  label="Full Name"
-                  defaultValue={ownerDefaultValue?.name}
-                  error={this.errors.name}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-4">
-                <form-control-select
-                  name="title"
-                  label="Prefix"
-                  defaultValue={ownerDefaultValue?.title}
-                  options={[
-                    { label: 'Select Prefix', value: '' },
-                    { label: 'Mrs.', value: 'Mrs.' },
-                  ]}
-                  error={this.errors.title}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-6">
-                <form-control-text
-                  name="email"
-                  label="Email Address"
-                  defaultValue={ownerDefaultValue?.email}
-                  error={this.errors.email}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-6">
-                <form-control-number-masked
-                  name="phone"
-                  label="Phone Number"
-                  defaultValue={ownerDefaultValue?.phone}
-                  error={this.errors.phone}
-                  inputHandler={this.inputHandler}
-                  mask={PHONE_MASKS.US}
-                />
-              </div>
-              <div class="col-12">
-                <label part="label" class="form-label">
-                  Birth Date
-                </label>
-              </div>
-              <div class="col-12 col-md-4">
-                <form-control-datepart
-                  name="dob_day"
-                  label="Day"
-                  defaultValue={ownerDefaultValue?.dob_day}
-                  error={this.errors.dob_day}
-                  inputHandler={this.inputHandler}
-                  type="day"
-                />
-              </div>
-              <div class="col-12 col-md-4">
-                <form-control-datepart
-                  name="dob_month"
-                  label="Month"
-                  defaultValue={ownerDefaultValue?.dob_month}
-                  error={this.errors.dob_month}
-                  inputHandler={this.inputHandler}
-                  type="month"
-                />
-              </div>
-              <div class="col-12 col-md-4">
-                <form-control-datepart
-                  name="dob_year"
-                  label="Year"
-                  defaultValue={ownerDefaultValue?.dob_year}
-                  error={this.errors.dob_year}
-                  inputHandler={this.inputHandler}
-                  type="year"
-                />
-              </div>
-              <div class="col-12">
-                <form-control-number
-                  name="identification_number"
-                  label="EIN/SSN"
-                  defaultValue={ownerDefaultValue?.identification_number}
-                  error={this.errors.identification_number}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12">
-                <justifi-business-address-form
-                  errors={this.errors.address}
-                  defaultValues={ownerDefaultValue?.address}
-                  handleFormUpdate={values => this.onAddressFormUpdate(values)}
-                />
-              </div>
-              <div class="col-12 d-flex flex-row-reverse">
-                <button
-                  type="submit"
-                  class={`btn btn-primary jfi-submit-button${this.isLoading ? ' jfi-submit-button-loading' : ''}`}
-                  disabled={this.isLoading}>
-                  {this.isLoading ? LoadingSpinner() : this.submitButtonText}
-                </button>
-              </div>
-            </div>
+            <div class='row gx-2 gy-2 mb-4'>
+                  <div class="col-12 col-md-6">
+                    <form-control-text
+                      name="name"
+                      label="Full Name"
+                      defaultValue={ownerDefaultValue?.name}
+                      error={this.errors.name}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                  <div class="col-12 col-md-4">
+                    <form-control-select
+                      name="title"
+                      label="Prefix"
+                      defaultValue={ownerDefaultValue?.title}
+                      options={[
+                        { label: 'Select Prefix', value: '' },
+                        { label: 'Mrs.', value: 'Mrs.' },
+                      ]}
+                      error={this.errors.title}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <form-control-text
+                      name="email"
+                      label="Email Address"
+                      defaultValue={ownerDefaultValue?.email}
+                      error={this.errors.email}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                  <div class="col-12 col-md-6">
+                    <form-control-number-masked
+                      name="phone"
+                      label="Phone Number"
+                      defaultValue={ownerDefaultValue?.phone}
+                      error={this.errors.phone}
+                      inputHandler={this.inputHandler}
+                      mask={PHONE_MASKS.US}
+                    />
+                  </div>
+                  <div class="col-12">
+                    <label part="label" class="form-label">
+                      Birth Date
+                    </label>
+                  </div>
+                  <div class="col-12 col-md-4">
+                    <form-control-datepart
+                      name="dob_day"
+                      label="Day"
+                      defaultValue={ownerDefaultValue?.dob_day}
+                      error={this.errors.dob_day}
+                      inputHandler={this.inputHandler}
+                      type="day"
+                    />
+                  </div>
+                  <div class="col-12 col-md-4">
+                    <form-control-datepart
+                      name="dob_month"
+                      label="Month"
+                      defaultValue={ownerDefaultValue?.dob_month}
+                      error={this.errors.dob_month}
+                      inputHandler={this.inputHandler}
+                      type="month"
+                    />
+                  </div>
+                  <div class="col-12 col-md-4">
+                    <form-control-datepart
+                      name="dob_year"
+                      label="Year"
+                      defaultValue={ownerDefaultValue?.dob_year}
+                      error={this.errors.dob_year}
+                      inputHandler={this.inputHandler}
+                      type="year"
+                    />
+                  </div>
+                  <div class="col-12">
+                    <form-control-number
+                      name="identification_number"
+                      label="EIN/SSN"
+                      defaultValue={ownerDefaultValue?.identification_number}
+                      error={this.errors.identification_number}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                  <div class="col-12">
+                    <justifi-business-address-form
+                      errors={this.errors.address}
+                      defaultValues={ownerDefaultValue?.address}
+                      handleFormUpdate={values => this.onAddressFormUpdate(values)}
+                    />
+                  </div>
+                  <div class="d-flex gap-2">
+                    <button
+                      type="submit"
+                      class={`btn btn-primary jfi-submit-button${this.isLoading ? ' jfi-submit-button-loading' : ''}`}
+                      disabled={this.isLoading}>
+                      {this.isLoading ? LoadingSpinner() : this.submitButtonText}
+                    </button>
+                  </div>
+                </div>
+                <hr />
           </fieldset>
         </form>
       </Host>

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, State, Event, EventEmitter } from '@stencil/c
 import { FormController } from '../../form/form';
 import { PHONE_MASKS } from '../../../utils/form-input-masks';
 import { Api, IApiResponse } from '../../../api';
-import { Identity, Owner } from '../../../api/Business';
+import { Identity, Owner } from '../../../api/Identity';
 import { parseIdentityInfo } from '../utils/payload-parsers';
 import { ownerSchema } from '../schemas/business-identity-schema';
 import { config } from '../../../../config';

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -19,7 +19,8 @@ export class BusinessOwnerForm {
   @Prop() ownerId?: string;
   @Prop() businessId?: string;
   @Prop() removeOwner: (id: string) => void;
-  @Prop() showRemoveOwnerButton?: boolean;
+  @Prop() newFormOpen?: boolean;
+  @Prop() ownersLength?: number;
   @State() isLoading: boolean = false;
   @State() formController: FormController;
   @State() errors: any = {};
@@ -40,6 +41,19 @@ export class BusinessOwnerForm {
 
   get submitButtonText() {
     return this.ownerId ? 'Update' : 'Add';
+  }
+
+  get showRemoveButton() {
+    const blankForm = !this.ownerId && this.newFormOpen;
+    if (this.ownersLength <= 1) {
+      return false
+    } else {
+      if (blankForm) {
+        return true;
+      } else if (this.ownerId && !this.newFormOpen) {
+        return true;
+      }
+    }
   }
 
   @Watch('isLoading')
@@ -257,7 +271,7 @@ export class BusinessOwnerForm {
                   disabled={this.isLoading}>
                   {this.isLoading ? LoadingSpinner() : this.submitButtonText}
                 </button>
-                {this.showRemoveOwnerButton &&
+                {this.showRemoveButton &&
                   <button
                     type="button"
                     class="btn btn-danger"

--- a/packages/webcomponents/src/components/business-forms/utils/payload-parsers.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/payload-parsers.ts
@@ -38,6 +38,7 @@ export const parseIdentityInfo = (values: any) => {
   delete values.address.id;
   delete values.address.created_at;
   delete values.address.updated_at;
+  delete values.business_id
 
   return values;
 }

--- a/packages/webcomponents/src/components/form/form.ts
+++ b/packages/webcomponents/src/components/form/form.ts
@@ -77,7 +77,7 @@ export class FormController {
     this.setNestedError(obj, properties, message);
   }
 
-  private async validate(context?: any): Promise<boolean> {
+  async validate(context?: any): Promise<boolean> {
     this._isValid = true;
     this._errors = {};
 


### PR DESCRIPTION
### Implement Owner Form component back into `business-form-stepped`

This PR re-implements the owners form into `business-form-stepped`. 

Some other small updates worth mentioning:

- Created Identity type file and abstracted identity / owner / representative things out of Business.ts and into Identity.ts
- Removed `private` from form.ts validate method so it could be used independently in owner-form

Links
-----

Closes #405 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA



Developer QA steps
--------------------

We will want to test the owners section of the business form excessively. 
In order to test, you should be comfortable using insomnia to create businesses, patch existing businesses, create web component tokens, etc.

In the case that you are going through the form with a newly created business that has no owner data:

- [ ] The owners section of the form should render with a blank identity form. 
   - [ ] The identity form that is rendered should not make an API Call since there is no owner-id passed to it.
   - [ ] Attempting to submit without filling out all required fields for the current form should trigger validation and prevent submission
   - [ ] Clicking `Add` when filling out the initial form should call submit for just that particular form.
   - [