### PR TITLE
adds mockdata to the business-details in storybook

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -14,9 +14,15 @@ const config = {
   },
   staticDirs: ["../public"],
   async viteFinal(config, { configType }) {
+    const storybookMocksEnabled = process.env.VITE_STORYBOOK_MOCKS_ENABLED;
+
     return mergeConfig(config, {
       plugins: [react()],
+      define: {
+        __VITE_STORYBOOK_MOCKS_ENABLED__: JSON.stringify(storybookMocksEnabled),
+      },
     });
   },
 };
+
 export default config;

--- a/apps/docs/globals.d.ts
+++ b/apps/docs/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __VITE_STORYBOOK_MOCKS_ENABLED__: string;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "storybook dev -p 6006",
     "build": "storybook build",
+    "build:mocks": "cross-env VITE_STORYBOOK_MOCKS_ENABLED=true storybook build",
     "preview-storybook": "serve storybook-static",
     "clean": "rm -rf .turbo && rm -rf node_modules",
     "lint": "eslint ./stories/*.stories.tsx --max-warnings 0"
@@ -17,7 +18,6 @@
     "ts-dedent": "^2.2.0"
   },
   "devDependencies": {
-    "storybook": "^7.6.8",
     "@storybook/addon-actions": "^7.6.8",
     "@storybook/addon-docs": "^7.6.8",
     "@storybook/addon-essentials": "^7.6.8",
@@ -29,7 +29,9 @@
     "@vitejs/plugin-react": "^4.2.1",
     "chromatic": "^10.6.0",
     "eslint": "^8.56.0",
+    "miragejs": "^0.1.48",
     "serve": "^14.2.1",
+    "storybook": "^7.6.8",
     "typescript": "^5.3.3",
     "vite": "^5.0.13"
   }

--- a/apps/docs/stories/utils/decorators.ts
+++ b/apps/docs/stories/utils/decorators.ts
@@ -1,4 +1,6 @@
-type Props = { name: string, value: any }[];
+import { mockAllServices } from "./mockAllServices";
+
+type Props = { name: string; value: any }[];
 
 const getPropsAndStyles = (storyContext: any) => {
   const args = storyContext.args;
@@ -47,6 +49,13 @@ const generateStyleBlock = (styleArg: any) => {
 export const customStoryDecorator = (storyComponent: any, storyContext: any) => {
   const fragment = new DocumentFragment();
   const { props, styleArg } = getPropsAndStyles(storyContext);
+
+  const isMocksEnabled = __VITE_STORYBOOK_MOCKS_ENABLED__ === 'true';
+
+  if (isMocksEnabled) {
+    mockAllServices();
+  }
+
   const component = applyArgsToStoryComponent(storyComponent, props);
 
   if (styleArg) {

--- a/apps/docs/stories/utils/mockAllServices.ts
+++ b/apps/docs/stories/utils/mockAllServices.ts
@@ -1,0 +1,16 @@
+import { createServer } from 'miragejs';
+import mockBusinessDetails from '../../../../packages/webcomponents/src/api/mockData/mockBusinessDetails.json';
+
+export const mockAllServices = () => {
+  createServer({
+    routes() {
+      this.urlPrefix = 'https://wc-proxy.justifi.ai/v1';
+
+      // The rest of the routes will be created in the following PRs
+      this.namespace = '/entities/business';
+
+      // To test an error response, just replace 'mockBusinessDetails' by an error response
+      this.get('/:id', () => mockBusinessDetails);
+    },
+  });
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "dev": "turbo run dev",
+    "dev": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'cross-env VITE_STORYBOOK_MOCKS_ENABLED=true pnpm --filter @repo/docs dev'",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",
     "test": "turbo run test",
@@ -14,6 +14,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",
+    "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "prettier": "^3.1.1",
     "turbo": "latest"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.1
         version: 2.27.1
+      concurrently:
+        specifier: ^8.2.2
+        version: 8.2.2
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       prettier:
         specifier: ^3.1.1
         version: 3.2.4
@@ -66,6 +72,9 @@ importers:
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
+      miragejs:
+        specifier: ^0.1.48
+        version: 0.1.48
       serve:
         specifier: ^14.2.1
         version: 14.2.1
@@ -2572,6 +2581,10 @@ packages:
       '@types/mdx': 2.0.10
       '@types/react': 18.2.48
       react: 18.2.0
+    dev: true
+
+  /@miragejs/pretender-node-polyfill@0.1.2:
+    resolution: {integrity: sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==}
     dev: true
 
   /@ndelangen/get-tarball@3.0.9:
@@ -5114,6 +5127,22 @@ packages:
       typedarray: 0.0.6
     dev: true
 
+  /concurrently@8.2.2:
+    resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
+    engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.1
+      spawn-command: 0.0.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+    dev: true
+
   /consola@3.2.3:
     resolution: {integrity: sha512-I5qxpzLv+sJhTVEoLYNcTW+bThDCPsit0vLNKShZx6rLtpilNpmmeTPaeqJb9ZE9dV3DGaeby6Vuhrw38WjeyQ==}
     engines: {node: ^14.18.0 || >=16.10.0}
@@ -5199,6 +5228,14 @@ packages:
       - ts-node
     dev: true
 
+  /cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
+    dependencies:
+      cross-spawn: 7.0.3
+    dev: true
+
   /cross-fetch@4.0.0:
     resolution: {integrity: sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==}
     dependencies:
@@ -5265,7 +5302,6 @@ packages:
     engines: {node: '>=0.11'}
     dependencies:
       '@babel/runtime': 7.23.8
-    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -5973,6 +6009,10 @@ packages:
       - supports-color
     dev: true
 
+  /fake-xml-http-request@2.1.2:
+    resolution: {integrity: sha512-HaFMBi7r+oEC9iJNpc3bvcW7Z7iLmM26hPDmlb0mFwyANSsOQAtJxbdWsXITKOzZUyMYK0zYCv3h5yDj9TsiXg==}
+    dev: true
+
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
     dev: true
@@ -6620,6 +6660,10 @@ packages:
   /indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+    dev: true
+
+  /inflected@2.1.0:
+    resolution: {integrity: sha512-hAEKNxvHf2Iq3H60oMBHkB4wl5jn3TPF3+fXek/sRwAB5gP9xWs4r7aweSF95f99HFoz69pnZTcu8f0SIHV18w==}
     dev: true
 
   /inflight@1.0.6:
@@ -7929,6 +7973,16 @@ packages:
       yallist: 4.0.0
     dev: true
 
+  /miragejs@0.1.48:
+    resolution: {integrity: sha512-MGZAq0Q3OuRYgZKvlB69z4gLN4G3PvgC4A2zhkCXCXrLD5wm2cCnwNB59xOBVA+srZ0zEes6u+VylcPIkB4SqA==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dependencies:
+      '@miragejs/pretender-node-polyfill': 0.1.2
+      inflected: 2.1.0
+      lodash: 4.17.21
+      pretender: 3.4.7
+    dev: true
+
   /mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
     dev: true
@@ -8418,6 +8472,13 @@ packages:
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /pretender@3.4.7:
+    resolution: {integrity: sha512-jkPAvt1BfRi0RKamweJdEcnjkeu7Es8yix3bJ+KgBC5VpG/Ln4JE3hYN6vJym4qprm8Xo5adhWpm3HCoft1dOw==}
+    dependencies:
+      fake-xml-http-request: 2.1.2
+      route-recognizer: 0.3.4
     dev: true
 
   /prettier@2.8.8:
@@ -9016,6 +9077,10 @@ packages:
       fsevents: 2.3.3
     dev: true
 
+  /route-recognizer@0.3.4:
+    resolution: {integrity: sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==}
+    dev: true
+
   /run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
@@ -9026,7 +9091,6 @@ packages:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
       tslib: 2.6.2
-    dev: false
 
   /safe-array-concat@1.1.0:
     resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}
@@ -9207,6 +9271,10 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /shell-quote@1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+    dev: true
+
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -9296,6 +9364,10 @@ packages:
 
   /space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
+    dev: true
+
+  /spawn-command@0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
     dev: true
 
   /spawndamnit@2.0.0:
@@ -9672,6 +9744,11 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+    dev: true
+
+  /tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
     dev: true
 
   /trim-newlines@3.0.1:


### PR DESCRIPTION
This PR introduces a straightforward approach for integrating mock data within our Storybook setup. It revolves around a new environment variable, `VITE_STORYBOOK_MOCKS_ENABLED`, which can be toggled between true and false within the pnpm dev script.

Setting `VITE_STORYBOOK_MOCKS_ENABLED` to true activates the `createServer()` function from [MirageJS](https://miragejs.com/), enabling us to define custom responses for API calls within the global story decorator. 

This feature provides flexibility in running or building Storybook by either connecting to our proxy API or utilizing the mock data, ensuring a seamless workflow. Additionally, this setup is configured to support Chromatic visual testing using the mocked data build.

**TODO in upcoming PRs**:

- Relocate all mock JSON responses to a centralized directory at the project's root, facilitating access for both Stencil and Storybook.
- Expand our mock server setup to include routes for additional components.
- Reinstate the Chromatic GitHub action for automated visual testing.

Links
-----

https://github.com/justifi-tech/web-component-library/issues/437

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add documentation

Developer QA steps
--------------------
[ ] - Run `pnpm install && pnpm build && pnpm dev` to update dependencies and run the project
[ ] -  Go to  [BusinessDetails component](6006/?path=/story/entities-businessdetails--basic&args=business-id:Ok)
[ ] - Business Details should load with the same mock data in the JSON file
[ ] - Changes in the `authToken` and `businessId` shouldn't affect the data.
[ ] - Ir removed `authToken` and `businessId` the `Invalid business id or auth token` error message should be visible
[ ] - Try to set `VITE_STORYBOOK_MOCKS_ENABLED` to false in `package.json` (root). Run `pnpm dev` and it should load data from the proxiAPI
