### PR TITLE
feat: enable Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic-deployment.yaml
+++ b/.github/workflows/chromatic-deployment.yaml
@@ -1,0 +1,37 @@
+name: 'Chromatic Deployment'
+
+on:
+  pull_request:
+    paths:
+      - 'packages/webcomponents/**'
+
+jobs:
+  chromatic-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8.7.5
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build webcomponents
+        run: pnpm build
+
+      - name: Run Chromatic
+        working-directory: ./apps/docs
+        run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -13,13 +13,17 @@ const config = {
     autodocs: true,
   },
   staticDirs: ["../public"],
-  async viteFinal(config, { configType }) {
+  async viteFinal(config) {
     const storybookMocksEnabled = process.env.VITE_STORYBOOK_MOCKS_ENABLED;
+    const storybookChromaticBuild = process.env.VITE_STORYBOOK_CHROMATIC_BUILD;
 
     return mergeConfig(config, {
       plugins: [react()],
       define: {
         __VITE_STORYBOOK_MOCKS_ENABLED__: JSON.stringify(storybookMocksEnabled),
+        __VITE_STORYBOOK_CHROMATIC_BUILD__: JSON.stringify(
+          storybookChromaticBuild
+        ),
       },
     });
   },

--- a/apps/docs/chromatic.config.json
+++ b/apps/docs/chromatic.config.json
@@ -1,0 +1,3 @@
+{
+  "buildScriptName": "build:chromatic"
+}

--- a/apps/docs/globals.d.ts
+++ b/apps/docs/globals.d.ts
@@ -1,1 +1,2 @@
 declare const __VITE_STORYBOOK_MOCKS_ENABLED__: string;
+declare const __VITE_STORYBOOK_CHROMATIC_BUILD__: string;

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,6 +7,7 @@
     "dev": "storybook dev -p 6006",
     "build": "storybook build",
     "build:mocks": "cross-env VITE_STORYBOOK_MOCKS_ENABLED=true storybook build",
+    "build:chromatic": "cross-env VITE_STORYBOOK_CHROMATIC_BUILD=true storybook build",
     "preview-storybook": "serve storybook-static",
     "clean": "rm -rf .turbo && rm -rf node_modules",
     "lint": "eslint ./stories/*.stories.tsx --max-warnings 0"

--- a/apps/docs/stories/utils/decorators.ts
+++ b/apps/docs/stories/utils/decorators.ts
@@ -1,4 +1,4 @@
-import { mockAllServices } from "./mockAllServices";
+import { API_PATHS, mockAllServices } from "./mockAllServices";
 
 type Props = { name: string; value: any }[];
 
@@ -13,7 +13,6 @@ const getPropsAndStyles = (storyContext: any) => {
 
   return { props: props, styleArg: styleArg }
 };
-
 
 const applyArgsToStoryComponent = (storyComponent: any, props: Props) => {
   const component = storyComponent();
@@ -51,9 +50,14 @@ export const customStoryDecorator = (storyComponent: any, storyContext: any) => 
   const { props, styleArg } = getPropsAndStyles(storyContext);
 
   const isMocksEnabled = __VITE_STORYBOOK_MOCKS_ENABLED__ === 'true';
+  const isChromaticBuild = __VITE_STORYBOOK_CHROMATIC_BUILD__ === 'true';
 
   if (isMocksEnabled) {
-    mockAllServices();
+    // Use mock data for GrossPaymentChart only in Chromatic builds for consistent screenshots.
+    // For regular Storybook, use proxyApi to view dynamic data, especially to see dates from the past 30 days.
+    mockAllServices({
+      bypass: isChromaticBuild ? [] : [API_PATHS.GROSS_VOLUME],
+    });
   }
 
   const component = applyArgsToStoryComponent(storyComponent, props);

--- a/apps/docs/stories/utils/mockAllServices.ts
+++ b/apps/docs/stories/utils/mockAllServices.ts
@@ -6,37 +6,50 @@ import mockPayments from '../../../../mockData/mockPaymentsSuccess.json';
 import mockPayout from '../../../../mockData/mockPayoutDetailsSuccess.json';
 import mockPayouts from '../../../../mockData/mockPayoutsSuccess.json';
 
-export const mockAllServices = () => {
+export const API_PATHS = {
+  BUSINESS_DETAILS: '/entities/business/:id',
+  GROSS_VOLUME: '/account/:accountId/reports/gross_volume',
+  PAYMENT_DETAILS: '/payments/:id',
+  PAYMENTS_LIST: '/account/:id/payments',
+  PAYOUT_DETAILS: '/payouts/:id',
+  PAYOUTS_LIST: '/account/:id/payouts',
+};
+
+type MockAllServicesConfig = {
+  bypass: string[];
+};
+
+export const mockAllServices = ({ bypass }: MockAllServicesConfig) => {
   createServer({
     routes() {
       this.urlPrefix = 'https://wc-proxy.justifi.ai/v1';
 
       // BusinessDetails
-      this.get('/entities/business/:id', () => mockBusinessDetails);
+      this.get(API_PATHS.BUSINESS_DETAILS, () => mockBusinessDetails);
 
-      this.patch('/entities/business/:id', (schema, request) => {
+      this.patch(API_PATHS.BUSINESS_DETAILS, (_schema, request) => {
         const id = request.params.id;
         const newDetails = JSON.parse(request.requestBody);
         return { ...mockBusinessDetails, ...newDetails, id };
       });
 
       // GrossPaymentChart
-      this.get(
-        '/account/:accountId/reports/gross_volume',
-        () => mockGrossPaymentChart
-      );
+      this.get(API_PATHS.GROSS_VOLUME, () => mockGrossPaymentChart);
 
       // PaymentDetails
-      this.get('payments/:id', () => mockPayment);
+      this.get(API_PATHS.PAYMENT_DETAILS, () => mockPayment);
 
       // PaymentsList
-      this.get('account/:id/payments', () => mockPayments);
+      this.get(API_PATHS.PAYMENTS_LIST, () => mockPayments);
 
       // PayoutDetails
-      this.get('payouts/:id', () => mockPayout);
+      this.get(API_PATHS.PAYOUT_DETAILS, () => mockPayout);
 
       // PayoutsList
-      this.get('account/:id/payouts', () => mockPayouts);
+      this.get(API_PATHS.PAYOUTS_LIST, () => mockPayouts);
+
+      // Ensure all other requests not handled by Mirage are sent to the real network
+      this.passthrough(...bypass);
 
       // To test an error response, you can use something like:
       // this.get('/somepath', new Response(500, {}, { error: 'An error message' }));


### PR DESCRIPTION
* This adds back the Chromatic workflow
* Also make Gross Payment Chart load proxyAPI data on Storybook, and mock data in Chromatic

Links
-----
#437 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------

- [X] Running Storybook locally, all components should load mock data, except for the Gross Payment Chart
- [X] After merging this, Chromatic should be enabled again, and all component screenshots should be taken with mock data  