### PR TITLE
Adds errorEvent to Payouts list

### DIFF
--- a/apps/docs/stories/components/payouts-list.stories.tsx
+++ b/apps/docs/stories/components/payouts-list.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta = {
   },
   parameters: {
     actions: {
-      handles: ['payout-row-clicked', 'error'],
+      handles: ['payout-row-clicked', 'errorEvent'],
     },
   },
   decorators: [

--- a/apps/docs/stories/components/payouts-list.stories.tsx
+++ b/apps/docs/stories/components/payouts-list.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta = {
   },
   parameters: {
     actions: {
-      handles: ['payout-row-clicked'],
+      handles: ['payout-row-clicked', 'error'],
     },
   },
   decorators: [

--- a/packages/webcomponents/src/api/ComponentError.ts
+++ b/packages/webcomponents/src/api/ComponentError.ts
@@ -1,0 +1,18 @@
+export enum ComponentErrorCodes {
+  MISSING_PROPS = 'missing-props',
+  FETCH_ERROR = 'fetch-error',
+  UNKNOWN_ERROR = 'unknown-error',
+}
+
+export enum ComponentErrorSeverity {
+  INFO = 'info',
+  WARNING = 'warning',
+  ERROR = 'error',
+}
+
+export interface ComponentError {
+  errorCode: ComponentErrorCodes; // A unique code identifying the error
+  message: string; // A descriptive message about the error
+  severity?: ComponentErrorSeverity; // Optional severity level
+  data?: any; // Additional data pertinent to the error (optional)
+}

--- a/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
@@ -30,7 +30,7 @@ export class PayoutsListCore {
     bubbles: true,
   }) rowClicked: EventEmitter<Payout>;
 
-  @Event() error: EventEmitter<ComponentError>;
+  @Event() errorEvent: EventEmitter<ComponentError>;
 
   componentWillLoad() {
     if (this.getPayouts) {
@@ -85,7 +85,7 @@ export class PayoutsListCore {
       },
       onError: (errorMessage) => {
         this.errorMessage = errorMessage;
-        this.error.emit({
+        this.errorEvent.emit({
           errorCode: ComponentErrorCodes.FETCH_ERROR,
           message: errorMessage,
         });

--- a/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
@@ -8,8 +8,7 @@ import {
 } from '../../api';
 import { formatCurrency, formatDate, formatTime } from '../../utils/utils';
 import { tableExportedParts } from '../table/exported-parts';
-import { ComponentError } from '../../components';
-import { ComponentErrorCodes } from '../../api/ComponentError';
+import { ComponentError, ComponentErrorCodes } from '../../api/ComponentError';
 
 @Component({
   tag: 'payouts-list-core',

--- a/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
@@ -8,6 +8,8 @@ import {
 } from '../../api';
 import { formatCurrency, formatDate, formatTime } from '../../utils/utils';
 import { tableExportedParts } from '../table/exported-parts';
+import { ComponentError } from '../../components';
+import { ComponentErrorCodes } from '../../api/ComponentError';
 
 @Component({
   tag: 'payouts-list-core',
@@ -16,15 +18,19 @@ import { tableExportedParts } from '../table/exported-parts';
 
 export class PayoutsListCore {
   @Prop() getPayouts: Function;
+
   @State() payouts: Payout[] = [];
   @State() loading: boolean = true;
   @State() errorMessage: string;
   @State() paging: PagingInfo = pagingDefaults;
-  @State() params: any
+  @State() params: any;
+
   @Event({
     eventName: 'payout-row-clicked',
     bubbles: true,
   }) rowClicked: EventEmitter<Payout>;
+
+  @Event() error: EventEmitter<ComponentError>;
 
   componentWillLoad() {
     if (this.getPayouts) {
@@ -79,6 +85,10 @@ export class PayoutsListCore {
       },
       onError: (errorMessage) => {
         this.errorMessage = errorMessage;
+        this.error.emit({
+          errorCode: ComponentErrorCodes.FETCH_ERROR,
+          message: errorMessage,
+        });
         this.loading = false;
       },
     });

--- a/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
@@ -36,7 +36,7 @@ export class PayoutsList {
   @State() getPayouts: Function;
   @State() errorMessage: string = null;
 
-  @Event() error: EventEmitter<ComponentError>;
+  @Event() errorEvent: EventEmitter<ComponentError>;
 
   componentWillLoad() {
     this.initializeGetPayouts();
@@ -57,7 +57,7 @@ export class PayoutsList {
       });
     } else {
       this.errorMessage = 'Account ID and Auth Token are required';
-      this.error.emit({
+      this.errorEvent.emit({
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         message: 'Account ID and Auth Token are required',
       });
@@ -66,7 +66,7 @@ export class PayoutsList {
 
   handleOnError = (event) => {
     this.errorMessage = event.detail.message;
-    this.error.emit(event.detail);
+    this.errorEvent.emit(event.detail);
   }
 
   render() {
@@ -76,7 +76,7 @@ export class PayoutsList {
 
     return (
       <Host exportedparts={tableExportedParts}>
-        <payouts-list-core getPayouts={this.getPayouts} onError={this.handleOnError} />
+        <payouts-list-core getPayouts={this.getPayouts} onErrorEvent={this.handleOnError} />
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
@@ -1,8 +1,9 @@
-import { Component, Host, h, Prop, State, Watch } from '@stencil/core';
+import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { tableExportedParts } from '../table/exported-parts';
 import { PayoutService } from '../../api/services/payout.service';
 import { makeGetPayouts } from './get-payouts';
 import { ErrorState } from '../details/utils';
+import { ComponentError, ComponentErrorCodes } from '../../api/ComponentError';
 
 /**
   * @exportedPart table-head: Table head
@@ -35,6 +36,8 @@ export class PayoutsList {
   @State() getPayouts: Function;
   @State() errorMessage: string = null;
 
+  @Event() error: EventEmitter<ComponentError>;
+
   componentWillLoad() {
     this.initializeGetPayouts();
   }
@@ -54,7 +57,16 @@ export class PayoutsList {
       });
     } else {
       this.errorMessage = 'Account ID and Auth Token are required';
+      this.error.emit({
+        errorCode: ComponentErrorCodes.MISSING_PROPS,
+        message: 'Account ID and Auth Token are required',
+      });
     }
+  }
+
+  handleOnError = (event) => {
+    this.errorMessage = event.detail.message;
+    this.error.emit(event.detail);
   }
 
   render() {
@@ -64,7 +76,7 @@ export class PayoutsList {
 
     return (
       <Host exportedparts={tableExportedParts}>
-        <payouts-list-core getPayouts={this.getPayouts} />
+        <payouts-list-core getPayouts={this.getPayouts} onError={this.handleOnError} />
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/payouts-list/readme.md
+++ b/packages/webcomponents/src/components/payouts-list/readme.md
@@ -7,20 +7,24 @@
 
 ## Properties
 
-| Property    | Attribute    | Description | Type     | Default     |
-| ----------- | ------------ | ----------- | -------- | ----------- |
-| `accountId` | `account-id` |             | `string` | `undefined` |
-| `authToken` | `auth-token` |             | `string` | `undefined` |
+| Property     | Attribute | Description | Type       | Default     |
+| ------------ | --------- | ----------- | ---------- | ----------- |
+| `getPayouts` | --        |             | `Function` | `undefined` |
 
 
 ## Events
 
-| Event                | Description | Type                  |
-| -------------------- | ----------- | --------------------- |
-| `payout-row-clicked` |             | `CustomEvent<Payout>` |
+| Event                | Description | Type                          |
+| -------------------- | ----------- | ----------------------------- |
+| `error`              |             | `CustomEvent<ComponentError>` |
+| `payout-row-clicked` |             | `CustomEvent<Payout>`         |
 
 
 ## Dependencies
+
+### Used by
+
+ - [justifi-payouts-list](.)
 
 ### Depends on
 
@@ -29,9 +33,10 @@
 ### Graph
 ```mermaid
 graph TD;
-  justifi-payouts-list --> justifi-table
+  payouts-list-core --> justifi-table
   justifi-table --> pagination-menu
-  style justifi-payouts-list fill:#f9f,stroke:#333,stroke-width:4px
+  justifi-payouts-list --> payouts-list-core
+  style payouts-list-core fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
 ----------------------------------------------

--- a/packages/webcomponents/src/components/payouts-list/readme.md
+++ b/packages/webcomponents/src/components/payouts-list/readme.md
@@ -16,7 +16,7 @@
 
 | Event                | Description | Type                          |
 | -------------------- | ----------- | ----------------------------- |
-| `error`              |             | `CustomEvent<ComponentError>` |
+| `errorEvent`         |             | `CustomEvent<ComponentError>` |
 | `payout-row-clicked` |             | `CustomEvent<Payout>`         |
 
 

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
@@ -85,7 +85,10 @@ describe('payouts-list-core', () => {
     await page.waitForChanges();
 
     expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({
-
+      detail: {
+        errorCode: 'fetch-error',
+        message: 'Fetch error',
+      }
     }));
   });
 

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
@@ -79,7 +79,7 @@ describe('payouts-list-core', () => {
 
     const page = await newSpecPage({
       components: [PayoutsListCore, Table, PaginationMenu],
-      template: () => <payouts-list-core getPayouts={getPayouts} onError={errorSpy} />,
+      template: () => <payouts-list-core getPayouts={getPayouts} onErrorEvent={errorSpy} />,
     });
 
     await page.waitForChanges();

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
@@ -36,7 +36,7 @@ describe('payouts-list', () => {
 
     const page = await newSpecPage({
       components: [PayoutsList, PayoutsListCore],
-      template: () => <justifi-payouts-list onError={onErrorSpy} />,
+      template: () => <justifi-payouts-list onErrorEvent={onErrorSpy} />,
     });
 
     await page.waitForChanges();

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
@@ -1,3 +1,4 @@
+import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
 import { PayoutsList } from "../payouts-list";
 import { PayoutsListCore } from "../payouts-list-core";
@@ -28,5 +29,25 @@ describe('payouts-list', () => {
     });
     await page.waitForChanges();
     expect(page.root).toMatchSnapshot();
+  });
+
+  it('emits an error event when accountId and authToken are not provided', async () => {
+    const onErrorSpy = jest.fn();
+
+    const page = await newSpecPage({
+      components: [PayoutsList, PayoutsListCore],
+      template: () => <justifi-payouts-list onError={onErrorSpy} />,
+    });
+
+    await page.waitForChanges();
+
+    expect(onErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          errorCode: 'missing-props',
+          message: 'Account ID and Auth Token are required',
+        },
+      })
+    );
   });
 });

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
@@ -2,6 +2,8 @@ import { h } from "@stencil/core";
 import { newSpecPage } from "@stencil/core/testing";
 import { PayoutsList } from "../payouts-list";
 import { PayoutsListCore } from "../payouts-list-core";
+import { PayoutService } from '../../../api/services/payout.service';
+jest.mock('../../../api/services/payout.service');
 
 describe('payouts-list', () => {
   it('renders an error message when accountId and authToken are not provided', async () => {
@@ -46,6 +48,34 @@ describe('payouts-list', () => {
         detail: {
           errorCode: 'missing-props',
           message: 'Account ID and Auth Token are required',
+        },
+      })
+    );
+  });
+
+  it('emits an error event when fetch fails', async () => {
+    PayoutService.prototype.fetchPayouts = jest.fn().mockRejectedValue(new Error('Fetch error'));
+
+    const onErrorSpy = jest.fn();
+
+    const page = await newSpecPage({
+      components: [PayoutsList, PayoutsListCore],
+      template: () => (
+        <justifi-payouts-list
+          account-id="abc"
+          auth-token="abc"
+          onErrorEvent={onErrorSpy}
+        />
+      ),
+    });
+
+    await page.waitForChanges();
+
+    expect(onErrorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          errorCode: 'fetch-error',
+          message: 'Fetch error',
         },
       })
     );


### PR DESCRIPTION
This adds an `errorEvent` to the PayoutsList that can be listened to handle errors.
Also creates a `componentError` type to be used across components.

Links
-----

#433 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add documentation

Developer QA steps
--------------------
[ ] - If an API error happens or If `authToken` or `accountId` are removed, it should emit `errorEvent` with the error details.
It the event should be logged in the Storybook actions tab
