### PR TITLE
Instantiate classes for additional-questions and representative form steps

### DIFF
--- a/packages/webcomponents/src/api/Business.ts
+++ b/packages/webcomponents/src/api/Business.ts
@@ -86,11 +86,25 @@ export interface ProductCategories {
   payment: boolean;
 }
 
-export interface AdditionalQuestions {
+export interface IAdditionalQuestions {
   business_revenue?: string;
   business_payment_volume?: string;
   business_dispute_volume?: string;
   business_receivable_volume?: string;
+}
+
+export class AdditionalQuestions implements IAdditionalQuestions {
+  public business_revenue?: string;
+  public business_payment_volume?: string;
+  public business_dispute_volume?: string;
+  public business_receivable_volume?: string;
+
+  constructor(additionalQuestions: IAdditionalQuestions) {
+    this.business_revenue = additionalQuestions.business_revenue;
+    this.business_payment_volume = additionalQuestions.business_payment_volume;
+    this.business_dispute_volume = additionalQuestions.business_dispute_volume;
+    this.business_receivable_volume = additionalQuestions.business_receivable_volume;
+  }
 }
 
 export interface ICoreBusinessInfo {
@@ -130,7 +144,7 @@ export class CoreBusinessInfo implements ICoreBusinessInfo {
 }
 
 export interface IBusiness {
-  additional_questions: AdditionalQuestions | {};
+  additional_questions: IAdditionalQuestions | {};
   business_structure: BusinessStructure;
   business_type: BusinessType;
   bank_accounts: BankAccount[];
@@ -154,7 +168,7 @@ export interface IBusiness {
 }
 
 export class Business implements IBusiness {
-  public additional_questions: AdditionalQuestions | {};
+  public additional_questions: IAdditionalQuestions | {};
   public business_structure: BusinessStructure;
   public business_type: BusinessType;
   public bank_accounts: BankAccount[];

--- a/packages/webcomponents/src/components/business-details/additional-questions-details/additional-questions-details.tsx
+++ b/packages/webcomponents/src/components/business-details/additional-questions-details/additional-questions-details.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, Prop, h } from '@stencil/core';
 import { DetailSectionTitle, DetailItem } from '../../details/utils';
-import { AdditionalQuestions } from '../../../api/Business';
+import { IAdditionalQuestions } from '../../../api/Business';
 import { isEmptyObject } from '../../../utils/utils';
 
 /**
@@ -17,7 +17,7 @@ import { isEmptyObject } from '../../../utils/utils';
   shadow: true,
 })
 export class AdditionalQuestionsDetails {
-  @Prop() additionalQuestions: AdditionalQuestions
+  @Prop() additionalQuestions: IAdditionalQuestions
 
   render() {
     if (isEmptyObject(this.additionalQuestions)) return null;

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/additional-questions/business-additional-questions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/additional-questions/business-additional-questions-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { IBusiness } from '../../../../api/Business';
+import { AdditionalQuestions, IAdditionalQuestions, IBusiness } from '../../../../api/Business';
 import { Api, IApiResponse } from '../../../../api';
 import { config } from '../../../../../config';
 import { additionQuestionsSchema } from '../../schemas/business-additional-questions-schema';
@@ -19,7 +19,7 @@ export class AdditionalQuestionsFormStep {
   @Prop() businessId: string;
   @State() formController: FormController;
   @State() errors: any = {};
-  @State() additional_questions: any = {};
+  @State() additional_questions: IAdditionalQuestions = {};
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event() serverError: EventEmitter<BusinessFormServerErrorEvent>;
@@ -34,8 +34,8 @@ export class AdditionalQuestionsFormStep {
     this.formLoading.emit(true);
     try {
       const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
-      this.additional_questions = response.data.additional_questions;
-      this.formController.setInitialValues(this.additional_questions);
+      this.additional_questions = new AdditionalQuestions(response.data.additional_questions || {});
+      this.formController.setInitialValues({ ...this.additional_questions });
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
     } finally {

--- a/packages/webcomponents/src/components/business-forms/business-form-stepped/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form-stepped/business-representative/business-representative-form-step.tsx
@@ -7,6 +7,8 @@ import { parseIdentityInfo } from '../../utils/payload-parsers';
 import { representativeSchema } from '../../schemas/business-identity-schema';
 import { config } from '../../../../../config';
 import { BusinessFormServerErrorEvent, BusinessFormServerErrors, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { Representative } from '../../../../api/Identity';
+
 
 @Component({
   tag: 'justifi-business-representative-form-step',
@@ -17,7 +19,7 @@ export class BusinessRepresentativeFormStep {
   @Prop() businessId: string;
   @State() formController: FormController;
   @State() errors: any = {};
-  @State() representative: any = {};
+  @State() representative: Representative = {};
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event() serverError: EventEmitter<BusinessFormServerErrorEvent>;
@@ -32,8 +34,8 @@ export class BusinessRepresentativeFormStep {
     this.formLoading.emit(true);
     try {
       const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
-      this.representative = response.data.representative;
-      this.formController.setInitialValues(this.representative);
+      this.representative = new Representative(response.data.representative || {});
+      this.formController.setInitialValues({ ...this.representative });
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
     } finally {


### PR DESCRIPTION
### Instantiate classes for additional-questions and representative form steps

This PR fixes an issue reported during our QA review last week. One of our participants noted that they got to the Representative step of the form and were unable to trigger validation by clicking Next or Previous buttons. After investigating briefly, I saw that the data that was being supplied to the form controller at this point was `null`, and it doesn't know how to trigger validation on `null`. 

This PR fixes this issue for both `additional-questions` and `representative` form steps by instantiating the data and ensuring there is an object supplied to the form controller for both of these steps. 


Links
-----

Closes #462 

Reference to issue on Google Sheets: [https://docs.google.com/spreadsheets/d/1KpgaPMl0X9OWxm7D3yAoBDOqkHcpTtWInZLS0OxqPSw/edit#gid=503272030&range=3:3](https://docs.google.com/spreadsheets/d/1KpgaPMl0X9OWxm7D3yAoBDOqkHcpTtWInZLS0OxqPSw/edit#gid=503272030&range=3:3)


Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------

For testing, you should create a blank business via insomnia - and run through the form again with this fresh business. You can create it with just a name. 

On each step of the form, before typing into any of the inputs, try clicking `Next` and ensuring that validation fires even when you haven't typed anything in. 

- [ ] Step 1
- [ ] Step 2
- [ ] Step 3
- [ ] Step 4
- [ ] Step 5