### PR TITLE
BusinessForm and PaymentProvisioning - Update Prefix Inputs to Title Inputs

### DIFF
--- a/.changeset/silver-bananas-remain.md
+++ b/.changeset/silver-bananas-remain.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+PaymentProvisioning and BusinessForm - updated Select Menu labeled Prefix in Representative and Owner Forms to now be Text Input labeled Title

--- a/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
@@ -67,21 +67,15 @@ export class BusinessRepresentative {
                 inputHandler={this.inputHandler}
               />
             </div>
-
             <div class="col-12 col-md-4">
-              <form-control-select
+              <form-control-text
                 name="title"
-                label="Prefix"
+                label="Title"
                 defaultValue={representativeDefaultValue?.title}
-                options={[
-                  { label: 'Select Prefix', value: '' },
-                  { label: 'Mrs.', value: 'Mrs.' },
-                ]}
                 error={this.errors.title}
                 inputHandler={this.inputHandler}
               />
             </div>
-
             <div class="col-12 col-md-6">
               <form-control-text
                 name="email"
@@ -91,7 +85,6 @@ export class BusinessRepresentative {
                 inputHandler={this.inputHandler}
               />
             </div>
-
             <div class="col-12 col-md-6">
               <form-control-number-masked
                 name="phone"
@@ -102,13 +95,11 @@ export class BusinessRepresentative {
                 mask={PHONE_MASKS.US}
               />
             </div>
-
             <div class="col-12">
               <label part="label" class="form-label">
                 Birth Date
               </label>
             </div>
-
             <div class="col-12 col-md-4">
               <form-control-datepart
                 name="dob_day"
@@ -119,7 +110,6 @@ export class BusinessRepresentative {
                 type="day"
               />
             </div>
-
             <div class="col-12 col-md-4">
               <form-control-datepart
                 name="dob_month"
@@ -130,7 +120,6 @@ export class BusinessRepresentative {
                 type="month"
               />
             </div>
-
             <div class="col-12 col-md-4">
               <form-control-datepart
                 name="dob_year"
@@ -141,7 +130,6 @@ export class BusinessRepresentative {
                 type="year"
               />
             </div>
-
             <div class="col-12">
               <form-control-number
                 name="identification_number"
@@ -151,7 +139,6 @@ export class BusinessRepresentative {
                 inputHandler={this.inputHandler}
               />
             </div>
-
             <div class="col-12">
               <justifi-business-address-form
                 errors={this.errors.address}

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -182,14 +182,10 @@ export class BusinessOwnerForm {
                 />
               </div>
               <div class="col-12 col-md-4">
-                <form-control-select
+                <form-control-text
                   name="title"
-                  label="Prefix"
+                  label="Title"
                   defaultValue={ownerDefaultValue?.title}
-                  options={[
-                    { label: 'Select Prefix', value: '' },
-                    { label: 'Mrs.', value: 'Mrs.' },
-                  ]}
                   error={this.errors.title}
                   inputHandler={this.inputHandler}
                 />

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -128,14 +128,10 @@ export class BusinessRepresentativeFormStep {
                 />
               </div>
               <div class="col-12 col-md-4">
-                <form-control-select
+                <form-control-text
                   name="title"
-                  label="Prefix"
+                  label="Title"
                   defaultValue={representativeDefaultValue?.title}
-                  options={[
-                    { label: 'Select Prefix', value: '' },
-                    { label: 'Mrs.', value: 'Mrs.' },
-                  ]}
                   error={this.errors.title}
                   inputHandler={this.inputHandler}
                 />


### PR DESCRIPTION
### Update input on BusinessForm and PaymentProvisioning - Change Select Menu with `Prefix` label to Text Input with `Title` label

This change is for `BusinessForm` (Representative section) and `PaymentProvisioning` (Steps 4 and 5, Rep and Owner Forms)


Links
-----

Closes #457 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA



Developer QA steps
--------------------

For BusinessForm:

- [ ] Ensure Business Form still works correctly - `Title` field for `Representative` should now be a text input and accept any string. 

For PaymentProvisioning:

- [ ] Ensure Step 4 still works correctly - `Title` field for `Representative` should now be a text input and accept any string. 
- [ ] Ensure Step 5 still works correctly - `Title` field for `Owner` forms should now be a text input and accept any string. 

