### PR TITLE
Handle Expired authToken Across All Components

### DIFF
--- a/packages/webcomponents/src/api/ComponentError.ts
+++ b/packages/webcomponents/src/api/ComponentError.ts
@@ -3,6 +3,7 @@ export enum ComponentErrorCodes {
   FETCH_ERROR = 'fetch-error',
   UNKNOWN_ERROR = 'unknown-error',
   TOKENIZE_ERROR = 'tokenize-error',
+  NOT_AUTHENTICATED = 'not-authenticated',
 }
 
 export enum ComponentErrorSeverity {

--- a/packages/webcomponents/src/api/services/utils.ts
+++ b/packages/webcomponents/src/api/services/utils.ts
@@ -1,6 +1,21 @@
+import { ComponentErrorCodes } from '../ComponentError';
+import { API_ERRORS } from '../shared';
+
 export const getErrorMessage = (error: any) => {
   if (typeof error === 'string') {
     return error;
   }
   return error.message;
+};
+
+export const getErrorCode = (code) => {
+  switch (code) {
+    case API_ERRORS.NOT_AUTHENTICATED:
+      return ComponentErrorCodes.NOT_AUTHENTICATED;
+
+    // add more cases as needed
+
+    default:
+      return ComponentErrorCodes.FETCH_ERROR;
+  }
 };

--- a/packages/webcomponents/src/api/shared.ts
+++ b/packages/webcomponents/src/api/shared.ts
@@ -10,9 +10,15 @@ export interface BankAccount {
   account_type: string;
 }
 
+// Errors on [capital]/config/locales/en.yml
+// Add more errors as needed
+export const API_ERRORS = {
+  NOT_AUTHENTICATED: 'Not Authenticated',
+};
+
 export const API_NOT_AUTHENTICATED_ERROR = {
   error: {
-    code: 'not_authenticated',
+    code: API_ERRORS.NOT_AUTHENTICATED,
     message: 'Not Authenticated',
   },
 };

--- a/packages/webcomponents/src/api/shared.ts
+++ b/packages/webcomponents/src/api/shared.ts
@@ -13,7 +13,7 @@ export interface BankAccount {
 // Errors on [capital]/config/locales/en.yml
 // Add more errors as needed
 export const API_ERRORS = {
-  NOT_AUTHENTICATED: 'Not Authenticated',
+  NOT_AUTHENTICATED: 'not_authenticated',
 };
 
 export const API_NOT_AUTHENTICATED_ERROR = {

--- a/packages/webcomponents/src/components/business-details/business-details-core.tsx
+++ b/packages/webcomponents/src/components/business-details/business-details-core.tsx
@@ -1,7 +1,7 @@
 import { Component, Event, EventEmitter, Host, Prop, State, h } from '@stencil/core';
 import { Business } from '../../api/Business';
 import { ErrorState, LoadingState } from '../details/utils';
-import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
+import { ComponentError } from '../../api/ComponentError';
 
 enum RENDER_STATES {
   LOADING = 'loading',
@@ -36,14 +36,15 @@ export class BusinessDetailsCore {
         this.business = business;
         this.renderState = RENDER_STATES.READY;
       },
-      onError: ({ error }) => {
+      onError: ({ error, code, severity }) => {
         this.errorMessage = error;
         this.renderState = RENDER_STATES.ERROR;
+
         this.errorEvent.emit({
-          errorCode: ComponentErrorCodes.FETCH_ERROR,
-          message: this.errorMessage,
-          severity: ComponentErrorSeverity.ERROR,
-        })
+          errorCode: code,
+          message: error,
+          severity,
+        });
       }
     });
   }

--- a/packages/webcomponents/src/components/business-details/get-business.ts
+++ b/packages/webcomponents/src/components/business-details/get-business.ts
@@ -1,5 +1,6 @@
 import { Business } from '../../api/Business';
-import { getErrorMessage } from '../../api/services/utils';
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetBusiness =
   ({ id, authToken, service }) =>
@@ -11,9 +12,19 @@ export const makeGetBusiness =
         onSuccess({ business: new Business(response.data) });
       } else {
         const responseError = getErrorMessage(response.error);
-        return onError({ error: responseError });
+        const code = getErrorCode(response.error?.code);
+        return onError({
+          error: responseError,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
       }
     } catch (error) {
-      return onError({ error: error.message || error });
+      const code = getErrorCode(error?.code);
+      return onError({
+        error: error.message || error,
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   };

--- a/packages/webcomponents/src/components/business-details/test/busines-details-core.spec.tsx
+++ b/packages/webcomponents/src/components/business-details/test/busines-details-core.spec.tsx
@@ -108,7 +108,7 @@ describe('BusinessDetailsCore', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         detail: {
-          errorCode: 'fetch-error',
+          errorCode: 'not-authenticated',
           message: 'Not Authenticated',
           severity: 'error',
         }

--- a/packages/webcomponents/src/components/business-details/test/get-business.spec.ts
+++ b/packages/webcomponents/src/components/business-details/test/get-business.spec.ts
@@ -1,6 +1,7 @@
 import { makeGetBusiness } from '../get-business';
 import mockResponse from '../../../api/mockData/mockBusinessDetails.json';
 import { Business, IBusiness } from '../../../api/Business';
+import { API_NOT_AUTHENTICATED_ERROR } from '../../../api/shared';
 
 // Mocks
 jest.mock('../../../api/services/utils.ts', () => ({
@@ -40,9 +41,7 @@ describe('makeGetBusiness', () => {
   });
 
   it('calls onError with an error message on fetch error', async () => {
-    const error = 'Test error';
-    const responseError = { error };
-    mockService.fetchBusiness.mockResolvedValue(responseError);
+    mockService.fetchBusiness.mockResolvedValue(API_NOT_AUTHENTICATED_ERROR);
 
     const onSuccess = jest.fn();
     const onError = jest.fn();
@@ -54,7 +53,11 @@ describe('makeGetBusiness', () => {
     });
     await getBusiness({ onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith({ error });
+    expect(onError).toHaveBeenCalledWith({
+      error: 'Not Authenticated',
+      code: 'not-authenticated',
+      severity: 'error',
+    });
   });
 
   it('calls onError with an error message on fetch exception', async () => {
@@ -71,6 +74,10 @@ describe('makeGetBusiness', () => {
     });
     await getBusiness({ onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith({ error: error.message });
+    expect(onError).toHaveBeenCalledWith({
+      error: error.message,
+      code: 'fetch-error',
+      severity: 'error',
+    });
   });
 });

--- a/packages/webcomponents/src/components/gross-payment-chart/get-gross-payment-chart-data.ts
+++ b/packages/webcomponents/src/components/gross-payment-chart/get-gross-payment-chart-data.ts
@@ -1,23 +1,30 @@
-import { ReportsService } from '../../api/services/reports.service';
-import { getErrorMessage } from '../../api/services/utils';
-
-interface MakeGetGrossPaymentChartDataProps {
-  id: string;
-  authToken: string;
-  service: ReportsService;
-}
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetGrossPaymentChartData =
-  ({ id, authToken, service }: MakeGetGrossPaymentChartDataProps) =>
+  ({ id, authToken, service }) =>
   async ({ onSuccess, onError }) => {
     try {
       const response = await service.fetchGrossVolumeChartData(id, authToken);
+
       if (!response.error) {
         onSuccess(response.data);
       } else {
-        onError(getErrorMessage(response.error));
+        const errorMessage = getErrorMessage(response.error);
+        const code = getErrorCode(response.error?.code);
+        onError({
+          error: errorMessage,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
       }
     } catch (error) {
-      onError(getErrorMessage(error));
+      const code = getErrorCode(error?.code);
+      const errorMessage = getErrorMessage(error);
+      onError({
+        error: errorMessage,
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   };

--- a/packages/webcomponents/src/components/gross-payment-chart/gross-payment-chart-core.tsx
+++ b/packages/webcomponents/src/components/gross-payment-chart/gross-payment-chart-core.tsx
@@ -3,7 +3,7 @@ import { Chart, BarController, Colors, BarElement, CategoryScale, LinearScale, L
 import { GrossVolumeReport } from '../../api/GrossVolume';
 import { generateChartOptions } from './chart-utils';
 import { ErrorState, LoadingState } from '../details/utils';
-import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
+import { ComponentError } from '../../api/ComponentError';
 
 Chart.register(
   Colors,
@@ -62,14 +62,15 @@ export class GrossPaymentChartCore {
         this.loading = false;
         this.grossVolumeReport = data;
       },
-      onError: (error: string) => {
+      onError: ({ error, code, severity }) => {
         this.loading = false;
         this.errorMessage = error;
+
         this.errorEvent.emit({
-          errorCode: ComponentErrorCodes.FETCH_ERROR,
+          errorCode: code,
           message: error,
-          severity: ComponentErrorSeverity.ERROR,
-        });
+          severity,
+        })
       }
     });
   }

--- a/packages/webcomponents/src/components/gross-payment-chart/test/get-gross-payment-chart-data.spec.ts
+++ b/packages/webcomponents/src/components/gross-payment-chart/test/get-gross-payment-chart-data.spec.ts
@@ -62,7 +62,11 @@ describe('makeGetGrossPaymentChartData', () => {
 
     await getGrossPaymentChartData({ onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith('Not Authenticated');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'not-authenticated',
+      error: 'Not Authenticated',
+      severity: 'error',
+    });
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
@@ -81,7 +85,9 @@ describe('makeGetGrossPaymentChartData', () => {
 
     await getGrossPaymentChartData({ onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith('Network error');
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Network error' })
+    );
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
@@ -101,7 +107,11 @@ describe('makeGetGrossPaymentChartData', () => {
 
     await getGrossPaymentChartData({ onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith('Not Authenticated');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'not-authenticated',
+      error: 'Not Authenticated',
+      severity: 'error',
+    });
     expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/packages/webcomponents/src/components/gross-payment-chart/test/gross-payment-chart-core.spec.tsx
+++ b/packages/webcomponents/src/components/gross-payment-chart/test/gross-payment-chart-core.spec.tsx
@@ -121,7 +121,7 @@ describe('gross-payment-chart', () => {
 
     expect(eventSpy).toHaveBeenCalledWith(expect.objectContaining({
       detail: {
-        errorCode: 'fetch-error',
+        errorCode: 'not-authenticated',
         message: 'Not Authenticated',
         severity: 'error',
       }

--- a/packages/webcomponents/src/components/gross-payment-chart/test/gross-payment-chart.spec.tsx
+++ b/packages/webcomponents/src/components/gross-payment-chart/test/gross-payment-chart.spec.tsx
@@ -3,6 +3,7 @@ import { newSpecPage } from "@stencil/core/testing";
 import { GrossPaymentChart } from "../gross-payment-chart";
 import { GrossPaymentChartCore } from "../gross-payment-chart-core";
 import { ReportsService } from "../../../api/services/reports.service";
+import { API_NOT_AUTHENTICATED_ERROR } from "../../../api/shared";
 jest.mock("../../../api/services/reports.service");
 
 describe('GrossPaymentChart', () => {
@@ -56,12 +57,7 @@ describe('GrossPaymentChart', () => {
   });
 
   it('emits an error event when fetch fails', async () => {
-    ReportsService.prototype.fetchGrossVolumeChartData = jest.fn().mockReturnValue({
-      "error": {
-        "code": "not_authenticated",
-        "message": "Not Authenticated"
-      }
-    });
+    ReportsService.prototype.fetchGrossVolumeChartData = jest.fn().mockReturnValue(API_NOT_AUTHENTICATED_ERROR);
 
     const errorEvent = jest.fn();
 
@@ -81,7 +77,7 @@ describe('GrossPaymentChart', () => {
     expect(errorEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         detail: {
-          errorCode: 'fetch-error',
+          errorCode: 'not-authenticated',
           message: 'Not Authenticated',
           severity: 'error',
         }

--- a/packages/webcomponents/src/components/payment-details/get-payment-details.ts
+++ b/packages/webcomponents/src/components/payment-details/get-payment-details.ts
@@ -1,5 +1,6 @@
 import { Payment } from '../../api';
-import { getErrorMessage } from '../../api/services/utils';
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPaymentDetails =
   ({ id, authToken, service }) =>
@@ -10,9 +11,19 @@ export const makeGetPaymentDetails =
         onSuccess({ payment: new Payment(response.data) });
       } else {
         const responseError = getErrorMessage(response.error);
-        onError(responseError);
+        const code = getErrorCode(response.error?.code);
+        onError({
+          error: responseError,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
       }
     } catch (error) {
-      onError(getErrorMessage(error));
+      const code = getErrorCode(error?.code);
+      onError({
+        error: getErrorMessage(error),
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   };

--- a/packages/webcomponents/src/components/payment-details/payment-details-core.tsx
+++ b/packages/webcomponents/src/components/payment-details/payment-details-core.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@st
 import { Payment } from '../../api';
 import { MapPaymentStatusToBadge, formatCurrency, formatDate, formatTime, snakeCaseToHumanReadable } from '../../utils/utils';
 import { CodeBlock, DetailItem, DetailSectionTitle, EntityHeadInfo, EntityHeadInfoItem, ErrorState, LoadingState } from '../details/utils';
-import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
+import { ComponentError } from '../../api/ComponentError';
 
 @Component({
   tag: 'payment-details-core',
@@ -38,13 +38,13 @@ export class PaymentDetailsCore {
         this.loading = false;
         this.errorMessage = null;
       },
-      onError: (error) => {
+      onError: ({ error, code, severity }) => {
         this.errorMessage = error;
         this.errorEvent.emit({
+          errorCode: code,
           message: error,
-          errorCode: ComponentErrorCodes.FETCH_ERROR,
-          severity: ComponentErrorSeverity.ERROR
-        });
+          severity,
+        })
         this.loading = false;
       },
     });

--- a/packages/webcomponents/src/components/payment-details/test/get-payment-details.spec.ts
+++ b/packages/webcomponents/src/components/payment-details/test/get-payment-details.spec.ts
@@ -60,7 +60,11 @@ describe('getPaymentDetails', () => {
     await getPaymentDetails({ onSuccess, onError });
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith('Error fetching payment');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching payment',
+      severity: 'error',
+    });
   });
 
   it('should call onError with an error message on API failure', async () => {
@@ -79,6 +83,10 @@ describe('getPaymentDetails', () => {
     await getPaymentDetails({ onSuccess, onError });
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith('Error fetching payment');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching payment',
+      severity: 'error',
+    });
   });
 });

--- a/packages/webcomponents/src/components/payment-details/test/payment-details-core.spec.tsx
+++ b/packages/webcomponents/src/components/payment-details/test/payment-details-core.spec.tsx
@@ -104,7 +104,7 @@ describe('payment-details-core', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({
       detail: {
         message: 'Not Authenticated',
-        errorCode: 'fetch-error',
+        errorCode: 'not-authenticated',
         severity: 'error'
       }
     }));

--- a/packages/webcomponents/src/components/payment-details/test/payment-details.spec.tsx
+++ b/packages/webcomponents/src/components/payment-details/test/payment-details.spec.tsx
@@ -110,7 +110,7 @@ describe('payment-details', () => {
     expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({
       detail: {
         message: 'Not Authenticated',
-        errorCode: 'fetch-error',
+        errorCode: 'not-authenticated',
         severity: 'error'
       }
     }));

--- a/packages/webcomponents/src/components/payments-list/get-payments.ts
+++ b/packages/webcomponents/src/components/payments-list/get-payments.ts
@@ -1,5 +1,6 @@
 import { Payment } from '../../api';
-import { getErrorMessage } from '../../api/services/utils';
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayments =
   ({ id, authToken, service }) =>
@@ -18,9 +19,19 @@ export const makeGetPayments =
         onSuccess({ payments, pagingInfo });
       } else {
         const responseError = getErrorMessage(response.error);
-        return onError(responseError);
+        const code = getErrorCode(response.error?.code);
+        return onError({
+          error: responseError,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
       }
     } catch (error) {
-      return onError(error.message || error);
+      const code = getErrorCode(error?.code);
+      return onError({
+        error: error.message || error,
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   };

--- a/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
 import { PagingInfo, Payment, pagingDefaults } from '../../api';
 import { MapPaymentStatusToBadge, formatCurrency, formatDate, formatTime } from '../../utils/utils';
-import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
+import { ComponentError } from '../../api/ComponentError';
 
 @Component({
   tag: 'payments-list-core',
@@ -59,12 +59,12 @@ export class PaymentsListCore {
         this.paging = pagingInfo;
         this.loading = false;
       },
-      onError: (errorMessage) => {
-        this.errorMessage = errorMessage;
+      onError: ({ error, code, severity }) => {
+        this.errorMessage = error;
         this.errorEvent.emit({
-          errorCode: ComponentErrorCodes.FETCH_ERROR,
-          message: errorMessage,
-          severity: ComponentErrorSeverity.ERROR,
+          errorCode: code,
+          message: error,
+          severity,
         });
         this.loading = false;
       },

--- a/packages/webcomponents/src/components/payments-list/test/get-payments.spec.ts
+++ b/packages/webcomponents/src/components/payments-list/test/get-payments.spec.ts
@@ -64,7 +64,11 @@ describe('makeGetPayments', () => {
     });
     await getPayments({ params: mockParams, onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith('Error fetching payments');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching payments',
+      severity: 'error',
+    });
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
@@ -83,7 +87,11 @@ describe('makeGetPayments', () => {
     });
     await getPayments({ params: mockParams, onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith('Network error');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Network error',
+      severity: 'error',
+    });
     expect(onSuccess).not.toHaveBeenCalled();
   });
 

--- a/packages/webcomponents/src/components/payout-details/get-payout-details.ts
+++ b/packages/webcomponents/src/components/payout-details/get-payout-details.ts
@@ -1,5 +1,6 @@
 import { Payout } from '../../api';
-import { getErrorMessage } from '../../api/services/utils';
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayoutDetails =
   ({ id, authToken, service }) =>
@@ -12,12 +13,21 @@ export const makeGetPayoutDetails =
 
         onSuccess(payout);
       } else {
-        const responseError = getErrorMessage(response.error);
-        const errorMessage = responseError;
-        onError(getErrorMessage(errorMessage));
+        const errorMessage = getErrorMessage(response.error);
+        const code = getErrorCode(response.error?.code);
+        onError({
+          error: errorMessage,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
       }
     } catch (error) {
-      const errorMessage = error;
-      onError(getErrorMessage(errorMessage));
+      const errorMessage = getErrorMessage(error);
+      const code = getErrorCode(error?.code);
+      onError({
+        error: errorMessage,
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   };

--- a/packages/webcomponents/src/components/payout-details/payout-details-core.tsx
+++ b/packages/webcomponents/src/components/payout-details/payout-details-core.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, State, Watch, Event, EventEmitter } from '@st
 import { IPayout, Payout } from '../../api';
 import { MapPayoutStatusToBadge, formatCurrency, formatDate, formatTime } from '../../utils/utils';
 import { CodeBlock, DetailItem, DetailSectionTitle, EntityHeadInfo, EntityHeadInfoItem, ErrorState, LoadingState } from '../details/utils';
-import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
+import { ComponentError } from '../../api/ComponentError';
 
 @Component({
   tag: 'payout-details-core',
@@ -38,12 +38,12 @@ export class PayoutDetailsCore {
         this.payout = payout;
         this.loading = false;
       },
-      onError: (errorMessage) => {
-        this.errorMessage = errorMessage;
+      onError: ({ error, code, severity }) => {
+        this.errorMessage = error;
         this.errorEvent.emit({
-          message: this.errorMessage,
-          errorCode: ComponentErrorCodes.FETCH_ERROR,
-          severity: ComponentErrorSeverity.ERROR,
+          message: error,
+          errorCode: code,
+          severity,
         });
         this.loading = false;
       },

--- a/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
+++ b/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
@@ -49,7 +49,11 @@ describe('getPayout', () => {
     await getPayout({ onSuccess, onError });
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith(errorMessage);
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching payout',
+      severity: 'error',
+    });
   });
 
   it('should call onError with an error message on API failure with error message', async () => {
@@ -68,6 +72,10 @@ describe('getPayout', () => {
     await getPayout({ onSuccess, onError });
 
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(onError).toHaveBeenCalledWith(errorMessage);
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching payout',
+      severity: 'error',
+    });
   });
 });

--- a/packages/webcomponents/src/components/payout-details/test/payout-details-core.spec.tsx
+++ b/packages/webcomponents/src/components/payout-details/test/payout-details-core.spec.tsx
@@ -129,7 +129,7 @@ describe('payout-details-core', () => {
     expect(onErrorEvent).toHaveBeenCalledWith(expect.objectContaining({
       detail: {
         message: 'Not Authenticated',
-        errorCode: 'fetch-error',
+        errorCode: 'not-authenticated',
         severity: 'error'
       }
     }));

--- a/packages/webcomponents/src/components/payouts-list/get-payouts.ts
+++ b/packages/webcomponents/src/components/payouts-list/get-payouts.ts
@@ -1,5 +1,6 @@
 import { Payout } from '../../api';
-import { getErrorMessage } from '../../api/services/utils';
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayouts =
   ({ id, authToken, service }) =>
@@ -17,10 +18,21 @@ export const makeGetPayouts =
 
         onSuccess({ payouts, pagingInfo });
       } else {
-        const responseError = getErrorMessage(response.error);
-        return onError(responseError);
+        const error = getErrorMessage(response.error);
+        const code = getErrorCode(response.error?.code);
+        return onError({
+          error,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
       }
     } catch (error) {
-      return onError(error.message || error);
+      const message = getErrorMessage(error);
+      const code = getErrorCode(error?.code);
+      return onError({
+        error: message,
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   };

--- a/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../api';
 import { formatCurrency, formatDate, formatTime } from '../../utils/utils';
 import { tableExportedParts } from '../table/exported-parts';
-import { ComponentError, ComponentErrorCodes } from '../../api/ComponentError';
+import { ComponentError } from '../../api/ComponentError';
 
 @Component({
   tag: 'payouts-list-core',
@@ -82,11 +82,12 @@ export class PayoutsListCore {
         this.paging = pagingInfo;
         this.loading = false;
       },
-      onError: (errorMessage) => {
-        this.errorMessage = errorMessage;
+      onError: ({ error, code, severity }) => {
+        this.errorMessage = error;
         this.errorEvent.emit({
-          errorCode: ComponentErrorCodes.FETCH_ERROR,
-          message: errorMessage,
+          errorCode: code,
+          message: error,
+          severity
         });
         this.loading = false;
       },

--- a/packages/webcomponents/src/components/payouts-list/test/get-payouts.spec.ts
+++ b/packages/webcomponents/src/components/payouts-list/test/get-payouts.spec.ts
@@ -58,7 +58,11 @@ describe('makeGetPayouts', () => {
     });
     await getPayouts({ params: mockParams, onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith('Error fetching payouts');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching payouts',
+      severity: 'error',
+    });
     expect(onSuccess).not.toHaveBeenCalled();
   });
 
@@ -77,7 +81,11 @@ describe('makeGetPayouts', () => {
     });
     await getPayouts({ params: mockParams, onSuccess, onError });
 
-    expect(onError).toHaveBeenCalledWith('Error fetching payouts');
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching payouts',
+      severity: 'error',
+    });
     expect(onSuccess).not.toHaveBeenCalled();
   });
 });

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
@@ -88,6 +88,7 @@ describe('payouts-list-core', () => {
       detail: {
         errorCode: 'fetch-error',
         message: 'Fetch error',
+        severity: 'error',
       }
     }));
   });

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list.spec.tsx
@@ -76,6 +76,7 @@ describe('payouts-list', () => {
         detail: {
           errorCode: 'fetch-error',
           message: 'Fetch error',
+          severity: 'error',
         },
       })
     );


### PR DESCRIPTION
**Description**:
This pull request updates all components that utilize authToken to uniformly handle API errors related to token expiration. Specifically, when an expired token is detected, each component will now emit an error event with the error code not-authenticated. This ensures consistent error handling across our application, improving stability and the user authentication experience.

Links
-----
#424 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  

Developer QA steps
--------------------
To force the error state you can use this expired token: `eyJraWQiOiJqdXN0aWZpLTQxNTczZmIyNjU0MDVmNDY0Y2UyIiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2F1dGguanVzdGlmaS1zdGFnaW5nLmNvbS8iLCJhenAiOiJ3Y3RfNVNKckZPWTI0YXJ5bUJRc2xTY3hvRiIsInN1YiI6IndjdF81U0pyRk9ZMjRhcnltQlFzbFNjeG9GQHNlc3Npb25zIiwiYXVkIjoiaHR0cHM6Ly9hcGkuanVzdGlmaS5haS92MSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyIsInBlcm1pc3Npb25zIjpbIndyaXRlOmFjY291bnQ6YWNjXzMzTzlESWdJZVMzOTFMSUxIRVIxZmYiLCJ3cml0ZTpidXNpbmVzczpiaXpfNm02VDlESUFtaW1WRlFZd2FoT2xQQiJdLCJleHAiOjE3MTA3OTc1MjksImlhdCI6MTcxMDc5MzkyOSwicGxhdGZvcm1fYWNjb3VudF9pZCI6ImFjY18zRklibDNUSWhUVUJoWGt3YVRYNTlaIn0.XTIyf8YsbqRKeSOPGj-LS-W2HC8D1QoXVOo7TMeRM6fE-TA2n1xc5naF1v57ddTvbg8MKqTBG0ssPsBvgk0db7WVtMNgM_WPSMje-0vRokJAH9aCyhYgKDA9IBhEAZ4ibbJiXMw11gwiB8Xi89952r-j01Qt-4kTVK2_pyeWvjnDdANM5w-nkgFdKffeIdc-C1P7Yvze3auiRZSR7PvGBJVgrO7U9L7T9EeyLer0xj26hlgIX-45AucSN3NVr7WZkjrX95ikC2fKhw5XG6U6yCD8MUFJ5wT4WO-yh4Ma7qdJg-ZK7gie1RiWF57ve4W8M3_uFOb8xrCz1AKqXjcugA`

[ ] - Run through all components and set the expired token in the controls. You should see an `error-event` emitted in the actions panel with the following `detail` property: 

![image](https://github.com/justifi-tech/web-component-library/assets/22480988/c178d8a9-bd4f-4e7f-932b-840065112699)



