### PR TITLE
Add title and removeTitle props to BusinessForm and PaymentProvisioning

### DIFF
--- a/.changeset/silly-phones-scream.md
+++ b/.changeset/silly-phones-scream.md
@@ -2,4 +2,5 @@
 "@justifi/webcomponents": minor
 ---
 
-BusinessForm and PaymentProvisioning - added new optional prop, `title`, which allows devs to add their own custom title to override the default `Business Information`. 
+ - BusinessForm and PaymentProvisioning - added new optional prop, `title`, which allows devs to add their own custom title to override the default `Business Information`. 
+ - BusinessForm and PaymentProvisioning - added new optional prop, `removeTitle`, which allows devs to remove the existing title altogether. 

--- a/.changeset/silly-phones-scream.md
+++ b/.changeset/silly-phones-scream.md
@@ -2,5 +2,5 @@
 "@justifi/webcomponents": minor
 ---
 
- - BusinessForm and PaymentProvisioning - added new optional prop, `title`, which allows devs to add their own custom title to override the default `Business Information`. 
+ - BusinessForm and PaymentProvisioning - added new optional prop, `form-title`, which allows devs to add their own custom title to override the default `Business Information`. 
  - BusinessForm and PaymentProvisioning - added new optional prop, `removeTitle`, which allows devs to remove the existing title altogether. 

--- a/.changeset/silly-phones-scream.md
+++ b/.changeset/silly-phones-scream.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": minor
+---
+
+BusinessForm and PaymentProvisioning - added new optional prop, `title`, which allows devs to add their own custom title to override the default `Business Information`. 

--- a/apps/docs/stories/components/business-form.stories.tsx
+++ b/apps/docs/stories/components/business-form.stories.tsx
@@ -28,6 +28,17 @@ const meta: Meta = {
         defaultValue: { summary: 'Business Information' }
       }
     },
+    'remove-title': {
+      type: 'boolean',
+      description: 'This prop removes the title displayed at the top of the form.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        category: 'props',
+        defaultValue: { summary: 'false' }
+      }
+    },
     'hide-errors': {
       type: 'boolean',
       description: 'When set to `true`, this prop will hide all error alerts from the form, allowing developers more control over how they wish to handle errors.',

--- a/apps/docs/stories/components/business-form.stories.tsx
+++ b/apps/docs/stories/components/business-form.stories.tsx
@@ -17,6 +17,17 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'title': {
+      type: 'string',
+      description: 'This prop updates the value of the title displayed at the top of the form.',
+      control: {
+        type: 'text',
+      },
+      table: {
+        category: 'props',
+        defaultValue: { summary: 'Business Information' }
+      }
+    },
     'hide-errors': {
       type: 'boolean',
       description: 'When set to `true`, this prop will hide all error alerts from the form, allowing developers more control over how they wish to handle errors.',

--- a/apps/docs/stories/components/business-form.stories.tsx
+++ b/apps/docs/stories/components/business-form.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'title': {
+    'form-title': {
       type: 'string',
       description: 'This prop updates the value of the title displayed at the top of the form.',
       control: {

--- a/apps/docs/stories/components/payment-provisioning.stories.tsx
+++ b/apps/docs/stories/components/payment-provisioning.stories.tsx
@@ -28,6 +28,17 @@ const meta: Meta = {
         defaultValue: { summary: 'Business Information' }
       }
     },
+    'remove-title': {
+      type: 'boolean',
+      description: 'This prop removes the title displayed at the top of the form.',
+      control: {
+        type: 'boolean',
+      },
+      table: {
+        category: 'props',
+        defaultValue: { summary: 'false' }
+      }
+    },
     'hide-errors': {
       type: 'boolean',
       description: 'When set to `true`, this prop will hide all error alerts from the form, allowing developers more control over how they wish to handle errors.',

--- a/apps/docs/stories/components/payment-provisioning.stories.tsx
+++ b/apps/docs/stories/components/payment-provisioning.stories.tsx
@@ -17,6 +17,17 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'title': {
+      type: 'string',
+      description: 'This prop updates the value of the title displayed at the top of the form.',
+      control: {
+        type: 'text',
+      },
+      table: {
+        category: 'props',
+        defaultValue: { summary: 'Business Information' }
+      }
+    },
     'hide-errors': {
       type: 'boolean',
       description: 'When set to `true`, this prop will hide all error alerts from the form, allowing developers more control over how they wish to handle errors.',

--- a/apps/docs/stories/components/payment-provisioning.stories.tsx
+++ b/apps/docs/stories/components/payment-provisioning.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'title': {
+    'form-title': {
       type: 'string',
       description: 'This prop updates the value of the title displayed at the top of the form.',
       control: {

--- a/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
@@ -21,6 +21,7 @@ export class BusinessForm {
   @Prop() authToken: string;
   @Prop() businessId: string;
   @Prop() hideErrors?: boolean = false;
+  @Prop() title?: string = 'Business Information';
   @State() isLoading: boolean = false;
   @State() errorMessage: BusinessFormServerErrors;
   @Event() submitted: EventEmitter<BusinessFormSubmitEvent>;
@@ -105,7 +106,7 @@ export class BusinessForm {
         <form onSubmit={this.validateAndSubmit}>
           <div class="row gap-3">
             <div class="col-12 mb-4">
-              <h1>Business Information</h1>
+              <h1>{this.title}</h1>
             </div>
             {this.showErrors && FormAlert(this.errorMessage)}
             <div class="col-12 mb-4">

--- a/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
@@ -21,7 +21,7 @@ export class BusinessForm {
   @Prop() authToken: string;
   @Prop() businessId: string;
   @Prop() hideErrors?: boolean = false;
-  @Prop() title?: string = 'Business Information';
+  @Prop() formTitle?: string = 'Business Information';
   @Prop() removeTitle?: boolean = false;
   @State() isLoading: boolean = false;
   @State() errorMessage: BusinessFormServerErrors;
@@ -35,8 +35,8 @@ export class BusinessForm {
     this.clickEventOld.emit(event);
   }
 
-  get formTitle() {
-    return this.removeTitle ? '' : this.title;
+  get title() {
+    return this.removeTitle ? '' : this.formTitle;
   }
 
   get disabledState() {
@@ -111,7 +111,7 @@ export class BusinessForm {
         <form onSubmit={this.validateAndSubmit}>
           <div class="row gap-3">
             <div class="col-12 mb-4">
-              <h1>{this.formTitle}</h1>
+              <h1>{this.title}</h1>
             </div>
             {this.showErrors && FormAlert(this.errorMessage)}
             <div class="col-12 mb-4">

--- a/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
@@ -22,6 +22,7 @@ export class BusinessForm {
   @Prop() businessId: string;
   @Prop() hideErrors?: boolean = false;
   @Prop() title?: string = 'Business Information';
+  @Prop() removeTitle?: boolean = false;
   @State() isLoading: boolean = false;
   @State() errorMessage: BusinessFormServerErrors;
   @Event() submitted: EventEmitter<BusinessFormSubmitEvent>;
@@ -32,6 +33,10 @@ export class BusinessForm {
     console.warn('`clickEvent` is deprecated and will be removed in the next major release. Please use `click-event` instead.');
     this.clickEventNew.emit(event);
     this.clickEventOld.emit(event);
+  }
+
+  get formTitle() {
+    return this.removeTitle ? '' : this.title;
   }
 
   get disabledState() {
@@ -106,7 +111,7 @@ export class BusinessForm {
         <form onSubmit={this.validateAndSubmit}>
           <div class="row gap-3">
             <div class="col-12 mb-4">
-              <h1>{this.title}</h1>
+              <h1>{this.formTitle}</h1>
             </div>
             {this.showErrors && FormAlert(this.errorMessage)}
             <div class="col-12 mb-4">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
@@ -18,11 +18,16 @@ export class PaymentProvisioning {
   @Prop() hideErrors?: boolean = false;
   @Prop() allowOptionalFields?: boolean = false;
   @Prop() title?: string = 'Business Information';
+  @Prop() removeTitle?: boolean = false;
   @State() formLoading: boolean = false;
   @State() errorMessage: string = '';
   @State() currentStep: number = 0;
   @State() totalSteps: number = 5;
   @Event({eventName: 'click-event'}) clickEvent: EventEmitter<BusinessFormClickEvent>;
+
+  get formTitle() {
+    return this.removeTitle ? '' : this.title;
+  }
 
   get showErrors() {
     return this.errorMessage && !this.hideErrors;
@@ -139,7 +144,7 @@ export class PaymentProvisioning {
   render() {
     return (
       <Host exportparts="label,input,input-invalid">
-        <h1>{this.title}</h1>
+        <h1>{this.formTitle}</h1>
         {this.showErrors && FormAlert(this.errorMessage)}
         <div class="my-4">
           {this.currentStepComponent()}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
@@ -17,6 +17,7 @@ export class PaymentProvisioning {
   @Prop() testMode: boolean = false;
   @Prop() hideErrors?: boolean = false;
   @Prop() allowOptionalFields?: boolean = false;
+  @Prop() title?: string = 'Business Information';
   @State() formLoading: boolean = false;
   @State() errorMessage: string = '';
   @State() currentStep: number = 0;
@@ -138,7 +139,7 @@ export class PaymentProvisioning {
   render() {
     return (
       <Host exportparts="label,input,input-invalid">
-        <h1>Business Information</h1>
+        <h1>{this.title}</h1>
         {this.showErrors && FormAlert(this.errorMessage)}
         <div class="my-4">
           {this.currentStepComponent()}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
@@ -17,7 +17,7 @@ export class PaymentProvisioning {
   @Prop() testMode: boolean = false;
   @Prop() hideErrors?: boolean = false;
   @Prop() allowOptionalFields?: boolean = false;
-  @Prop() title?: string = 'Business Information';
+  @Prop() formTitle?: string = 'Business Information';
   @Prop() removeTitle?: boolean = false;
   @State() formLoading: boolean = false;
   @State() errorMessage: string = '';
@@ -25,8 +25,8 @@ export class PaymentProvisioning {
   @State() totalSteps: number = 5;
   @Event({eventName: 'click-event'}) clickEvent: EventEmitter<BusinessFormClickEvent>;
 
-  get formTitle() {
-    return this.removeTitle ? '' : this.title;
+  get title() {
+    return this.removeTitle ? '' : this.formTitle;
   }
 
   get showErrors() {
@@ -144,7 +144,7 @@ export class PaymentProvisioning {
   render() {
     return (
       <Host exportparts="label,input,input-invalid">
-        <h1>{this.formTitle}</h1>
+        <h1>{this.title}</h1>
         {this.showErrors && FormAlert(this.errorMessage)}
         <div class="my-4">
           {this.currentStepComponent()}


### PR DESCRIPTION
### Add optional title prop to BusinessForm and PaymentProvisioning

Straight-forward PR:

- Adds optional prop: `title` to `BusinessForm` and `PaymentProvisioning` components
- allows users to update title shown on form
- updates documentation, adds controls to storybook docs

- Adds optional prop: `removeTitle` to `BusinessForm` and `PaymentProvisioning` components
- allows users to remove title shown on form
- updates documentation, adds controls to storybook docs

Links
-----

Closes #480

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------

Fairly easy QA - can check in Storybook

- [ ] BusinessForm - verify that `title` prop displayed in Storybook controls updates form title - replaces `Business Information`
- [ ] PaymentProvisioning - - verify that `title` prop displayed in Storybook controls updates form title - replaces `Business Information`

