### PR TITLE
PaymentForm disableSubmitButton method

### DIFF
--- a/.changeset/mean-falcons-shop.md
+++ b/.changeset/mean-falcons-shop.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": patch
+"@repo/docs": patch
+---
+
+Added disableSubmitButton method to PaymentForm

--- a/apps/docs/stories/components/payment-form.stories.tsx
+++ b/apps/docs/stories/components/payment-form.stories.tsx
@@ -96,6 +96,12 @@ const meta: Meta = {
         category: 'methods'
       }
     },
+    'disableSubmitButton': {
+      description: '`disableSubmitButton() => Promise<void>`',
+      table: {
+        category: 'methods'
+      }
+    },
     'fillBillingForm': {
       description: '`fillBillingForm(fields: BillingFormFields) => Promise<void>`',
       table: {

--- a/packages/webcomponents/src/components/payment-form/payment-form.tsx
+++ b/packages/webcomponents/src/components/payment-form/payment-form.tsx
@@ -44,6 +44,11 @@ export class PaymentForm {
     this.submitButtonEnabled = true;
   }
 
+  @Method()
+  async disableSubmitButton() {
+    this.submitButtonEnabled = false;
+  }
+
   paymentMethodSelectedHandler(event: CustomEvent) {
     const paymentMethodType: PaymentMethodTypes = event.detail;
     this.selectedPaymentMethodType = paymentMethodType;


### PR DESCRIPTION
We have a method for `enableSubmitButton` - this method is used to re-enable the PaymentForm submit button in a implementers submit flow. Because the PaymentForm only handles tokenization of payment methods, the implementer then needs to use the token to make a payment and tell the form to re-enable the submit button when that is done.

We are now adding a `disableSubmitButton` to give implementers more control, such as disabling payments prior to a prerequisite to payment 

Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [x] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
- Pull the branch/install/build/run dev server
- In storybook, go to the PaymentForm example
- In the developer tools / console, run `const el = document.querySelector('justifi-payment-form')`, then `await el.disableSubmitButton()`
- [x] The submit button should now be disabled
