### PR TITLE
Add call to validate form before submitting by hitting Add button

### DIFF
--- a/.changeset/fifty-cheetahs-roll.md
+++ b/.changeset/fifty-cheetahs-roll.md
@@ -1,5 +1,5 @@
 ---
-"@justifi/webcomponents": minor
+"@justifi/webcomponents": patch
 ---
 
  - PaymentProvisioning component - fixed bug that allowed individual owner form to be submitted without proper form validation. 

--- a/.changeset/fifty-cheetahs-roll.md
+++ b/.changeset/fifty-cheetahs-roll.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": minor
+---
+
+ - PaymentProvisioning component - fixed bug that allowed individual owner form to be submitted without proper form validation. 

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -24,7 +24,7 @@ export class BusinessOwnerForm {
   @Prop() authToken: string;
   @Prop() ownerId?: string;
   @Prop() businessId?: string;
-  @Prop() allowOptionalFields?: boolean;
+  @Prop() allowOptionalFields?: boolean = false;
   @Prop() removeOwner: (id: string) => void;
   @Prop() newFormOpen?: boolean;
   @Prop() ownersLength?: number;
@@ -170,12 +170,15 @@ export class BusinessOwnerForm {
 
   @Method()
   async submit(): Promise<boolean> {
-    return this.sendData();
+    const isValid = await this.validate();
+    if (isValid) {
+      return this.sendData();
+    }
   }
 
-  validateAndSubmit = (event: any) => {
+  validateAndSubmit = async (event: any) => {
     event.preventDefault();
-    const isValid = this.formController.validate();
+    const isValid = await this.validate();
     if (isValid) {
       this.submit();
     }

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -24,7 +24,7 @@ export class BusinessOwnerForm {
   @Prop() authToken: string;
   @Prop() ownerId?: string;
   @Prop() businessId?: string;
-  @Prop() allowOptionalFields?: boolean = false;
+  @Prop() allowOptionalFields?: boolean;
   @Prop() removeOwner: (id: string) => void;
   @Prop() newFormOpen?: boolean;
   @Prop() ownersLength?: number;


### PR DESCRIPTION
### Fixes validation bug in owner form part of PaymentProvisioning component


Links
-----

Closes #489 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA



Developer QA steps
--------------------

- [ ] Ensure form submission on owners-forms works properly with validation being called before allowing submit when clicking `Add` or `Update` on individual form
- [ ] Ensure form submission on owners-forms works properly with validation being called before allowing submit when clicking `Submit` at the bottom of the form. 

