### PR TITLE
Improve validations and logic for identity forms (Representatives and Owners)

### DIFF
--- a/.changeset/olive-beers-push.md
+++ b/.changeset/olive-beers-push.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+ - BusinessForm and PaymentProvisioning components: Improved form validations for representative and owner sections. 

--- a/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { PHONE_MASKS } from '../../../../utils/form-input-masks';
+import { PHONE_MASKS, SSN_MASK } from '../../../../utils/form-input-masks';
 import { deconstructDate } from '../../utils/helpers';
 
 @Component({
@@ -116,12 +116,13 @@ export class BusinessRepresentative {
               />
             </div>
             <div class="col-12 col-md-8">
-              <form-control-number
+              <form-control-number-masked
                 name="identification_number"
                 label="SSN"
                 defaultValue={representativeDefaultValue?.identification_number}
                 error={this.errors.identification_number}
                 inputHandler={this.inputHandler}
+                mask={SSN_MASK}
               />
             </div>
             <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State, Event, EventEmitter, Method, Watch } from '@stencil/core';
 import { FormController } from '../../form/form';
-import { PHONE_MASKS } from '../../../utils/form-input-masks';
+import { PHONE_MASKS, SSN_MASK } from '../../../utils/form-input-masks';
 import { Api, IApiResponse } from '../../../api';
 import { Identity, Owner } from '../../../api/Identity';
 import { parseIdentityInfo } from '../utils/payload-parsers';
@@ -267,12 +267,13 @@ export class BusinessOwnerForm {
                 />
               </div>
               <div class="col-12 col-md-8">
-                <form-control-number
+                <form-control-number-masked
                   name="identification_number"
                   label="SSN"
                   defaultValue={ownerDefaultValue?.identification_number}
                   error={this.errors.identification_number}
                   inputHandler={this.inputHandler}
+                  mask={SSN_MASK}
                 />
               </div>
               <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { PHONE_MASKS } from '../../../../utils/form-input-masks';
+import { PHONE_MASKS, SSN_MASK } from '../../../../utils/form-input-masks';
 import Api, { IApiResponse } from '../../../../api/Api';
 import { IBusiness } from '../../../../api/Business';
 import { parseIdentityInfo } from '../../utils/payload-parsers';
@@ -186,12 +186,13 @@ export class BusinessRepresentativeFormStep {
                 />
               </div>
               <div class="col-12 col-md-8">
-                <form-control-number
+                <form-control-number-masked
                   name="identification_number"
                   label="SSN"
                   defaultValue={representativeDefaultValue?.identification_number}
                   error={this.errors.identification_number}
                   inputHandler={this.inputHandler}
+                  mask={SSN_MASK}
                 />
               </div>
               <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/schemas/business-address-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-address-schema.ts
@@ -1,31 +1,11 @@
 import { object, string } from 'yup';
-import StateOptions from '../../../utils/state-options';
-import { transformEmptyString } from './schema-helpers';
-
-const lineOneValidation = string()
-  .min(5, 'Address must be at least 5 characters')
-  .max(100, 'Address must be less than 100 characters')
-  .matches(/^(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/, 'Enter valid address line 1')
-  .transform(transformEmptyString);
-
-const lineTwoValidation = string()
-  .max(100, 'Address must be less than 100 characters')
-  .matches(/^(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/, 'Enter valid address line 2')
-  .transform(transformEmptyString);
-
-const cityValidation = string()
-  .min(2, 'City must be at least 2 characters')
-  .max(50, 'City must be less than 50 characters')
-  .matches(/^(?!^\s+$)[a-zA-Z\s]*$/, 'Enter valid city')
-  .transform(transformEmptyString);
-
-const stateValidation = string()
-  .oneOf(StateOptions.map((option) => option.value), 'Select state')
-  .transform(transformEmptyString);
-
-const postalValidation = string()
-  .matches(/^[0-9]{5}$/, 'Enter valid postal code')
-  .transform(transformEmptyString);
+import { 
+  cityValidation,
+  lineOneValidation, 
+  lineTwoValidation,
+  postalValidation,
+  stateValidation
+} from './schema-validations';
 
 export const addressSchema = (allowOptionalFields?: boolean) => {
   const schema = object({

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -1,55 +1,18 @@
-import { object, string } from 'yup';
-import { BusinessTypeOptions } from '../utils/business-form-types';
-import {
-  businessNameRegex,
-  phoneRegex,
-  stringLettersOnlyRegex,
-  taxIdRegex,
-  transformEmptyString,
-  urlRegex }
-  from './schema-helpers';
-
-const nameValidation = string()
-  .min(2, 'Name must be at least 2 characters')
-  .max(100, 'Name must be less than 100 characters')
-  .matches(businessNameRegex, 'Enter valid business name')
-  .transform(transformEmptyString);
-
-const doingBusinessAsValidation = string()
-  .min(2, 'Name must be at least 2 characters')
-  .max(100, 'Name must be less than 100 characters')
-  .matches(businessNameRegex, 'Enter valid doing business as')
-  .transform(transformEmptyString);
-
-const websiteUrlValidation = string()
-  .matches(urlRegex, 'Enter valid website url')
-  .transform(transformEmptyString);
-
-const emailValidation = string()
-  .email('Enter valid email')
-  .transform(transformEmptyString);
-
-const phoneValidation = string()
-  .matches(phoneRegex, 'Enter valid phone number')
-  .transform(transformEmptyString);
-
-const businessTypeValidation = string()
-  .oneOf(BusinessTypeOptions.map((option) => option.value), 'Select business type')
-  .transform(transformEmptyString);
-
-const industryValidation = string()
-  .min(2, 'Industry must be at least 2 characters')
-  .max(50, 'Industry must be less than 50 characters')
-  .matches(stringLettersOnlyRegex, 'Enter valid industry')
-  .transform(transformEmptyString);
-
-const taxIdValidation = string()
-  .matches(taxIdRegex, 'Enter valid tax id')
-  .transform(transformEmptyString);
+import { object } from 'yup';
+import { 
+  businessTypeValidation,
+  doingBusinessAsValidation,
+  emailValidation,
+  industryValidation,
+  businessNameValidation, 
+  phoneValidation, 
+  taxIdValidation, 
+  websiteUrlValidation
+} from './schema-validations';
 
 export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
   const schema = object({
-    legal_name: nameValidation.required('Enter legal name'),
+    legal_name: businessNameValidation.required('Enter legal name'),
     website_url: websiteUrlValidation.required('Enter business website url'),
     email: emailValidation.required('Enter business email'),
     phone: phoneValidation.required('Enter phone number'),
@@ -60,7 +23,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
   });
 
   const easySchema = object({
-    legal_name: nameValidation.required('Enter legal name'),
+    legal_name: businessNameValidation.required('Enter legal name'),
     website_url: websiteUrlValidation.nullable(),
     email: emailValidation.nullable(),
     phone: phoneValidation.nullable(),

--- a/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
@@ -1,45 +1,29 @@
-import { object, string } from 'yup';
+import { object } from 'yup';
 import { addressSchema } from './business-address-schema';
-import { phoneRegex, transformEmptyString } from './schema-helpers';
-
-const dobValidation = (title: string) => {
-  return (
-    string()
-    .test('min', 'Enter a valid date', (value) => {
-      const date = new Date(value);
-      const minDate = new Date('1902-01-01');
-      return date >= minDate;
-    })
-    .test('age', `${title} must be at least 18 years old`, (value) => {
-      const date = new Date(value);
-      const minAgeDate = new Date();
-      minAgeDate.setFullYear(minAgeDate.getFullYear() - 18);
-      return date <= minAgeDate;
-    })
-    .transform(transformEmptyString)
-  )
-};
+import { 
+  dobValidation, 
+  emailValidation, 
+  identityNameValidation, 
+  phoneValidation, 
+  ssnValidation
+} from './schema-validations';
 
 export const identitySchema = (title: string, allowOptionalFields?: boolean) => {
   const schema = object({
-    name: string().required(`Enter ${title} name`),
-    email: string()
-      .email(`Enter valid ${title} email`)
-      .required(`Enter ${title} email`),
-    phone: string().matches(phoneRegex, 'Enter valid phone number').required('Enter phone number'),
+    name: identityNameValidation.required(`Enter ${title} name`),
+    email: emailValidation.required(`Enter ${title} email`),
+    phone: phoneValidation.required('Enter phone number'),
     dob_full: dobValidation(title).required('Enter date of birth'),
-    identification_number: string(),
+    identification_number: ssnValidation.required('Enter SSN'),
     address: addressSchema(allowOptionalFields),
   });
 
   const easySchema = object({
-    name: string().required(`Enter ${title} name`),
-    email: string()
-      .email(`Enter valid ${title} email`)
-      .nullable(),
-    phone: string().matches(phoneRegex, 'Enter valid phone number').nullable(),
+    name: identityNameValidation.required(`Enter ${title} name`),
+    email: emailValidation.nullable(),
+    phone: phoneValidation.nullable(),
     dob_full: dobValidation(title).nullable('Enter date of birth'),
-    identification_number: string().nullable(),
+    identification_number: ssnValidation.nullable(),
     address: addressSchema(allowOptionalFields),
   });
 

--- a/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
@@ -22,7 +22,7 @@ export const identitySchema = (title: string, allowOptionalFields?: boolean) => 
     name: identityNameValidation.required(`Enter ${title} name`),
     email: emailValidation.nullable(),
     phone: phoneValidation.nullable(),
-    dob_full: dobValidation(title).nullable('Enter date of birth'),
+    dob_full: dobValidation(title).nullable(),
     identification_number: ssnValidation.nullable(),
     address: addressSchema(allowOptionalFields),
   });

--- a/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
@@ -4,25 +4,28 @@ import {
   dobValidation, 
   emailValidation, 
   identityNameValidation, 
+  identityTitleValidation, 
   phoneValidation, 
   ssnValidation
 } from './schema-validations';
 
-export const identitySchema = (title: string, allowOptionalFields?: boolean) => {
+export const identitySchema = (role: string, allowOptionalFields?: boolean) => {
   const schema = object({
-    name: identityNameValidation.required(`Enter ${title} name`),
-    email: emailValidation.required(`Enter ${title} email`),
+    name: identityNameValidation.required(`Enter ${role} name`),
+    title: identityTitleValidation.required(`Enter ${role} title`),
+    email: emailValidation.required(`Enter ${role} email`),
     phone: phoneValidation.required('Enter phone number'),
-    dob_full: dobValidation(title).required('Enter date of birth'),
+    dob_full: dobValidation(role).required('Enter date of birth'),
     identification_number: ssnValidation.required('Enter SSN'),
     address: addressSchema(allowOptionalFields),
   });
 
   const easySchema = object({
-    name: identityNameValidation.required(`Enter ${title} name`),
+    name: identityNameValidation.required(`Enter ${role} name`),
+    title: identityTitleValidation.nullable(),
     email: emailValidation.nullable(),
     phone: phoneValidation.nullable(),
-    dob_full: dobValidation(title).nullable(),
+    dob_full: dobValidation(role).nullable(),
     identification_number: ssnValidation.nullable(),
     address: addressSchema(allowOptionalFields),
   });

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
@@ -12,3 +12,5 @@ export const urlRegex = /^(?:http(s)?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,2
 export const taxIdRegex = /^\d{9}$/;
 
 export const stringLettersOnlyRegex = /^(?!^\s+$)[a-zA-Z\s]*$/;
+
+export const ssnRegex = /^(?!000|666|9\d{2})\d{3}(?!00)\d{2}(?!0000)\d{4}$/;

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -1,0 +1,48 @@
+import { string } from "yup";
+import { BusinessTypeOptions } from "../utils/business-form-types";
+import { 
+  businessNameRegex, 
+  phoneRegex, 
+  stringLettersOnlyRegex, 
+  taxIdRegex, 
+  transformEmptyString, 
+  urlRegex } 
+  from "./schema-helpers";
+
+export const businessNameValidation = string()
+  .min(2, 'Name must be at least 2 characters')
+  .max(100, 'Name must be less than 100 characters')
+  .matches(businessNameRegex, 'Enter valid business name')
+  .transform(transformEmptyString);
+
+export const doingBusinessAsValidation = string()
+  .min(2, 'Name must be at least 2 characters')
+  .max(100, 'Name must be less than 100 characters')
+  .matches(businessNameRegex, 'Enter valid doing business as')
+  .transform(transformEmptyString);
+
+export const websiteUrlValidation = string()
+  .matches(urlRegex, 'Enter valid website url')
+  .transform(transformEmptyString);
+
+export const emailValidation = string()
+  .email('Enter valid email')
+  .transform(transformEmptyString);
+
+export const phoneValidation = string()
+  .matches(phoneRegex, 'Enter valid phone number')
+  .transform(transformEmptyString);
+
+export const businessTypeValidation = string()
+  .oneOf(BusinessTypeOptions.map((option) => option.value), 'Select business type')
+  .transform(transformEmptyString);
+
+export const industryValidation = string()
+  .min(2, 'Industry must be at least 2 characters')
+  .max(50, 'Industry must be less than 50 characters')
+  .matches(stringLettersOnlyRegex, 'Enter valid industry')
+  .transform(transformEmptyString);
+
+export const taxIdValidation = string()
+  .matches(taxIdRegex, 'Enter valid tax id')
+  .transform(transformEmptyString);

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -61,7 +61,13 @@ export const identityNameValidation = string()
   .matches(stringLettersOnlyRegex, 'Enter valid name')
   .transform(transformEmptyString);
 
-export const dobValidation = (title: string) => {
+export const identityTitleValidation = string()
+  .min(2, 'Title must be at least 2 characters')
+  .max(50, 'Title must be less than 50 characters')
+  .matches(stringLettersOnlyRegex, 'Enter valid title')
+  .transform(transformEmptyString);
+
+export const dobValidation = (role: string) => {
   return (
     string()
     .test('min', 'Enter a valid date', (value) => {
@@ -69,7 +75,7 @@ export const dobValidation = (title: string) => {
       const minDate = new Date('1902-01-01');
       return date >= minDate;
     })
-    .test('age', `${title} must be at least 18 years old`, (value) => {
+    .test('age', `${role} must be at least 18 years old`, (value) => {
       const date = new Date(value);
       const minAgeDate = new Date();
       minAgeDate.setFullYear(minAgeDate.getFullYear() - 18);
@@ -115,4 +121,3 @@ export const stateValidation = string()
 export const postalValidation = string()
   .matches(/^[0-9]{5}$/, 'Enter valid postal code')
   .transform(transformEmptyString);
-  

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -1,13 +1,27 @@
 import { string } from "yup";
 import { BusinessTypeOptions } from "../utils/business-form-types";
+import StateOptions from "../../../utils/state-options";
 import { 
   businessNameRegex, 
   phoneRegex, 
+  ssnRegex, 
   stringLettersOnlyRegex, 
   taxIdRegex, 
   transformEmptyString, 
   urlRegex } 
   from "./schema-helpers";
+
+// Common Validations
+
+export const emailValidation = string()
+  .email('Enter valid email')
+  .transform(transformEmptyString);
+
+export const phoneValidation = string()
+  .matches(phoneRegex, 'Enter valid phone number')
+  .transform(transformEmptyString);
+
+// Core Info Validations
 
 export const businessNameValidation = string()
   .min(2, 'Name must be at least 2 characters')
@@ -25,14 +39,6 @@ export const websiteUrlValidation = string()
   .matches(urlRegex, 'Enter valid website url')
   .transform(transformEmptyString);
 
-export const emailValidation = string()
-  .email('Enter valid email')
-  .transform(transformEmptyString);
-
-export const phoneValidation = string()
-  .matches(phoneRegex, 'Enter valid phone number')
-  .transform(transformEmptyString);
-
 export const businessTypeValidation = string()
   .oneOf(BusinessTypeOptions.map((option) => option.value), 'Select business type')
   .transform(transformEmptyString);
@@ -46,3 +52,67 @@ export const industryValidation = string()
 export const taxIdValidation = string()
   .matches(taxIdRegex, 'Enter valid tax id')
   .transform(transformEmptyString);
+
+// Identity Validations
+
+export const identityNameValidation = string()
+  .min(2, 'Name must be at least 2 characters')
+  .max(100, 'Name must be less than 100 characters')
+  .matches(stringLettersOnlyRegex, 'Enter valid name')
+  .transform(transformEmptyString);
+
+export const dobValidation = (title: string) => {
+  return (
+    string()
+    .test('min', 'Enter a valid date', (value) => {
+      const date = new Date(value);
+      const minDate = new Date('1902-01-01');
+      return date >= minDate;
+    })
+    .test('age', `${title} must be at least 18 years old`, (value) => {
+      const date = new Date(value);
+      const minAgeDate = new Date();
+      minAgeDate.setFullYear(minAgeDate.getFullYear() - 18);
+      return date <= minAgeDate;
+    })
+    .transform(transformEmptyString)
+  )
+};
+
+export const ssnValidation = string()
+  .matches(ssnRegex, 'Enter valid SSN')
+  .test('not-repeat', 'Enter valid SSN', (value) => {
+    return !/^(\d)\1+$/.test(value);
+  })
+  .test('not-seq', 'Enter valid SSN', (value) => {
+    return value !== '123456789';
+  })
+  .transform(transformEmptyString);
+
+// Address Validations
+
+export const lineOneValidation = string()
+  .min(5, 'Address must be at least 5 characters')
+  .max(100, 'Address must be less than 100 characters')
+  .matches(/^(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/, 'Enter valid address line 1')
+  .transform(transformEmptyString);
+
+export const lineTwoValidation = string()
+  .max(100, 'Address must be less than 100 characters')
+  .matches(/^(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/, 'Enter valid address line 2')
+  .transform(transformEmptyString);
+
+export const cityValidation = string()
+  .min(2, 'City must be at least 2 characters')
+  .max(50, 'City must be less than 50 characters')
+  .matches(/^(?!^\s+$)[a-zA-Z\s]*$/, 'Enter valid city')
+  .transform(transformEmptyString);
+
+export const stateValidation = string()
+  .oneOf(StateOptions.map((option) => option.value), 'Select state')
+  .transform(transformEmptyString);
+
+export const postalValidation = string()
+  .matches(/^[0-9]{5}$/, 'Enter valid postal code')
+  .transform(transformEmptyString);
+  

--- a/packages/webcomponents/src/components/business-forms/utils/payload-parsers.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/payload-parsers.ts
@@ -38,8 +38,9 @@ export const parseIdentityInfo = (values: any) => {
   delete values.address.id;
   delete values.address.created_at;
   delete values.address.updated_at;
-  delete values.business_id
+  delete values.business_id;
   delete values.dob_full;
+  delete values.ssn_last4;
 
   return values;
 }

--- a/packages/webcomponents/src/utils/form-input-masks.ts
+++ b/packages/webcomponents/src/utils/form-input-masks.ts
@@ -3,3 +3,5 @@ export const PHONE_MASKS = {
 };
 
 export const TAX_ID_MASKS = { US: '00-0000000' };
+
+export const SSN_MASK = '000-00-0000';


### PR DESCRIPTION
### Improve validations and logic for identity forms (Representatives and Owners)

~NOTE: This PR is in line after #488 - that one needs to be reviewed and merged first.~
This one is ready to go! 

This PR builds on the previous one and completes validations for the identity forms. 

This PR does the following:

- Moves schema validations used in schema files to `schema-validations.ts`
- Adds validation logic to identity schemas. 
- changes SSN field in identity form to `form-control-number-masked`, in conjunction with its own validation logic. 

Links
-----

Closes #458

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------

BusinessForm:

- [x] Ensure that form can be completed as expected with new validation logic for Representative Form

PaymentProvisioning:

- [x] (`allow-optional-fields === false` Ensure that form can be completed as expected with new validation logic for Representative Form and Owner Forms
- [x] (`allow-optional-fields === true` Ensure that form can be completed as expected with new validation logic for Representative Form and Owner Forms




