### PR TITLE
Fix ready event for card-form and bank-account-form

### DIFF
--- a/.changeset/wise-parrots-appear.md
+++ b/.changeset/wise-parrots-appear.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+ - Fixed bug preventing `CardForm` and `BankAccountForm` from consistently emitting `ready` event. 

--- a/packages/webcomponents/src/components/payment-method-form/payment-method-form.tsx
+++ b/packages/webcomponents/src/components/payment-method-form/payment-method-form.tsx
@@ -126,12 +126,12 @@ export class PaymentMethodForm {
           src={this.getIframeSrc()}
           ref={el => {
             this.iframeElement = el as HTMLIFrameElement;
+            this.initializeFrameCommunicationService();
           }}
           onLoad={() => {
             iFrameResize({
               scrollbars: false,
             }, this.iframeElement);
-            this.initializeFrameCommunicationService();
             this.sendStyleOverrides();
           }}
         ></iframe>


### PR DESCRIPTION
### Fix ready event for card-form and bank-account-form


Links
-----

Closes #498 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------

- [ ] Ensure `ready` event is being emitted by `CardForm`
- [ ] Ensure `ready` event is being emitted by `BankAccountForm`

