### PR TITLE
Check for PO Box in Address Validations

### DIFF
--- a/.changeset/smart-lies-reflect.md
+++ b/.changeset/smart-lies-reflect.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- `PaymentProvisioning` and `BusinessForm` components: updated address validation to prevent users from submitting PO Box addresses. 

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
@@ -17,4 +17,6 @@ export const numbersOnlyRegex = /^\d+$/;
 
 export const ssnRegex = /^(?!000|666|9\d{2})\d{3}(?!00)\d{2}(?!0000)\d{4}$/;
 
-export const streetAddressRegex = /^(?!.*PO Box)(?!.*P\.O\. Box)(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/;
+export const streetAddressRegex = /^(?!^\s+$)[a-zA-Z0-9\s,&.-]*$/;
+
+export const poBoxRegex = /P\.?\s?O\.?\s?Box|Postal\sBox/i;

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
@@ -16,3 +16,5 @@ export const stringLettersOnlyRegex = /^(?!^\s+$)[a-zA-Z\s]*$/;
 export const numbersOnlyRegex = /^\d+$/;
 
 export const ssnRegex = /^(?!000|666|9\d{2})\d{3}(?!00)\d{2}(?!0000)\d{4}$/;
+
+export const streetAddressRegex = /^(?!.*PO Box)(?!.*P\.O\. Box)(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/;

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -6,6 +6,7 @@ import {
   numbersOnlyRegex, 
   phoneRegex, 
   ssnRegex, 
+  streetAddressRegex, 
   stringLettersOnlyRegex, 
   taxIdRegex, 
   transformEmptyString, 
@@ -115,18 +116,18 @@ export const ssnValidation = string()
 export const lineOneValidation = string()
   .min(5, 'Address must be at least 5 characters')
   .max(100, 'Address must be less than 100 characters')
-  .matches(/^(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/, 'Enter valid address line 1')
+  .matches(streetAddressRegex, 'Enter valid address line 1')
   .transform(transformEmptyString);
 
 export const lineTwoValidation = string()
   .max(100, 'Address must be less than 100 characters')
-  .matches(/^(?!^\s+$)[a-zA-Z0-9\s,.'-]*$/, 'Enter valid address line 2')
+  .matches(streetAddressRegex, 'Enter valid address line 2')
   .transform(transformEmptyString);
 
 export const cityValidation = string()
   .min(2, 'City must be at least 2 characters')
   .max(50, 'City must be less than 50 characters')
-  .matches(/^(?!^\s+$)[a-zA-Z\s]*$/, 'Enter valid city')
+  .matches(stringLettersOnlyRegex, 'Enter valid city')
   .transform(transformEmptyString);
 
 export const stateValidation = string()

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -5,6 +5,7 @@ import {
   businessNameRegex, 
   numbersOnlyRegex, 
   phoneRegex, 
+  poBoxRegex, 
   ssnRegex, 
   streetAddressRegex, 
   stringLettersOnlyRegex, 
@@ -117,11 +118,17 @@ export const lineOneValidation = string()
   .min(5, 'Address must be at least 5 characters')
   .max(100, 'Address must be less than 100 characters')
   .matches(streetAddressRegex, 'Enter valid address line 1')
+  .test('not-po-box', 'A PO Box is not a valid address entry', (value) => {
+    return !poBoxRegex.test(value);
+  })
   .transform(transformEmptyString);
 
 export const lineTwoValidation = string()
   .max(100, 'Address must be less than 100 characters')
   .matches(streetAddressRegex, 'Enter valid address line 2')
+  .test('not-po-box', 'A PO Box is not a valid address entry', (value) => {
+    return !poBoxRegex.test(value);
+  })
   .transform(transformEmptyString);
 
 export const cityValidation = string()


### PR DESCRIPTION
### Check for PO Box in Address Validations

Request from customer success team - ensure that clients cannot enter `PO Box` or `P.O. Box` in address lines 1 or 2 for business or identity addresses. 

NOTE: This should be merged after PR #501 


Links
-----

Closes #492

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------

- [ ] Verify that users are unable to submit address updates if `PO Box` is present in Line 1 or Line 2. `P.O. Box`, `Postal Box`, should also be captured in validation and fire errors. 
- [ ] Users should still be able to submit strings that don't include PO Box or its variations. 

