### PR TITLE
Add business_structure back to business forms

### DIFF
--- a/.changeset/witty-months-refuse.md
+++ b/.changeset/witty-months-refuse.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- `BusinessForm` and `PaymentProvisioning` - revert change that removed `business_structure` option from form in. 

--- a/packages/webcomponents/src/api/Business.ts
+++ b/packages/webcomponents/src/api/Business.ts
@@ -9,6 +9,22 @@ export enum BusinessType {
   government_entity = 'government_entity',
 }
 
+export enum BusinessStructure {
+  sole_proprietorship = 'sole_proprietorship',
+  single_llc = 'single_llc',
+  multi_llc = 'multi_llc',
+  private_partnership = 'private_partnership',
+  private_corporation = 'private_corporation',
+  unincorporated_association = 'unincorporated_association',
+  public_partnership = 'public_partnership',
+  public_corporation = 'public_corporation',
+  incorporated = 'incorporated',
+  unincorporated = 'unincorporated',
+  government_unit = 'government_unit',
+  government_instrumentality = 'government_instrumentality',
+  tax_exempt_government_instrumentality = 'tax_exempt_government_instrumentality',
+}
+
 export interface IAddress {
   id?: string;
   platform_account_id?: string;
@@ -94,6 +110,7 @@ export class AdditionalQuestions implements IAdditionalQuestions {
 
 export interface ICoreBusinessInfo {
   business_type?: BusinessType;
+  business_structure?: BusinessStructure;
   legal_name?: string;
   doing_business_as?: string;
   industry?: string;
@@ -105,6 +122,7 @@ export interface ICoreBusinessInfo {
 
 export class CoreBusinessInfo implements ICoreBusinessInfo {
   public business_type: BusinessType;
+  public business_structure: BusinessStructure;
   public legal_name: string;
   public doing_business_as: string;
   public industry: string;
@@ -115,6 +133,7 @@ export class CoreBusinessInfo implements ICoreBusinessInfo {
 
   constructor(coreBusinessInfo: ICoreBusinessInfo) {
     this.business_type = coreBusinessInfo.business_type;
+    this.business_structure = coreBusinessInfo.business_structure;
     this.legal_name = coreBusinessInfo.legal_name;
     this.doing_business_as = coreBusinessInfo.doing_business_as;
     this.industry = coreBusinessInfo.industry;
@@ -128,6 +147,7 @@ export class CoreBusinessInfo implements ICoreBusinessInfo {
 export interface IBusiness {
   additional_questions: IAdditionalQuestions | {};
   business_type: BusinessType;
+  business_structure: BusinessStructure;
   bank_accounts: BankAccount[];
   created_at: string;
   documents: Document[];
@@ -151,6 +171,7 @@ export interface IBusiness {
 export class Business implements IBusiness {
   public additional_questions: IAdditionalQuestions | {};
   public business_type: BusinessType;
+  public business_structure: BusinessStructure;
   public bank_accounts: BankAccount[];
   public created_at: string;
   public documents: Document[];
@@ -174,6 +195,7 @@ export class Business implements IBusiness {
     this.additional_questions = business.additional_questions || {};
     this.bank_accounts = business.bank_accounts;
     this.business_type = business.business_type;
+    this.business_structure = business.business_structure;
     this.created_at = business.created_at;
     this.documents = business.documents;
     this.doing_business_as = business.doing_business_as;

--- a/packages/webcomponents/src/components/business-details/generic-info-details/generic-info-details.tsx
+++ b/packages/webcomponents/src/components/business-details/generic-info-details/generic-info-details.tsx
@@ -29,6 +29,10 @@ export class GenericInfoDetails {
                 title="Business Type"
                 value={snakeCaseToHumanReadable(this.business?.business_type)}
               />
+              <DetailItem
+                title="Business Structure"
+                value={snakeCaseToHumanReadable(this.business?.business_structure)}
+              />
               <DetailItem title="Industry" value={this.business?.industry} />
             </div>
             <div class="col-12 col-md-6">

--- a/packages/webcomponents/src/components/business-details/generic-info-details/test/__snapshots__/generic-info-details.spec.tsx.snap
+++ b/packages/webcomponents/src/components/business-details/generic-info-details/test/__snapshots__/generic-info-details.spec.tsx.snap
@@ -36,6 +36,14 @@ exports[`GenericInfoDetails should render 1`] = `
           </div>
           <div class="d-table-row gap-2">
             <span class="d-table-cell fw-bold px-2" part="detail-section-item-title">
+              Business Structure
+            </span>
+            <span class="d-table-cell flex-1 px-2 text-wrap" part="detail-section-item-data">
+              Sole Proprietorship
+            </span>
+          </div>
+          <div class="d-table-row gap-2">
+            <span class="d-table-cell fw-bold px-2" part="detail-section-item-title">
               Industry
             </span>
             <span class="d-table-cell flex-1 px-2 text-wrap" part="detail-section-item-data">

--- a/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
@@ -1,5 +1,5 @@
 import { Component, Host, h, Prop, State } from '@stencil/core';
-import { BusinessTypeOptions } from '../../utils/business-form-types';
+import { BusinessStructureOptions, BusinessTypeOptions } from '../../utils/business-form-types';
 import { FormController } from '../../../form/form';
 import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
@@ -81,6 +81,16 @@ export class BusinessCoreInfo {
               />
             </div>
             <div class="col-12 col-md-6">
+              <form-control-select
+                name="business_structure"
+                label="Business Structure"
+                options={BusinessStructureOptions}
+                defaultValue={coreInfoDefaultValue.business_structure}
+                error={this.errors.business_structure}
+                inputHandler={this.inputHandler}
+              />
+            </div>
+            <div class="col-12 col-md-6">
               <form-control-text
                 name="industry"
                 label="Industry"
@@ -89,7 +99,7 @@ export class BusinessCoreInfo {
                 inputHandler={this.inputHandler}
               />
             </div>
-            <div class="col-12">
+            <div class="col-12 col-md-6">
               <form-control-number-masked
                 name="tax_id"
                 label="Tax ID"

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -7,7 +7,7 @@ import { businessCoreInfoSchema } from '../../schemas/business-core-info-schema'
 import { config } from '../../../../../config';
 import { parseCoreInfo } from '../../utils/payload-parsers';
 import { flattenNestedObject } from '../../../../utils/utils';
-import { BusinessFormServerErrorEvent, BusinessFormServerErrors, BusinessFormSubmitEvent, BusinessTypeOptions } from '../../utils/business-form-types';
+import { BusinessFormServerErrorEvent, BusinessFormServerErrors, BusinessFormSubmitEvent, BusinessStructureOptions, BusinessTypeOptions } from '../../utils/business-form-types';
 
 /**
  *
@@ -146,6 +146,16 @@ export class BusinessCoreInfoFormStep {
                 />
               </div>
               <div class="col-12 col-md-6">
+                <form-control-select
+                  name="business_structure"
+                  label="Business Structure"
+                  options={BusinessStructureOptions}
+                  defaultValue={coreInfoDefaultValue.business_structure}
+                  error={this.errors.business_structure}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-6">
                 <form-control-text
                   name="industry"
                   label="Industry"
@@ -154,7 +164,7 @@ export class BusinessCoreInfoFormStep {
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12">
+              <div class="col-12 col-md-6">
                 <form-control-number-masked
                   name="tax_id"
                   label="Tax ID"

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -7,7 +7,8 @@ import {
   businessNameValidation, 
   phoneValidation, 
   taxIdValidation, 
-  websiteUrlValidation
+  websiteUrlValidation,
+  businessStructureValidation
 } from './schema-validations';
 
 export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
@@ -18,6 +19,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     phone: phoneValidation.required('Enter phone number'),
     doing_business_as: doingBusinessAsValidation.required('Enter doing business as'),
     business_type: businessTypeValidation.required('Select business type'),
+    business_structure: businessStructureValidation.required('Select business structure'),
     industry: industryValidation.required('Enter a business industry'),
     tax_id: taxIdValidation.required('Enter tax id'),
   });
@@ -29,6 +31,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     phone: phoneValidation.nullable(),
     doing_business_as: doingBusinessAsValidation.nullable(),
     business_type: businessTypeValidation.nullable(),
+    business_structure: businessStructureValidation.nullable(),
     industry: industryValidation.nullable(),
     tax_id: taxIdValidation.nullable(),
   });

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -1,5 +1,5 @@
 import { string } from "yup";
-import { BusinessTypeOptions } from "../utils/business-form-types";
+import { BusinessStructureOptions, BusinessTypeOptions } from "../utils/business-form-types";
 import StateOptions from "../../../utils/state-options";
 import { 
   businessNameRegex, 
@@ -41,6 +41,10 @@ export const websiteUrlValidation = string()
 
 export const businessTypeValidation = string()
   .oneOf(BusinessTypeOptions.map((option) => option.value), 'Select business type')
+  .transform(transformEmptyString);
+
+export const businessStructureValidation = string()
+  .oneOf(BusinessStructureOptions.map((option) => option.value), 'Select business structure')
   .transform(transformEmptyString);
 
 export const industryValidation = string()

--- a/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
@@ -1,4 +1,4 @@
-import { BusinessType } from "../../../api/Business";
+import { BusinessStructure, BusinessType } from "../../../api/Business";
 
 export interface BusinessFormSubmitEvent {
   data: any;
@@ -84,3 +84,65 @@ export const BusinessTypeOptions: { label: string; value: BusinessType | string 
     value: BusinessType.government_entity,
   },
 ];
+
+export const BusinessStructureOptions: {
+  label: string;
+  value: BusinessStructure | string;
+}[] = [
+    {
+      label: 'Choose business structure',
+      value: '',
+    },
+    {
+      label: 'Sole Proprietorship',
+      value: BusinessStructure.sole_proprietorship,
+    },
+    {
+      label: 'LLC (Single)',
+      value: BusinessStructure.single_llc,
+    },
+    {
+      label: 'LLC (Multiple)',
+      value: BusinessStructure.multi_llc,
+    },
+    {
+      label: 'Private Partnership',
+      value: BusinessStructure.private_partnership,
+    },
+    {
+      label: 'Private Corporation',
+      value: BusinessStructure.private_corporation,
+    },
+    {
+      label: 'Unincorporated Association',
+      value: BusinessStructure.unincorporated_association,
+    },
+    {
+      label: 'Public Partnership',
+      value: BusinessStructure.public_partnership,
+    },
+    {
+      label: 'Public Corporation',
+      value: BusinessStructure.public_corporation,
+    },
+    {
+      label: 'Incorporated',
+      value: BusinessStructure.incorporated,
+    },
+    {
+      label: 'Unincorporated',
+      value: BusinessStructure.unincorporated,
+    },
+    {
+      label: 'Government Unit',
+      value: BusinessStructure.government_unit,
+    },
+    {
+      label: 'Government Instrumentality',
+      value: BusinessStructure.government_instrumentality,
+    },
+    {
+      label: 'Tax Exempt Government Instrumentality',
+      value: BusinessStructure.tax_exempt_government_instrumentality,
+    },
+  ];


### PR DESCRIPTION
### Add business_structure back to business forms

reverts change that removed `business_structure` from forms. Requested by back-end to revert this change 


Links
-----

Closes #508 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA



