### PR TITLE
Checkout theme switcher

### DIFF
--- a/apps/docs/stories/components/checkout.stories.tsx
+++ b/apps/docs/stories/components/checkout.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { withActions } from '@storybook/addon-actions/decorator';
 import { StoryBaseArgs } from '../utils';
-import theme from '../theme';
+import themes, { ThemeNames } from '../theme';
 
 import '@justifi/webcomponents/dist/module/justifi-checkout';
 
@@ -12,10 +12,17 @@ const meta: Meta = {
   component: 'justifi-checkout',
   args: {
     ...storyBaseArgs.args,
-    'checkout-id': '123'
+    'checkout-id': '123',
+    theme: ThemeNames.Light
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    theme: {
+      options: Object.values(ThemeNames),
+      control: {
+        type: 'select',
+      }
+    },
     'checkout-id': {
       description: 'tbd',
       table: {
@@ -53,10 +60,11 @@ const meta: Meta = {
 
 export const Basic: StoryObj = {};
 Basic.decorators = [
-  (story: any) => {
+  (story: any, storyArgs: any) => {
     // Import the style here to not pollute other framework stories
+    const selectedTheme = storyArgs.args.theme as ThemeNames;
     const styleElement = document.createElement('style');
-    styleElement.textContent = theme;
+    styleElement.textContent = themes[selectedTheme];
 
     return `${styleElement.outerHTML}${story()}`;
   },

--- a/apps/docs/stories/components/checkout.stories.tsx
+++ b/apps/docs/stories/components/checkout.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { withActions } from '@storybook/addon-actions/decorator';
 import { StoryBaseArgs } from '../utils';
-import themes, { ThemeNames } from '../theme';
+import themes, { ThemeNames } from '../themes';
 
 import '@justifi/webcomponents/dist/module/justifi-checkout';
 

--- a/apps/docs/stories/theme.tsx
+++ b/apps/docs/stories/theme.tsx
@@ -1,6 +1,24 @@
-const theme = `
-  body {  
+export enum ThemeNames {
+  None = 'None (bootstrap defaults)',
+  Light = 'Light',
+  Dark = 'Dark',
+}
+
+const light = `
+  body {
+    background-color: #f8f8f8;
   }
 `;
 
-export default theme;
+const dark = `
+  body {
+    background-color: #333;
+  }
+`;
+
+const themes = {
+  [ThemeNames.Light]: light,
+  [ThemeNames.Dark]: dark
+}
+
+export default themes;

--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -1,0 +1,125 @@
+const dark = `
+body {
+  background-color: rgb(20, 22, 25);
+}
+
+justifi-checkout {
+  display: block;
+  max-width: 400px;
+  margin: 5% auto;
+  padding: 40px;
+  background-color: rgb(28, 31, 35);
+  border-radius: 4px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+}
+
+:root {
+  /* new vars */
+  --jfi-body-color: rgb(182, 190, 201);
+  --jfi-header-color: #fff;
+  --jfi-header-border: 1px solid #fff;
+
+  /* general */
+  --jfi-load-google-font: 'Open Sans', sans-serif;
+
+  /* layout */
+  --jfi-layout-font-family: Arial, sans-serif;
+  --jfi-layout-padding: 20px;
+  --jfi-layout-form-control-spacing-x: 10px;
+  --jfi-layout-form-control-spacing-y: 10px;
+
+  /* colors */
+  --jfi-primary-color: rgb(164, 201, 245);
+
+  /* form control */
+  --jfi-form-control-background-color: transparent;
+  --jfi-form-control-border-color: rgba(255, 255, 255, 0.7);
+  --jfi-form-control-border-color-focus: rgb(164, 201, 245);
+  --jfi-form-control-border-color-error: rgb(244, 67, 54);
+  --jfi-form-control-border-width: 1px;
+  --jfi-form-control-border-bottom-width: 1px;
+  --jfi-form-control-border-left-width: 1px;
+  --jfi-form-control-border-right-width: 1px;
+  --jfi-form-control-border-top-width: 1px;
+  --jfi-form-control-border-radius: 0.375rem;
+  --jfi-form-control-border-style: solid;
+  --jfi-form-control-box-shadow: none;
+  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
+  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(244, 67, 54, 0.4);
+  --jfi-form-control-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
+  --jfi-form-control-color: rgba(255, 255, 255, 1);
+  --jfi-form-control-color-focus: rgba(255, 255, 255, 1);
+  --jfi-form-control-font-size: 1rem;
+  --jfi-form-control-font-weight: normal;
+  --jfi-form-control-line-height: 1.5;
+  --jfi-form-control-margin: 0;
+  --jfi-form-control-padding: 0.375rem 0.75rem;
+  --jfi-form-control-disabled-background-color: transparent;
+  --jfi-form-control-disabled-color: rgba(255, 255, 255, 0.5);
+
+  /* form label */
+  --jfi-form-label-color: var(--jfi-body-color);
+  --jfi-form-label-font-family: Arial, sans-serif;
+  --jfi-form-label-font-size: 16px;
+  --jfi-form-label-font-weight: normal;
+  --jfi-form-label-margin: 0 0 0.5rem 0;
+
+  /* validation messages */
+  --jfi-error-message-color: rgb(244, 67, 54);
+  --jfi-error-message-margin: 5px;
+  --jfi-error-message-font-size: 12px;
+
+  /* Below only used in justifi-payment-form */
+  /* form radio group */
+  --jfi-radio-button-background-color: transparent;
+  --jfi-radio-button-border-color: rgba(255, 255, 255, 0.7);
+
+  --jfi-radio-button-background-color-selected: rgba(164, 201, 245, .4);
+  --jfi-radio-button-border-color-selected: rgb(164, 201, 245);
+
+  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(164, 201, 245, .5);
+  --jfi-radio-button-border-color-focus: rgb(164, 201, 245);
+
+  --jfi-radio-button-padding: 5px;
+  --jfi-radio-button-font-size: 16px;
+
+  --jfi-radio-button-group-width: 100%;
+  --jfi-radio-button-group-color: var(--jfi-body-color);
+  --jfi-radio-button-group-color-hover: #fff;
+  --jfi-radio-button-group-divider: 1px solid rgba(255, 255, 255, 0.5);
+  --jfi-radio-button-group-background-color: transparent;
+  --jfi-radio-button-group-background-color-hover: rgba(144, 202, 249, .1);
+
+
+  /* submit button */
+  --jfi-submit-button-width: 100%;
+  --jfi-submit-button-padding: 5px 15px;
+  --jfi-submit-button-font-size: 14px;
+  --jfi-submit-button-box-shadow: none;
+  --jfi-submit-button-border-radius: 4px;
+  --jfi-submit-button-line-height: 1.75;
+  --jfi-submit-button-text-transform: uppercase;
+
+  --jfi-submit-button-color: rgb(144, 202, 249);
+  --jfi-submit-button-background-color: transparent;
+  --jfi-submit-button-border-color: rgba(144, 202, 249, 0.5);
+
+  --jfi-submit-button-color-hover: rgb(144, 202, 249);
+  --jfi-submit-button-background-color-hover: rgba(144, 202, 249, .1);
+  --jfi-submit-button-border-color-hover: rgba(144, 202, 249, 1);
+
+  --jfi-submit-button-color-focus: rgb(144, 202, 249);
+  --jfi-submit-button-background-color-focus: rgba(144, 202, 249, .1);
+  --jfi-submit-button-border-color-focus: rgba(144, 202, 249, 1);
+
+  --jfi-submit-button-color-active: rgb(144, 202, 249);
+  --jfi-submit-button-background-color-active: rgba(144, 202, 249, .25);
+  --jfi-submit-button-border-color-active: rgba(144, 202, 249, 1);
+
+  --jfi-submit-button-color-loading: rgba(255, 255, 255, 0.5);
+  --jfi-submit-button-border-color-loading: rgba(255, 255, 255, 0.5);
+  --jfi-submit-button-background-color-loading: transparent;
+}
+`;
+
+export default dark;

--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -1,6 +1,6 @@
 const dark = `
 body {
-  background-color: rgb(20, 22, 25);
+  background-color: #161616;
 }
 
 justifi-checkout {
@@ -8,7 +8,7 @@ justifi-checkout {
   max-width: 400px;
   margin: 5% auto;
   padding: 40px;
-  background-color: rgb(28, 31, 35);
+  background-color: #191919;
   border-radius: 4px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
 }
@@ -35,17 +35,17 @@ justifi-checkout {
   --jfi-form-control-background-color: transparent;
   --jfi-form-control-border-color: rgba(255, 255, 255, 0.7);
   --jfi-form-control-border-color-focus: rgb(164, 201, 245);
-  --jfi-form-control-border-color-error: rgb(244, 67, 54);
+  --jfi-form-control-border-color-error: #FF785A;
   --jfi-form-control-border-width: 1px;
   --jfi-form-control-border-bottom-width: 1px;
   --jfi-form-control-border-left-width: 1px;
   --jfi-form-control-border-right-width: 1px;
   --jfi-form-control-border-top-width: 1px;
-  --jfi-form-control-border-radius: 0.375rem;
+  --jfi-form-control-border-radius: 4px;
   --jfi-form-control-border-style: solid;
   --jfi-form-control-box-shadow: none;
-  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
-  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(244, 67, 54, 0.4);
+  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(255, 120, 90, 0.25);
+  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(255, 120, 90, 0.5);
   --jfi-form-control-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
   --jfi-form-control-color: rgba(255, 255, 255, 1);
   --jfi-form-control-color-focus: rgba(255, 255, 255, 1);
@@ -65,7 +65,7 @@ justifi-checkout {
   --jfi-form-label-margin: 0 0 0.5rem 0;
 
   /* validation messages */
-  --jfi-error-message-color: rgb(244, 67, 54);
+  --jfi-error-message-color: #FF785A;
   --jfi-error-message-margin: 5px;
   --jfi-error-message-font-size: 12px;
 
@@ -74,10 +74,10 @@ justifi-checkout {
   --jfi-radio-button-background-color: transparent;
   --jfi-radio-button-border-color: rgba(255, 255, 255, 0.7);
 
-  --jfi-radio-button-background-color-selected: rgba(164, 201, 245, .4);
-  --jfi-radio-button-border-color-selected: rgb(164, 201, 245);
+  --jfi-radio-button-background-color-selected: rgba(255, 120, 90, .5);
+  --jfi-radio-button-border-color-selected: rgba(255, 120, 90, 1);
 
-  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(164, 201, 245, .5);
+  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(255, 120, 90, 0.25);
   --jfi-radio-button-border-color-focus: rgb(164, 201, 245);
 
   --jfi-radio-button-padding: 5px;
@@ -88,37 +88,37 @@ justifi-checkout {
   --jfi-radio-button-group-color-hover: #fff;
   --jfi-radio-button-group-divider: 1px solid rgba(255, 255, 255, 0.5);
   --jfi-radio-button-group-background-color: transparent;
-  --jfi-radio-button-group-background-color-hover: rgba(144, 202, 249, .1);
+  --jfi-radio-button-group-background-color-hover: rgba(255, 120, 90, 0.25);
 
 
   /* submit button */
   --jfi-submit-button-width: 100%;
   --jfi-submit-button-padding: 5px 15px;
-  --jfi-submit-button-font-size: 14px;
+  --jfi-submit-button-font-size: 16px;
   --jfi-submit-button-box-shadow: none;
   --jfi-submit-button-border-radius: 4px;
   --jfi-submit-button-line-height: 1.75;
   --jfi-submit-button-text-transform: uppercase;
 
-  --jfi-submit-button-color: rgb(144, 202, 249);
-  --jfi-submit-button-background-color: transparent;
-  --jfi-submit-button-border-color: rgba(144, 202, 249, 0.5);
+  --jfi-submit-button-color: #191919;
+  --jfi-submit-button-background-color: #FFF05A;
+  --jfi-submit-button-border-color: #FFF05A;
 
-  --jfi-submit-button-color-hover: rgb(144, 202, 249);
-  --jfi-submit-button-background-color-hover: rgba(144, 202, 249, .1);
-  --jfi-submit-button-border-color-hover: rgba(144, 202, 249, 1);
+  --jfi-submit-button-color-hover: #191919;
+  --jfi-submit-button-background-color-hover: #FFD25A;
+  --jfi-submit-button-border-color-hover: #FFD25A;
 
-  --jfi-submit-button-color-focus: rgb(144, 202, 249);
-  --jfi-submit-button-background-color-focus: rgba(144, 202, 249, .1);
-  --jfi-submit-button-border-color-focus: rgba(144, 202, 249, 1);
+  --jfi-submit-button-color-focus: #191919;
+  --jfi-submit-button-background-color-focus: #FFD25A;
+  --jfi-submit-button-border-color-focus: #FFD25A;
 
-  --jfi-submit-button-color-active: rgb(144, 202, 249);
-  --jfi-submit-button-background-color-active: rgba(144, 202, 249, .25);
-  --jfi-submit-button-border-color-active: rgba(144, 202, 249, 1);
+  --jfi-submit-button-color-active: #191919;
+  --jfi-submit-button-background-color-active: #FFAA5A;
+  --jfi-submit-button-border-color-active: #FFAA5A;
 
-  --jfi-submit-button-color-loading: rgba(255, 255, 255, 0.5);
-  --jfi-submit-button-border-color-loading: rgba(255, 255, 255, 0.5);
-  --jfi-submit-button-background-color-loading: transparent;
+  --jfi-submit-button-color-loading: rgba(255, 255, 255, 1);
+  --jfi-submit-button-border-color-loading: rgba(255, 255, 255, 0.25);
+  --jfi-submit-button-background-color-loading: rgba(255, 255, 255, 0.25);
 }
 `;
 

--- a/apps/docs/stories/themes/index.ts
+++ b/apps/docs/stories/themes/index.ts
@@ -1,22 +1,14 @@
+import dark from "./dark";
+import light from "./light";
+
 export enum ThemeNames {
   None = 'None (bootstrap defaults)',
   Light = 'Light',
   Dark = 'Dark',
 }
 
-const light = `
-  body {
-    background-color: #f8f8f8;
-  }
-`;
-
-const dark = `
-  body {
-    background-color: #333;
-  }
-`;
-
 const themes = {
+  [ThemeNames.None]: '',
   [ThemeNames.Light]: light,
   [ThemeNames.Dark]: dark
 }

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -115,8 +115,8 @@ justifi-checkout {
   --jfi-submit-button-background-color-active: rgba(144, 202, 249, .25);
   --jfi-submit-button-border-color-active: rgba(144, 202, 249, 1);
 
-  --jfi-submit-button-color-loading: rgba(255, 255, 255, 0.5);
-  --jfi-submit-button-border-color-loading: rgba(255, 255, 255, 0.5);
+  --jfi-submit-button-color-loading: rgba(0, 0, 0, 0.5);
+  --jfi-submit-button-border-color-loading: rgba(0, 0, 0, 0.5);
   --jfi-submit-button-background-color-loading: transparent;
 }
 `;

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -1,0 +1,124 @@
+const light = `
+body {
+  background-color: #efefef;
+}
+
+justifi-checkout {
+  display: block;
+  max-width: 400px;
+  margin: 5% auto;
+  padding: 40px;
+  background-color: #fff;
+  border-radius: 4px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.2);
+}
+
+:root {
+  /* new vars */
+  --jfi-body-color: #333;
+  --jfi-header-color: #222;
+  --jfi-header-border: 1px solid #222;
+
+  /* general */
+  --jfi-load-google-font: 'Open Sans', sans-serif;
+
+  /* layout */
+  --jfi-layout-font-family: Arial, sans-serif;
+  --jfi-layout-padding: 20px;
+  --jfi-layout-form-control-spacing-x: 10px;
+  --jfi-layout-form-control-spacing-y: 10px;
+
+  /* colors */
+  --jfi-primary-color: rgb(164, 201, 245);
+
+  /* form control */
+  --jfi-form-control-background-color: transparent;
+  --jfi-form-control-border-color: #555;
+  --jfi-form-control-border-color-focus: #333;
+  --jfi-form-control-border-color-error: rgb(138, 42, 35);
+  --jfi-form-control-border-width: 1px;
+  --jfi-form-control-border-bottom-width: 1px;
+  --jfi-form-control-border-left-width: 1px;
+  --jfi-form-control-border-right-width: 1px;
+  --jfi-form-control-border-top-width: 1px;
+  --jfi-form-control-border-radius: 0;
+  --jfi-form-control-border-style: solid;
+  --jfi-form-control-box-shadow: none;
+  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
+  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(244, 67, 54, 0.4);
+  --jfi-form-control-box-shadow-focus: 0 0 0 0.25rem rgba(0, 0, 0, .25);
+  --jfi-form-control-color: var(--jfi-body-color);
+  --jfi-form-control-color-focus: var(--jfi-body-color);
+  --jfi-form-control-font-size: 1rem;
+  --jfi-form-control-font-weight: normal;
+  --jfi-form-control-line-height: 1.5;
+  --jfi-form-control-margin: 0;
+  --jfi-form-control-padding: 0.375rem 0.75rem;
+  --jfi-form-control-disabled-background-color: transparent;
+  --jfi-form-control-disabled-color: rgba(255, 255, 255, 0.5);
+
+  /* form label */
+  --jfi-form-label-color: var(--jfi-body-color);
+  --jfi-form-label-font-family: Arial, sans-serif;
+  --jfi-form-label-font-size: 16px;
+  --jfi-form-label-font-weight: normal;
+  --jfi-form-label-margin: 0 0 0.5rem 0;
+
+  /* validation messages */
+  --jfi-error-message-color: rgb(138, 42, 35);
+  --jfi-error-message-margin: 8px 0 0 0;
+  --jfi-error-message-font-size: 12px;
+
+  /* Below only used in justifi-payment-form */
+  /* form radio group */
+  --jfi-radio-button-background-color: transparent;
+  --jfi-radio-button-border-color: #555;
+
+  --jfi-radio-button-background-color-selected: #333;
+  --jfi-radio-button-border-color-selected: #333;
+
+  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(0, 0, 0, .25);
+  --jfi-radio-button-border-color-focus: #333;
+
+  --jfi-radio-button-padding: 5px;
+  --jfi-radio-button-font-size: 16px;
+
+  --jfi-radio-button-group-width: 100%;
+  --jfi-radio-button-group-color: var(--jfi-body-color);
+  --jfi-radio-button-group-color-hover: initial;
+  --jfi-radio-button-group-divider: 1px solid rgba(0, 0, 0, 0.25);
+  --jfi-radio-button-group-background-color: transparent;
+  --jfi-radio-button-group-background-color-hover: rgba(0, 0, 0, .025);
+
+  /* submit button */
+  --jfi-submit-button-width: 100%;
+  --jfi-submit-button-padding: 6px 18px;
+  --jfi-submit-button-font-size: 16px;
+  --jfi-submit-button-box-shadow: none;
+  --jfi-submit-button-border-radius: 0px;
+  --jfi-submit-button-line-height: 1.75;
+  --jfi-submit-button-text-transform: none;
+
+  --jfi-submit-button-color: #333;
+  --jfi-submit-button-background-color: transparent;
+  --jfi-submit-button-border-color: #333;
+
+  --jfi-submit-button-color-hover: #222;
+  --jfi-submit-button-background-color-hover: rgba(0, 0, 0, .05);
+  --jfi-submit-button-border-color-hover: #222;
+
+  --jfi-submit-button-color-focus: rgb(144, 202, 249);
+  --jfi-submit-button-background-color-focus: rgba(144, 202, 249, .1);
+  --jfi-submit-button-border-color-focus: rgba(144, 202, 249, 1);
+
+  --jfi-submit-button-color-active: rgb(144, 202, 249);
+  --jfi-submit-button-background-color-active: rgba(144, 202, 249, .25);
+  --jfi-submit-button-border-color-active: rgba(144, 202, 249, 1);
+
+  --jfi-submit-button-color-loading: rgba(255, 255, 255, 0.5);
+  --jfi-submit-button-border-color-loading: rgba(255, 255, 255, 0.5);
+  --jfi-submit-button-background-color-loading: transparent;
+}
+`;
+
+export default light;


### PR DESCRIPTION
Adds a theme switching capability to the Checkout component story. We will want to roll this out to all components later, which will require additional styles to be added to the themes.

Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
- Run the branch locally
- Go to the Checkout component story
- [ ] The theme should default to `Light`. Try changing it to `Dark` and `None` - the styling should change!
