### PR TITLE
Refact(Api): Change Api props to receive an object instead of two arguments

### DIFF
--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -22,16 +22,33 @@ export interface IApiResponseCollection<T> extends IApiResponse<T> {
   page_info: PagingInfo;
 }
 
-const Api = (authToken: string, apiOrigin: string) => {
+interface IApiProps {
+  authToken?: string;
+  apiOrigin: string;
+}
+
+const Api = ({ authToken, apiOrigin }: IApiProps) => {
   async function getAuthorizationHeader() {
+    if (!authToken) {
+      return {
+        'Content-Type': 'application/json',
+      };
+    }
+
     return {
-      'Authorization': `Bearer ${authToken}`,
+      Authorization: `Bearer ${authToken}`,
       'Idempotency-Key': uuidv4(),
       'Content-Type': 'application/json',
     };
   }
 
-  async function makeRequest(endpoint: string, method: string, params?: any, body?: any, signal?: AbortSignal) {
+  async function makeRequest(
+    endpoint: string,
+    method: string,
+    params?: any,
+    body?: any,
+    signal?: AbortSignal
+  ) {
     const url = `${apiOrigin}/v1/${endpoint}`;
     const requestUrl = params ? `${url}?${new URLSearchParams(params)}` : url;
     const response = await fetch(requestUrl, {
@@ -51,7 +68,12 @@ const Api = (authToken: string, apiOrigin: string) => {
     return makeRequest(endpoint, 'GET', params, null, signal);
   }
 
-  async function post(endpoint: string, body?: any, params?: any, signal?: AbortSignal) {
+  async function post(
+    endpoint: string,
+    body?: any,
+    params?: any,
+    signal?: AbortSignal
+  ) {
     return makeRequest(endpoint, 'POST', params, body, signal);
   }
 

--- a/packages/webcomponents/src/api/services/business.service.ts
+++ b/packages/webcomponents/src/api/services/business.service.ts
@@ -15,6 +15,6 @@ export class BusinessService implements IBusinessService {
     authToken: string
   ): Promise<IApiResponse<IBusiness>> {
     const endpoint = `entities/business/${businessId}`;
-    return Api(authToken, config.proxyApiOrigin).get(endpoint);
+    return Api({ authToken, apiOrigin: config.proxyApiOrigin }).get(endpoint);
   }
 }

--- a/packages/webcomponents/src/api/services/checkout.service.ts
+++ b/packages/webcomponents/src/api/services/checkout.service.ts
@@ -4,34 +4,39 @@ import { config } from '../../../config';
 export interface ICheckoutService {
   fetchCheckout(
     authToken: string,
-    checkoutId: string,
+    checkoutId: string
   ): Promise<IApiResponse<ICheckout>>;
 
   complete(
     authToken: string,
     checkoutId: string,
-    payment: { payment_mode: string; payment_token?: string; },
+    payment: { payment_mode: string; payment_token?: string }
   ): Promise<IApiResponse<ICheckoutCompleteResponse>>;
 }
 
 export class CheckoutService implements ICheckoutService {
   async fetchCheckout(
     authToken: string,
-    checkoutId: string,
+    checkoutId: string
   ): Promise<IApiResponse<ICheckout>> {
     const endpoint = `checkouts/${checkoutId}`;
-    return Api(authToken, config.proxyApiOrigin).get(endpoint);
+    return Api({ authToken, apiOrigin: config.proxyApiOrigin }).get(endpoint);
   }
   async complete(
     authToken: string,
     checkoutId: string,
-    payment: { payment_mode: string; payment_token?: string; },
+    payment: { payment_mode: string; payment_token?: string }
   ): Promise<IApiResponse<ICheckoutCompleteResponse>> {
     const endpoint = `checkouts/${checkoutId}/complete`;
-    const payload: { payment_mode: string, payment_token?: string } = { payment_mode: payment.payment_mode };
+    const payload: { payment_mode: string; payment_token?: string } = {
+      payment_mode: payment.payment_mode,
+    };
     if (payment.payment_token) {
       payload.payment_token = payment.payment_token;
     }
-    return Api(authToken, config.proxyApiOrigin).post(endpoint, JSON.stringify(payload));
+    return Api({ authToken, apiOrigin: config.proxyApiOrigin }).post(
+      endpoint,
+      JSON.stringify(payload)
+    );
   }
 }

--- a/packages/webcomponents/src/api/services/payment.service.ts
+++ b/packages/webcomponents/src/api/services/payment.service.ts
@@ -19,7 +19,7 @@ export class PaymentService implements IPaymentService {
     authToken: string,
     params: any
   ): Promise<IApiResponseCollection<IPayment[]>> {
-    const api = Api(authToken, config.proxyApiOrigin);
+    const api = Api({ authToken, apiOrigin: config.proxyApiOrigin });
     const endpoint = `account/${accountId}/payments`;
     return api.get(endpoint, params);
   }
@@ -29,6 +29,6 @@ export class PaymentService implements IPaymentService {
     authToken: string
   ): Promise<IApiResponse<IPayment>> {
     const endpoint = `payments/${paymentId}`;
-    return Api(authToken, config.proxyApiOrigin).get(endpoint);
+    return Api({ authToken, apiOrigin: config.proxyApiOrigin }).get(endpoint);
   }
 }

--- a/packages/webcomponents/src/api/services/payout.service.ts
+++ b/packages/webcomponents/src/api/services/payout.service.ts
@@ -19,7 +19,7 @@ export class PayoutService implements IPayoutService {
     authToken: string,
     params: any
   ): Promise<IApiResponseCollection<IPayout[]>> {
-    const api = Api(authToken, config.proxyApiOrigin);
+    const api = Api({ authToken, apiOrigin: config.proxyApiOrigin });
     const endpoint = `account/${accountId}/payouts`;
     return api.get(endpoint, params);
   }
@@ -28,7 +28,7 @@ export class PayoutService implements IPayoutService {
     payoutId: string,
     authToken: string
   ): Promise<IApiResponse<IPayout>> {
-    const api = Api(authToken, config.proxyApiOrigin);
+    const api = Api({ authToken, apiOrigin: config.proxyApiOrigin });
     const endpoint = `payouts/${payoutId}`;
     return api.get(endpoint);
   }

--- a/packages/webcomponents/src/api/services/reports.service.ts
+++ b/packages/webcomponents/src/api/services/reports.service.ts
@@ -7,7 +7,7 @@ export class ReportsService {
     accountId: string,
     authToken: string
   ): Promise<IApiResponse<GrossVolumeReport>> {
-    const api = Api(authToken, config.proxyApiOrigin);
+    const api = Api({ authToken: authToken, apiOrigin: config.proxyApiOrigin });
     const endpoint = `account/${accountId}/reports/gross_volume`;
     return api.get(endpoint);
   }

--- a/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
@@ -26,8 +26,8 @@ export class BusinessForm {
   @State() isLoading: boolean = false;
   @State() errorMessage: BusinessFormServerErrors;
   @Event() submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({eventName: 'click-event'}) clickEventNew: EventEmitter<BusinessFormClickEvent>;
-  @Event({eventName: 'clickEvent'}) clickEventOld: EventEmitter<BusinessFormClickEvent>;
+  @Event({ eventName: 'click-event' }) clickEventNew: EventEmitter<BusinessFormClickEvent>;
+  @Event({ eventName: 'clickEvent' }) clickEventOld: EventEmitter<BusinessFormClickEvent>;
 
   fireClickEvents(event: BusinessFormClickEvent) {
     console.warn('`clickEvent` is deprecated and will be removed in the next major release. Please use `click-event` instead.');
@@ -66,7 +66,7 @@ export class BusinessForm {
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
     this.formController = new FormController(businessFormSchema);
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
 
@@ -105,7 +105,7 @@ export class BusinessForm {
   handleReponse(response) {
     if (response.error) {
       this.errorMessage = BusinessFormServerErrors.patchData;
-    } 
+    }
     this.submitted.emit({ data: response });
     this.instantiateBusiness(response.data);
   }
@@ -136,7 +136,7 @@ export class BusinessForm {
                 type="submit"
                 class="btn btn-primary jfi-submit-button"
                 disabled={this.disabledState}
-                onClick={() => this.fireClickEvents({ name: BusinessFormClickActions.submit})}
+                onClick={() => this.fireClickEvents({ name: BusinessFormClickActions.submit })}
               >
                 {this.isLoading ? 'Loading...' : 'Submit'}
               </button>

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -8,12 +8,13 @@ import { identitySchema } from '../schemas/business-identity-schema';
 import { config } from '../../../../config';
 import { LoadingSpinner } from '../../form/utils';
 import { deconstructDate } from '../utils/helpers';
-import { 
-  OwnerFormSubmitEvent, 
-  OwnerFormServerErrorEvent, 
-  OwnerFormServerErrors, 
-  OwnerFormClickEvent, 
-  OwnerFormClickActions } 
+import {
+  OwnerFormSubmitEvent,
+  OwnerFormServerErrorEvent,
+  OwnerFormServerErrors,
+  OwnerFormClickEvent,
+  OwnerFormClickActions
+}
   from '../utils/business-form-types';
 
 @Component({
@@ -99,7 +100,7 @@ export class BusinessOwnerForm {
         const response = await this.api.patch(this.identityEndpoint, JSON.stringify(payload));
         return this.handleResponse(response);
       } else {
-        const payload = { ...parseIdentityInfo(this.formController.values.getValue()), business_id: this.businessId};
+        const payload = { ...parseIdentityInfo(this.formController.values.getValue()), business_id: this.businessId };
         const response = await this.api.post(this.identityEndpoint, JSON.stringify(payload));
         this.ownerId = response.data.id;
         return this.handleResponse(response);
@@ -112,7 +113,7 @@ export class BusinessOwnerForm {
   }
 
   handleResponse(response: any) {
-    this.submitted.emit({ data: response, metadata: { ownerId: this.ownerId }});
+    this.submitted.emit({ data: response, metadata: { ownerId: this.ownerId } });
     let errorMessage = this.ownerId ? OwnerFormServerErrors.patchData : OwnerFormServerErrors.postData;
     if (response.error) {
       this.serverError.emit({ data: response.error, message: errorMessage });
@@ -128,7 +129,7 @@ export class BusinessOwnerForm {
     if (!this.authToken) console.error(missingAuthTokenMessage);
 
     this.formController = new FormController(identitySchema('owner', this.allowOptionalFields));
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step.tsx
@@ -26,7 +26,7 @@ export class AdditionalQuestionsFormStep {
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event() serverError: EventEmitter<BusinessFormServerErrorEvent>;
-  
+
   private api: any;
 
   get businessEndpoint() {
@@ -50,7 +50,7 @@ export class AdditionalQuestionsFormStep {
     this.formLoading.emit(true);
     try {
       const payload = this.formController.values.getValue();
-      const response = await this.api.patch(this.businessEndpoint, JSON.stringify({ additional_questions: payload}));
+      const response = await this.api.patch(this.businessEndpoint, JSON.stringify({ additional_questions: payload }));
       this.handleResponse(response, onSuccess);
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.patchData });
@@ -65,7 +65,7 @@ export class AdditionalQuestionsFormStep {
     } else {
       onSuccess();
     }
-    this.submitted.emit({ data: response, metadata: { completedStep: 'additionalQuestions' }});
+    this.submitted.emit({ data: response, metadata: { completedStep: 'additionalQuestions' } });
   }
 
   @Method()
@@ -80,7 +80,7 @@ export class AdditionalQuestionsFormStep {
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
     this.formController = new FormController(additionalQuestionsSchema(this.allowOptionalFields));
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -66,14 +66,14 @@ export class BusinessCoreInfoFormStep {
       this.formLoading.emit(false);
     }
   }
-  
+
   handleResponse(response, onSuccess) {
     if (response.error) {
       this.serverError.emit({ data: response.error, message: BusinessFormServerErrors.patchData });
     } else {
       onSuccess();
     }
-    this.submitted.emit({ data: response, metadata: { completedStep: 'coreInfo' }});
+    this.submitted.emit({ data: response, metadata: { completedStep: 'coreInfo' } });
   }
 
   @Method()
@@ -88,12 +88,12 @@ export class BusinessCoreInfoFormStep {
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
     this.formController = new FormController(businessCoreInfoSchema(this.allowOptionalFields));
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
 
   componentDidLoad() {
-    this.formController.values.subscribe(values => 
+    this.formController.values.subscribe(values =>
       this.coreInfo = { ...values }
     );
     this.formController.errors.subscribe(errors => {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
@@ -3,12 +3,13 @@ import { IBusiness } from '../../../../api/Business';
 import { Api, IApiResponse } from '../../../../api';
 import { config } from '../../../../../config';
 import { Owner } from '../../../../api/Identity';
-import { 
-  BusinessFormServerErrorEvent, 
-  BusinessFormServerErrors, 
-  BusinessFormSubmitEvent, 
-  OwnerFormClickActions, 
-  OwnerFormClickEvent } 
+import {
+  BusinessFormServerErrorEvent,
+  BusinessFormServerErrors,
+  BusinessFormSubmitEvent,
+  OwnerFormClickActions,
+  OwnerFormClickEvent
+}
   from '../../utils/business-form-types';
 
 /**
@@ -61,7 +62,7 @@ export class BusinessOwnersFormStep {
       this.refs[ownerIndex] = ref;
     }
   }
-  
+
   private fetchData = async () => {
     this.formLoading.emit(true);
     try {
@@ -83,7 +84,7 @@ export class BusinessOwnersFormStep {
     this.formLoading.emit(true);
     try {
       const payload = await this.managePayload();
-      const response = await this.api.patch(this.businessEndpoint, JSON.stringify({owners: payload}));
+      const response = await this.api.patch(this.businessEndpoint, JSON.stringify({ owners: payload }));
       this.handleResponse(response, onSuccess);
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.patchData });
@@ -120,13 +121,13 @@ export class BusinessOwnersFormStep {
     if (!this.authToken) console.error(missingAuthTokenMessage);
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
 
   private addOwnerForm = (fireClick?: boolean) => {
     this.newFormOpen = true;
-    const newOwner = { ...new Owner({})};
+    const newOwner = { ...new Owner({}) };
     this.owners = [...this.owners, newOwner];
     fireClick && this.clickEvent.emit({ name: OwnerFormClickActions.addOwnerForm });
   };
@@ -160,10 +161,10 @@ export class BusinessOwnersFormStep {
         <div class='col-12'>
           {this.owners.map((owner) => {
             return (
-              <justifi-owner-form 
+              <justifi-owner-form
                 key={owner.id}
-                authToken={this.authToken} 
-                businessId={this.businessId} 
+                authToken={this.authToken}
+                businessId={this.businessId}
                 ownerId={owner.id}
                 removeOwner={this.removeOwnerForm}
                 newFormOpen={this.newFormOpen}
@@ -171,12 +172,12 @@ export class BusinessOwnersFormStep {
                 onSubmitted={(e: CustomEvent) => this.handleOwnerSubmit(e)}
                 onFormLoading={(e: CustomEvent) => this.formLoading.emit(e.detail)}
                 allowOptionalFields={this.allowOptionalFields}
-                ref={(ref) => {this.matchRef(ref, owner.id)}}
+                ref={(ref) => { this.matchRef(ref, owner.id) }}
               />
             );
           })}
         </div>
-        {this.showAddOwnerButton && 
+        {this.showAddOwnerButton &&
           <div class='col-12'>
             <button class='btn btn-primary' onClick={() => this.addOwnerForm(true)}>Add Owner</button>
           </div>

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -63,7 +63,7 @@ export class BusinessRepresentativeFormStep {
     } else {
       onSuccess();
     }
-    this.submitted.emit({ data: response, metadata: { completedStep: 'representative' }});
+    this.submitted.emit({ data: response, metadata: { completedStep: 'representative' } });
   }
 
   @Method()
@@ -78,7 +78,7 @@ export class BusinessRepresentativeFormStep {
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
     this.formController = new FormController(identitySchema('representative', this.allowOptionalFields));
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
 
@@ -101,10 +101,10 @@ export class BusinessRepresentativeFormStep {
   onAddressFormUpdate = (values: any): void => {
     this.formController.setValues({
       ...this.formController.values.getValue(),
-        address: {
-          ...this.formController.values.getValue().address,
-          ...values,
-        }
+      address: {
+        ...this.formController.values.getValue().address,
+        ...values,
+      }
     });
   }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step.tsx
@@ -5,7 +5,7 @@ import { Address, IAddress, IBusiness } from '../../../../api/Business';
 import { parseAddressInfo } from '../../utils/payload-parsers';
 import { addressSchema } from '../../schemas/business-address-schema';
 import { config } from '../../../../../config';
-import { BusinessFormServerErrorEvent, BusinessFormServerErrors, BusinessFormSubmitEvent  } from '../../utils/business-form-types';
+import { BusinessFormServerErrorEvent, BusinessFormServerErrors, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import StateOptions from '../../../../utils/state-options';
 import { filterPostalInput } from '../../../form/utils';
 
@@ -52,7 +52,7 @@ export class LegalAddressFormStep {
     this.formLoading.emit(true);
     try {
       const payload = parseAddressInfo(this.formController.values.getValue());
-      const response = await this.api.patch(this.businessEndpoint, JSON.stringify({ legal_address: payload}));
+      const response = await this.api.patch(this.businessEndpoint, JSON.stringify({ legal_address: payload }));
       this.handleResponse(response, onSuccess);
     } catch (error) {
       this.serverError.emit({ data: error, message: BusinessFormServerErrors.patchData });
@@ -67,7 +67,7 @@ export class LegalAddressFormStep {
     } else {
       onSuccess();
     }
-    this.submitted.emit({ data: response, metadata: { completedStep: 'legalAddress' }});
+    this.submitted.emit({ data: response, metadata: { completedStep: 'legalAddress' } });
   }
 
   @Method()
@@ -82,7 +82,7 @@ export class LegalAddressFormStep {
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
     this.formController = new FormController(addressSchema(this.allowOptionalFields));
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
 

--- a/packages/webcomponents/src/components/business-list/business-list.tsx
+++ b/packages/webcomponents/src/components/business-list/business-list.tsx
@@ -87,7 +87,7 @@ export class BusinessList {
     const endpoint = `entities/business`;
     let accountIDParam = { account_id: this.accountId };
 
-    const response: IApiResponseCollection<Business[]> = await Api(this.authToken, config.proxyApiOrigin,)
+    const response: IApiResponseCollection<Business[]> = await Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin },)
       .get(endpoint, { ...accountIDParam, ...this.params });
 
     if (!response.error) {

--- a/packages/webcomponents/src/components/payment-balance-transactions/payment-balance-transactions.tsx
+++ b/packages/webcomponents/src/components/payment-balance-transactions/payment-balance-transactions.tsx
@@ -63,7 +63,7 @@ export class PaymentBalanceTransactions {
     const endpoint = `account/${this.accountId}/payments/${this.paymentId}/payment_balance_transactions`;
 
     const response: IApiResponseCollection<IPaymentBalanceTransaction[]> =
-      await Api(this.authToken, config.proxyApiOrigin).get(endpoint, this.params);
+      await Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin }).get(endpoint, this.params);
 
     if (!response.error) {
       this.paging = {

--- a/packages/webcomponents/src/components/proceeds-list/proceeds-list.tsx
+++ b/packages/webcomponents/src/components/proceeds-list/proceeds-list.tsx
@@ -92,7 +92,7 @@ export class ProceedsList {
     this.loading = true;
     const endpoint = `account/${this.accountId}/proceeds`;
 
-    const response: IApiResponseCollection<Proceed[]> = await Api(this.authToken, config.privateApiOrigin)
+    const response: IApiResponseCollection<Proceed[]> = await Api({ authToken: this.authToken, apiOrigin: config.privateApiOrigin })
       .get(endpoint, this.params);
 
     if (!response.error) {

--- a/packages/webcomponents/src/components/refund-form/refund-form.tsx
+++ b/packages/webcomponents/src/components/refund-form/refund-form.tsx
@@ -125,7 +125,7 @@ export class RefundForm {
     if (!this.authToken) {
       console.warn('Warning: Missing auth-token.');
     }
-    this.api = Api(this.authToken, config.proxyApiOrigin);
+    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
   }
 
   render() {

--- a/packages/webcomponents/src/components/subaccount-details/subaccount-details.tsx
+++ b/packages/webcomponents/src/components/subaccount-details/subaccount-details.tsx
@@ -31,7 +31,7 @@ export class SubaccountDetails {
   }
 
   async fetchOnboardingData(): Promise<void> {
-    const api = Api(this.authToken, '');
+    const api = Api({ authToken: this.authToken, apiOrigin: '' });
     const endpoint = `onboarding/${this.subaccountId}`;
 
     const response: IApiResponse<IOnboardingData> = await api.get(endpoint);
@@ -43,7 +43,7 @@ export class SubaccountDetails {
   }
 
   async fetchSubAccountData(): Promise<void> {
-    const api = Api(this.authToken, config.privateApiOrigin);
+    const api = Api({ authToken: this.authToken, apiOrigin: config.privateApiOrigin });
     const endpoint = `account/${this.accountId}/seller_accounts/${this.subaccountId}`;
 
     const response: IApiResponse<ISubAccount> = await api.get(endpoint);

--- a/packages/webcomponents/src/components/subaccounts-list/subaccounts-list.tsx
+++ b/packages/webcomponents/src/components/subaccounts-list/subaccounts-list.tsx
@@ -53,7 +53,7 @@ export class SubaccountsList {
       return;
     }
     this.loading = true;
-    const api = Api(this.authToken, config.privateApiOrigin);
+    const api = Api({ authToken: this.authToken, apiOrigin: config.privateApiOrigin });
     const endpoint = `account/${this.accountId}/seller_accounts`;
 
 


### PR DESCRIPTION
This PR updates the Api class to accept a single object parameter instead of two separate arguments. The new usage is `Api({ authToken, iframeOrigin })` instead of `Api(authToken, iframeOrigin)`.

The reason being that the analytics endpoint does not receive an authToken. Consequently, the Api class has been updated to handle cases where `authToken` is absent.

This changes nothing in the components usage.

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------
[ ] - All components should be still loading and saving data without errors

