### PR TITLE
feat: Analytics class and BusinessDetails implementation

### DIFF
--- a/packages/webcomponents/src/api/Analytics.ts
+++ b/packages/webcomponents/src/api/Analytics.ts
@@ -1,0 +1,90 @@
+import { ComponentInterface } from '@stencil/core';
+import webcomponentsPackageJson from '../../package.json';
+import { AnalyticsService } from './services/analytics.service';
+import { camelToKebab } from '../utils/utils';
+
+interface iBasicData {
+  component_name: string;
+  component_version: string;
+  client_user_agent: string;
+  client_platform: string;
+  client_origin: string;
+  error?: any;
+}
+
+const getEvents = (component) =>
+  Object.keys(component)
+    .filter((key) => typeof component[key] === 'object' && component[key].emit)
+    .map(camelToKebab);
+
+/**
+ * @class JustifiAnalytics
+ * @description A class to track analytics for a component
+ * @param { component } ComponentInterface - The component to track
+ *
+ */
+class JustifiAnalytics {
+  componentInstance: any;
+  eventEmitters: string[];
+  service: AnalyticsService;
+  basicData: iBasicData;
+
+  constructor(component: ComponentInterface) {
+    this.service = new AnalyticsService();
+    this.componentInstance = component;
+    this.setUpBasicData();
+    this.setupLifecycleTracking();
+    this.trackCustomEvents();
+  }
+
+  setUpBasicData() {
+    this.basicData = {
+      component_name: this.componentInstance.tagName,
+      component_version: webcomponentsPackageJson.version,
+      client_user_agent: navigator.userAgent,
+      // navigator.platform is deprecated, use navigator.userAgent instead
+      client_platform: navigator.userAgent,
+      client_origin: window.location.origin,
+    };
+  }
+
+  handleCustomEvent = async (data: any) => {
+    // Track the event
+    await this.service.record(data);
+  };
+
+  private trackCustomEvents() {
+    this.eventEmitters = getEvents(this.componentInstance);
+
+    // for each event, add an event listener
+    this.eventEmitters.forEach((eventName) => {
+      this.componentInstance.addEventListener(eventName, (event: any) =>
+        this.handleCustomEvent({
+          event_type: eventName,
+          data: { ...this.basicData, error: event.detail },
+        })
+      );
+    });
+  }
+
+  setupLifecycleTracking() {
+    const originalComponentDidLoad = this.componentInstance.componentDidLoad;
+
+    this.componentInstance.componentDidLoad = () => {
+      this.service.record({ event_type: 'init', data: this.basicData });
+
+      if (originalComponentDidLoad) {
+        return originalComponentDidLoad.apply(this.componentInstance);
+      }
+    };
+  }
+
+  cleanup() {
+    // Remove event listeners
+    this.eventEmitters.forEach((event) => {
+      this.componentInstance.removeEventListener(event, this.handleCustomEvent);
+    });
+  }
+}
+
+export default JustifiAnalytics;

--- a/packages/webcomponents/src/api/Analytics.ts
+++ b/packages/webcomponents/src/api/Analytics.ts
@@ -12,7 +12,7 @@ interface iBasicData {
   error?: any;
 }
 
-const getEvents = (component) =>
+const getEventNames = (component) =>
   Object.keys(component)
     .filter((key) => typeof component[key] === 'object' && component[key].emit)
     .map(camelToKebab);
@@ -54,7 +54,7 @@ class JustifiAnalytics {
   };
 
   private trackCustomEvents() {
-    this.eventEmitters = getEvents(this.componentInstance);
+    this.eventEmitters = getEventNames(this.componentInstance);
 
     // for each event, add an event listener
     this.eventEmitters.forEach((eventName) => {

--- a/packages/webcomponents/src/api/services/analytics.service.ts
+++ b/packages/webcomponents/src/api/services/analytics.service.ts
@@ -1,0 +1,24 @@
+import { config } from '../../../config';
+import Api from '../Api';
+
+interface iAnayticsBody {
+  event_type: string;
+  data: {
+    component_name: string;
+    component_version: string;
+    client_user_agent: string;
+    client_platform: string;
+    client_origin: string;
+    error?: any;
+  };
+}
+
+export class AnalyticsService {
+  async record(body: iAnayticsBody): Promise<void> {
+    const endpoint = 'analytics';
+    return Api({ apiOrigin: config.proxyApiOrigin }).post(
+      endpoint,
+      JSON.stringify(body)
+    );
+  }
+}

--- a/packages/webcomponents/src/components/business-details/business-details.tsx
+++ b/packages/webcomponents/src/components/business-details/business-details.tsx
@@ -3,6 +3,7 @@ import { ErrorState } from '../details/utils';
 import { BusinessService } from '../../api/services/business.service';
 import { makeGetBusiness } from './get-business';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
+import JustifiAnalytics from '../../api/Analytics';
 
 /**
  *
@@ -23,10 +24,20 @@ export class BusinessDetails {
   @State() errorMessage: string;
   @State() getBusiness: Function;
 
-  @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
+  analytics: JustifiAnalytics;
+
+  @Event({
+    eventName: 'error-event'
+  }) errorEvent: EventEmitter<ComponentError>;
+
 
   componentWillLoad() {
+    this.analytics = new JustifiAnalytics(this);
     this.initializeGetBusiness();
+  }
+
+  disconnectedCallback() {
+    this.analytics.cleanup();
   }
 
   private initializeGetBusiness() {

--- a/packages/webcomponents/src/components/business-details/test/business-details.spec.tsx
+++ b/packages/webcomponents/src/components/business-details/test/business-details.spec.tsx
@@ -2,6 +2,14 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { BusinessDetails } from '../business-details';
 import { BusinessDetailsCore } from '../business-details-core';
+import JustifiAnalytics from '../../../api/Analytics';
+
+beforeEach(() => {
+  // Bypass Analytics to avoid errors. Analytics attaches events listeners to HTML elements
+  // which are not available in Jest/node environment
+  // @ts-ignore
+  JustifiAnalytics.prototype.trackCustomEvents = jest.fn();
+});
 
 describe('justifi-business-details', () => {
   it('initializes getBusiness on load with valid props', async () => {

--- a/packages/webcomponents/src/utils/utils.ts
+++ b/packages/webcomponents/src/utils/utils.ts
@@ -179,6 +179,10 @@ export function snakeCaseToHumanReadable(snakeCaseStr: string): string {
     .join(' ');
 }
 
+export function camelToKebab(str: string): string {
+  return str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
+}
+
 export function flattenNestedObject(obj) {
   const result = {};
 


### PR DESCRIPTION
This PR creates the following.
- Analytics class - A class that will track the events and lifecycle methods of a component and send data to analytics.
- Analytics service - A service to post to analytics Api.

This PR also implements the Analytics in the BusinessDetails component as first reference.

Another PR will follow up this with the implementation on the rest of the components.

Links
-----
#496 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [x] Perform dev QA


Developer QA steps
--------------------

[ ] - BusinessDetails: When the component loads, there should be a successful network request to `analytics` with a request payload like this: 
```
{
    "event_type": "init",
    "data": {
        "component_name": "JUSTIFI-BUSINESS-DETAILS",
        "component_version": "4.13.0",
        "client_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
        "client_platform": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
        "client_origin": "http://localhost:6006"
    }
}
```
[ ] - BusinessDetails: If an error is forced (for instance: remove the `business-id` or `auth-token`), there should be a successful network request to `analytics` with a request payload like this: 
```
{
    "event_type": "error-event",
    "data": {
        "component_name": "JUSTIFI-BUSINESS-DETAILS",
        "component_version": "4.13.0",
        "client_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
        "client_platform": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
        "client_origin": "http://localhost:6006",
        "error": {
            "errorCode": "missing-props",
            "message": "Invalid business id or auth token",
            "severity": "error"
        }
    }
}
```




