### PR TITLE
Add getSelectedPaymentMethodType method to PaymentForm

### DIFF
--- a/.changeset/chilled-dancers-provide.md
+++ b/.changeset/chilled-dancers-provide.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix issue with PaymentForm where card form is being shown instead of bank account form when card prop is false and bank-account prop is true

--- a/packages/webcomponents/src/components/payment-form/payment-form.tsx
+++ b/packages/webcomponents/src/components/payment-form/payment-form.tsx
@@ -49,6 +49,22 @@ export class PaymentForm {
     this.submitButtonEnabled = false;
   }
 
+  showPaymentMethodTypeSelector() {
+    return this.card && this.bankAccount;
+  }
+
+  getSelectedPaymentMethodType() {
+    if (this.showPaymentMethodTypeSelector()) {
+      return this.selectedPaymentMethodType;
+    } else if (this.card) {
+      return PaymentMethodTypes.card;
+    } else if (this.bankAccount) {
+      return PaymentMethodTypes.bankAccount;
+    } else {
+      return PaymentMethodTypes.card;
+    }
+  }
+
   paymentMethodSelectedHandler(event: CustomEvent) {
     const paymentMethodType: PaymentMethodTypes = event.detail;
     this.selectedPaymentMethodType = paymentMethodType;
@@ -92,17 +108,17 @@ export class PaymentForm {
     return (
       <Host>
         <form class="row gy-3">
-          {this.card && this.bankAccount && (
+          {this.showPaymentMethodTypeSelector() && (
             <div class="col-12">
               <justifi-payment-method-selector
-                selectedPaymentMethodType={this.selectedPaymentMethodType}
+                selectedPaymentMethodType={this.getSelectedPaymentMethodType()}
                 onPaymentMethodSelected={event => this.paymentMethodSelectedHandler(event)}
               />
             </div>
           )}
           <div class="col-12">
             <justifi-payment-method-form
-              payment-method-form-type={this.selectedPaymentMethodType}
+              payment-method-form-type={this.getSelectedPaymentMethodType()}
               iframeOrigin={config.iframeOrigin}
               ref={el => {
                 if (el) {


### PR DESCRIPTION
Fix issue with PaymentForm where card form is being shown instead of bank account form when card prop is false and bank-account prop is true

Links
-----
Fixes https://github.com/justifi-tech/web-component-library/issues/527

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
Run the branch locally, and in the PaymentForm example try the following
- set card prop to `false` and bank account to `false`, the card form should show (something needs to show, card is the fallback)
- set card prop to `true` and bank account to `true`, the payment method toggle should show and user can flip between card form and bank account form
- card form `true`, bank account `false`
- bank account `true`, card `false

