### PR TITLE
Make SSN Optional in form if ssn_last4 is present

### DIFF
--- a/.changeset/kind-suns-bathe.md
+++ b/.changeset/kind-suns-bathe.md
@@ -1,0 +1,7 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- `BusinessForm` and `PaymentProvisioning` components: Added conditional logic to require SSN for representatives and owners if `ssn_last4` is missing or null.
+  - Labels for SSN field conditionally update now. If `ssn_last4` is already defined for the given identity, the label shown will be `Change SSN (optional)` as opposed to `SSN`.
+

--- a/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
@@ -11,6 +11,10 @@ export class BusinessRepresentative {
   @Prop() formController: FormController;
   @State() errors: any = {};
   @State() representative: any = {};
+
+  get identificationNumberLabel() {
+    return this.representative.ssn_last4 ? 'Change SSN (optional)' : 'SSN';
+  }
   
   componentDidLoad() {
     this.formController.errors.subscribe(
@@ -118,7 +122,7 @@ export class BusinessRepresentative {
             <div class="col-12 col-md-8">
               <form-control-number-masked
                 name="identification_number"
-                label="SSN"
+                label={this.identificationNumberLabel}
                 defaultValue={representativeDefaultValue?.identification_number}
                 error={this.errors.identification_number}
                 inputHandler={this.inputHandler}

--- a/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-representative/business-representative.tsx
@@ -13,7 +13,7 @@ export class BusinessRepresentative {
   @State() representative: any = {};
 
   get identificationNumberLabel() {
-    return this.representative.ssn_last4 ? 'Change SSN (optional)' : 'SSN';
+    return this.representative.ssn_last4 ? 'Update SSN (optional)' : 'SSN';
   }
   
   componentDidLoad() {

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -46,7 +46,7 @@ export class BusinessOwnerForm {
   }
 
   get identificationNumberLabel() {
-    return this.owner.ssn_last4 ? 'Change SSN (optional)' : 'SSN';
+    return this.owner.ssn_last4 ? 'Update SSN (optional)' : 'SSN';
   }
 
   get formTitle() {

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -45,6 +45,10 @@ export class BusinessOwnerForm {
     return this.ownerId ? `entities/identity/${this.ownerId}` : 'entities/identity';
   }
 
+  get identificationNumberLabel() {
+    return this.owner.ssn_last4 ? 'Change SSN (Optional)' : 'SSN';
+  }
+
   get formTitle() {
     return this.ownerId ? 'Edit Business Owner' : 'Add Business Owner';
   }
@@ -270,7 +274,7 @@ export class BusinessOwnerForm {
               <div class="col-12 col-md-8">
                 <form-control-number-masked
                   name="identification_number"
-                  label="SSN"
+                  label={this.identificationNumberLabel}
                   defaultValue={ownerDefaultValue?.identification_number}
                   error={this.errors.identification_number}
                   inputHandler={this.inputHandler}

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -46,7 +46,7 @@ export class BusinessOwnerForm {
   }
 
   get identificationNumberLabel() {
-    return this.owner.ssn_last4 ? 'Change SSN (Optional)' : 'SSN';
+    return this.owner.ssn_last4 ? 'Change SSN (optional)' : 'SSN';
   }
 
   get formTitle() {
@@ -93,6 +93,7 @@ export class BusinessOwnerForm {
       this.serverError.emit({ data: error, message: OwnerFormServerErrors.fetchData });
     } finally {
       this.isLoading = false;
+      console.log(this.formController.getInitialValues());
     }
   }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -31,6 +31,10 @@ export class BusinessRepresentativeFormStep {
     return `entities/business/${this.businessId}`
   }
 
+  get identificationNumberLabel() {
+    return this.representative.ssn_last4 ? 'Change SSN (optional)' : 'SSN';
+  }
+
   private fetchData = async () => {
     this.formLoading.emit(true);
     try {
@@ -188,7 +192,7 @@ export class BusinessRepresentativeFormStep {
               <div class="col-12 col-md-8">
                 <form-control-number-masked
                   name="identification_number"
-                  label="SSN"
+                  label={this.identificationNumberLabel}
                   defaultValue={representativeDefaultValue?.identification_number}
                   error={this.errors.identification_number}
                   inputHandler={this.inputHandler}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -32,7 +32,7 @@ export class BusinessRepresentativeFormStep {
   }
 
   get identificationNumberLabel() {
-    return this.representative.ssn_last4 ? 'Change SSN (optional)' : 'SSN';
+    return this.representative.ssn_last4 ? 'Update SSN (optional)' : 'SSN';
   }
 
   private fetchData = async () => {

--- a/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
@@ -1,4 +1,4 @@
-import { object } from 'yup';
+import { object, string } from 'yup';
 import { addressSchema } from './business-address-schema';
 import { 
   dobValidation, 
@@ -16,7 +16,8 @@ export const identitySchema = (role: string, allowOptionalFields?: boolean) => {
     email: emailValidation.required(`Enter ${role} email`),
     phone: phoneValidation.required('Enter phone number'),
     dob_full: dobValidation(role).required('Enter date of birth'),
-    identification_number: ssnValidation.required('Enter SSN'),
+    ssn_last4: string().nullable(),
+    identification_number: ssnValidation,
     address: addressSchema(allowOptionalFields),
   });
 
@@ -26,6 +27,7 @@ export const identitySchema = (role: string, allowOptionalFields?: boolean) => {
     email: emailValidation.nullable(),
     phone: phoneValidation.nullable(),
     dob_full: dobValidation(role).nullable(),
+    ssn_last4: string().nullable(),
     identification_number: ssnValidation.nullable(),
     address: addressSchema(allowOptionalFields),
   });

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -114,6 +114,11 @@ export const dobValidation = (role: string) => {
 
 export const ssnValidation = string()
   .matches(ssnRegex, 'Enter valid SSN')
+  .when('ssn_last4', {
+    is: (val: string) => !val || val.length === 0,
+    then: (schema) => schema.required('Enter SSN'),
+    otherwise: (schema) => schema.nullable(),
+  })
   .test('not-repeat', 'Enter valid SSN', (value) => {
     return !/^(\d)\1+$/.test(value);
   })


### PR DESCRIPTION
### Make SSN Optional in form if ssn_last4 is present

This PR fixes a bug that could potentially occur on the Owners Form step - due to improved validation rules for the SSN field. 

Links
-----

Closes #534 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------
Changes are applied to the identity schema, which means the validation logic applies to the following sub components: `owner-form.tsx`, `business-representative-form.tsx` and `business-representative-form-step.tsx`.

- [x] On the original `BusinessForm` component - complete the form for a new business. Verify that the SSN field is required if you try to submit without entering anything into this field. 
- [x] Once you have successfully patched the business - either refresh the page, or scroll down to confirm that the label for the SSN Field has updated from `SSN` => `Change SSN (optional`
- [x] Verify that you can submit the business without entering anything new into the SSN field for the representative. 

- [x] On the `PaymentProvisioning` component - complete the form for a new business. Verify that the SSN field is required for the Representative Step, and the Owner Forms on the Owner step, if you try to submit without entering anything into this field. 
- [x] Once you have successfully patched the business - refresh and complete the form again. Confirm that the label for SSN for existing representatives and owners shows `Change SSN (optional)`
- [x] Verify that you can submit these form steps without entering anything new into the SSN field. 

