### PR TITLE
532 checkout radio button default border color is incorrect

### DIFF
--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -71,14 +71,14 @@ justifi-checkout {
 
   /* Below only used in justifi-payment-form */
   /* form radio group */
-  --jfi-radio-button-background-color: transparent;
-  --jfi-radio-button-border-color: rgba(255, 255, 255, 0.7);
+  --jfi-radio-input-background-color: transparent;
+  --jfi-radio-input-border-color: rgba(255, 255, 255, 0.7);
 
-  --jfi-radio-button-background-color-selected: rgba(255, 120, 90, .5);
-  --jfi-radio-button-border-color-selected: rgba(255, 120, 90, 1);
+  --jfi-radio-input-background-color-selected: rgba(255, 120, 90, .5);
+  --jfi-radio-input-border-color-selected: rgba(255, 120, 90, 1);
 
-  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(255, 120, 90, 0.25);
-  --jfi-radio-button-border-color-focus: rgb(164, 201, 245);
+  --jfi-radio-input-box-shadow-focus: 0 0 0 0.25rem rgba(255, 120, 90, 0.25);
+  --jfi-radio-input-border-color-focus: rgb(164, 201, 245);
 
   --jfi-radio-button-padding: 5px;
   --jfi-radio-button-font-size: 16px;

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -71,14 +71,14 @@ justifi-checkout {
 
   /* Below only used in justifi-payment-form */
   /* form radio group */
-  --jfi-radio-button-background-color: transparent;
-  --jfi-radio-button-border-color: #555;
+  --jfi-radio-input-background-color: transparent;
+  --jfi-radio-input-border-color: #555;
 
-  --jfi-radio-button-background-color-selected: #333;
-  --jfi-radio-button-border-color-selected: #333;
+  --jfi-radio-input-background-color-selected: #333;
+  --jfi-radio-input-border-color-selected: #333;
 
-  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(0, 0, 0, .25);
-  --jfi-radio-button-border-color-focus: #333;
+  --jfi-radio-input-box-shadow-focus: 0 0 0 0.25rem rgba(0, 0, 0, .25);
+  --jfi-radio-input-border-color-focus: #333;
 
   --jfi-radio-button-padding: 5px;
   --jfi-radio-button-font-size: 16px;

--- a/apps/docs/stories/utils/css-variables.tsx
+++ b/apps/docs/stories/utils/css-variables.tsx
@@ -74,6 +74,13 @@ export const CSSVars = () => (
   --jfi-radio-button-border-color-hover
   --jfi-radio-button-group-width
 
+  /* Below only used in justifi-checkout */
+  /* form radio input */
+  --jfi-radio-input-box-shadow-focus
+  --jfi-radio-input-background-color-selected
+  --jfi-radio-input-border-color
+  --jfi-radio-input-border-color-selected
+
   /* submit button */
   --jfi-submit-button-color
   --jfi-submit-button-background-color

--- a/packages/webcomponents/src/components/checkout/payment-method-options.scss
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.scss
@@ -26,7 +26,6 @@
     &:checked:focus {
       background-color: var(--jfi-radio-button-background-color-selected);
       border-color: var(--jfi-radio-button-border-color-selected);
-      box-shadow: var(--jfi-radio-button-box-shadow-focus);
     }
 
     &:focus {

--- a/packages/webcomponents/src/components/checkout/payment-method-options.scss
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.scss
@@ -26,6 +26,7 @@
     &:checked:focus {
       background-color: var(--jfi-radio-button-background-color-selected);
       border-color: var(--jfi-radio-button-border-color-selected);
+      box-shadow: var(--jfi-radio-button-box-shadow-focus);
     }
 
     &:focus {

--- a/packages/webcomponents/src/components/checkout/payment-method-options.scss
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.scss
@@ -19,18 +19,18 @@
   }
 
   input[type="radio"] {
-    background-color: var(--jfi-radio-button-background-color);
-    border-color: var(--jfi-radio-button-border-color);
+    background-color: var(--jfi-radio-input-background-color);
+    border-color: var(--jfi-radio-input-border-color);
 
     &:checked,
     &:checked:focus {
-      background-color: var(--jfi-radio-button-background-color-selected);
-      border-color: var(--jfi-radio-button-border-color-selected);
+      background-color: var(--jfi-radio-input-background-color-selected);
+      border-color: var(--jfi-radio-input-border-color-selected);
     }
 
     &:focus {
-      border-color: var(--jfi-radio-button-border-color-focus);
-      box-shadow: var(--jfi-radio-button-box-shadow-focus);
+      border-color: var(--jfi-radio-input-border-color-focus);
+      box-shadow: var(--jfi-radio-input-box-shadow-focus);
     }
   }
 

--- a/packages/webcomponents/src/styles/root.scss
+++ b/packages/webcomponents/src/styles/root.scss
@@ -42,9 +42,9 @@
   --jfi-radio-button-color: var(--jfi-primary-color);
   --jfi-radio-button-background-color: transparent;
   --jfi-radio-button-color-selected: white;
-  --jfi-radio-button-background-color-selected: #{$dark};
-  --jfi-radio-button-border-color: #{$secondary};
-  --jfi-radio-button-border-color-selected: #{$dark};
+  --jfi-radio-button-background-color-selected: var(--jfi-primary-color);
+  --jfi-radio-button-border-color: var(--jfi-primary-color);
+  --jfi-radio-button-border-color-selected: var(--jfi-primary-color);
   --jfi-radio-button-padding: #{$input-padding-y $input-padding-x};
   --jfi-radio-button-font-size: #{$input-font-size};
   --jfi-radio-button-color-hover: var(--jfi-primary-color);
@@ -54,7 +54,7 @@
   --jfi-radio-button-border-color-selected-hover: var(--jfi-primary-color);
   --jfi-radio-button-border-color-hover: var(--jfi-primary-color);
 
-  --jfi-radio-button-box-shadow-focus: 0 0 #{$focus-ring-blur} #{$focus-ring-width}em rgba($secondary, $focus-ring-opacity);
+  --jfi-radio-button-box-shadow-focus: #{$form-check-input-focus-box-shadow};
   --jfi-radio-button-border-color-focus: #{$form-check-input-focus-border};
 
   --jfi-radio-button-group-color: var(--jfi-body-color);
@@ -62,6 +62,12 @@
   --jfi-radio-button-group-divider: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
   --jfi-radio-button-group-background-color: transparent;
   --jfi-radio-button-group-background-color-hover: var(--bs-gray-100);
+
+  /* form radio input */
+  --jfi-radio-input-box-shadow-focus: #{$form-check-input-focus-box-shadow};
+  --jfi-radio-input-background-color-selected: #{$dark};
+  --jfi-radio-input-border-color: #{$secondary};
+  --jfi-radio-input-border-color-selected: #{$dark};
 
   /* submit button */
   --jfi-submit-button-color: white;

--- a/packages/webcomponents/src/styles/root.scss
+++ b/packages/webcomponents/src/styles/root.scss
@@ -42,9 +42,9 @@
   --jfi-radio-button-color: var(--jfi-primary-color);
   --jfi-radio-button-background-color: transparent;
   --jfi-radio-button-color-selected: white;
-  --jfi-radio-button-background-color-selected: var(--jfi-primary-color);
-  --jfi-radio-button-border-color: var(--jfi-primary-color);
-  --jfi-radio-button-border-color-selected: var(--jfi-primary-color);
+  --jfi-radio-button-background-color-selected: #{$dark};
+  --jfi-radio-button-border-color: #{$secondary};
+  --jfi-radio-button-border-color-selected: #{$dark};
   --jfi-radio-button-padding: #{$input-padding-y $input-padding-x};
   --jfi-radio-button-font-size: #{$input-font-size};
   --jfi-radio-button-color-hover: var(--jfi-primary-color);
@@ -54,7 +54,7 @@
   --jfi-radio-button-border-color-selected-hover: var(--jfi-primary-color);
   --jfi-radio-button-border-color-hover: var(--jfi-primary-color);
 
-  --jfi-radio-button-box-shadow-focus: #{$form-check-input-focus-box-shadow};
+  --jfi-radio-button-box-shadow-focus: 0 0 0 .25em rgb(108, 117, 125, 0.25);
   --jfi-radio-button-border-color-focus: #{$form-check-input-focus-border};
 
   --jfi-radio-button-group-color: var(--jfi-body-color);

--- a/packages/webcomponents/src/styles/root.scss
+++ b/packages/webcomponents/src/styles/root.scss
@@ -54,7 +54,7 @@
   --jfi-radio-button-border-color-selected-hover: var(--jfi-primary-color);
   --jfi-radio-button-border-color-hover: var(--jfi-primary-color);
 
-  --jfi-radio-button-box-shadow-focus: 0 0 0 .25em rgb(108, 117, 125, 0.25);
+  --jfi-radio-button-box-shadow-focus: 0 0 #{$focus-ring-blur} #{$focus-ring-width}em rgba($secondary, $focus-ring-opacity);
   --jfi-radio-button-border-color-focus: #{$form-check-input-focus-border};
 
   --jfi-radio-button-group-color: var(--jfi-body-color);


### PR DESCRIPTION
This changes the radio-buttons border/background/box-shadow when selected/focused to grey color instead of blue.

- The blue color is from Bootstrap `$primary` and it's the same one on focused regular inputs. However, on radio buttons it looks odd. (Decided to keep the box-shadow blue as it is also on inputs)

<img width="558" alt="image" src="https://github.com/justifi-tech/web-component-library/assets/22480988/d64e716f-374b-43a2-bb6f-291c15cc57d1">

<img width="565" alt="image" src="https://github.com/justifi-tech/web-component-library/assets/22480988/3b4a2dd0-f895-4491-9ea9-1041b924fc1d">



**Code explanation**: 
- `$secondary` and `$dark` are Bootstrap variables that are accessible on our code the same way `$primary` is.


Links
-----

[#532](https://github.com/justifi-tech/web-component-library/issues/532)


Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------
[ ] Go to http://localhost:6006/?path=/story/payment-facilitation-payments-checkout--basic
The radio buttons should not have the default bootstrap $primary (blue) color when checked/focused

