### PR TITLE
Fix PaymentForm prop logic for card and bankAccount

### DIFF
--- a/.changeset/weak-hairs-notice.md
+++ b/.changeset/weak-hairs-notice.md
@@ -2,4 +2,4 @@
 "@justifi/webcomponents": patch
 ---
 
-- Fully resolved issue with the `PaymentForm` component props that show bank-account form.
+- Fully resolved issue with the `PaymentForm` component props that show the bank-account form.

--- a/.changeset/weak-hairs-notice.md
+++ b/.changeset/weak-hairs-notice.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Addressed an issue previously marked as resolved in the `PaymentForm` component where the card form was being shown instead of the bank account form when the card prop was false and the bank-account prop was true. The issue persisted under certain conditions and is now fully resolved.

--- a/.changeset/weak-hairs-notice.md
+++ b/.changeset/weak-hairs-notice.md
@@ -2,4 +2,4 @@
 "@justifi/webcomponents": patch
 ---
 
-- Addressed an issue previously marked as resolved in the `PaymentForm` component where the card form was being shown instead of the bank account form when the card prop was false and the bank-account prop was true. The issue persisted under certain conditions and is now fully resolved.
+- Fully resolved issue with the `PaymentForm` component props that show bank-account form.

--- a/packages/webcomponents/src/components/payment-form/payment-form.tsx
+++ b/packages/webcomponents/src/components/payment-form/payment-form.tsx
@@ -14,7 +14,7 @@ import { getErrorMessage } from '../../api/services/utils';
 })
 export class PaymentForm {
   @Prop() bankAccount?: boolean;
-  @Prop() card?: boolean = true;
+  @Prop() card?: boolean;
   @Prop() email?: string;
   @Prop() clientId?: string;
   @Prop() authToken?: string;

--- a/packages/webcomponents/src/components/payment-form/test/payment-form.spec.tsx
+++ b/packages/webcomponents/src/components/payment-form/test/payment-form.spec.tsx
@@ -61,7 +61,7 @@ describe('justifi-payment-form', () => {
 
     // Assert that the properties exist and have the expected default values
     expect(paymentForm).toHaveProperty('bankAccount', undefined);
-    expect(paymentForm).toHaveProperty('card', true);
+    expect(paymentForm).toHaveProperty('card', undefined);
     expect(paymentForm).toHaveProperty('email', undefined);
     expect(paymentForm).toHaveProperty('clientId', undefined);
     expect(paymentForm).toHaveProperty('accountId', undefined);


### PR DESCRIPTION
### Fix PaymentForm prop logic for card and bankAccount

Fixes an existing bug on the PaymentForm related to the card and bankAccount props. Removes the default `true` for card prop that never gets changed, and thus never allows the other prop to work correctly. 


Links
-----

Closes #537 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------



