### PR TITLE
Improve address validation billing form

### DIFF
--- a/.changeset/nice-feet-train.md
+++ b/.changeset/nice-feet-train.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Improved form validations for billing form fields in `PaymentForm` and `Checkout` components

--- a/packages/webcomponents/src/components/billing-form/billing-form-schema.ts
+++ b/packages/webcomponents/src/components/billing-form/billing-form-schema.ts
@@ -1,6 +1,9 @@
 import { object, string } from 'yup';
 import { RegExZip } from '../../utils/utils';
 
+// All of these schema validations already exist in the schema files in business-form directory. 
+// I want to make a common schema directory for top level access to all schema files. I guess?
+
 export interface BillingFormFields {
   name: string;
   address_line1: string;

--- a/packages/webcomponents/src/components/billing-form/billing-form-schema.ts
+++ b/packages/webcomponents/src/components/billing-form/billing-form-schema.ts
@@ -1,9 +1,12 @@
-import { object, string } from 'yup';
-import { RegExZip } from '../../utils/utils';
-
-// All of these schema validations already exist in the schema files in business-form directory. 
-// I want to make a common schema directory for top level access to all schema files. I guess?
-
+import { object } from 'yup';
+import { 
+  cityValidation,
+  identityNameValidation, 
+  lineOneValidation, 
+  lineTwoValidation,
+  postalValidation,
+  stateValidation
+} from '../business-forms/schemas/schema-validations';
 export interface BillingFormFields {
   name: string;
   address_line1: string;
@@ -14,12 +17,12 @@ export interface BillingFormFields {
 }
 
 const BillingFormSchema = object({
-  name: string().required('Enter name'),
-  address_line1: string().required('Enter street address'),
-  address_line2: string(),
-  address_city: string().required('Enter city'),
-  address_state: string().required('Choose state'),
-  address_postal_code: string().required('Enter ZIP').matches(RegExZip, 'Enter a valid ZIP').min(5, 'Enter a valid ZIP'),
+  name: identityNameValidation.required('Enter full name'),
+  address_line1: lineOneValidation.required('Enter street address'),
+  address_line2: lineTwoValidation.nullable(),
+  address_city: cityValidation.required('Enter city'),
+  address_state: stateValidation.required('Select state'),
+  address_postal_code: postalValidation.required('Enter postal code'),
 });
 
 export default BillingFormSchema;

--- a/packages/webcomponents/src/components/billing-form/billing-form.tsx
+++ b/packages/webcomponents/src/components/billing-form/billing-form.tsx
@@ -1,7 +1,7 @@
-import { Component, Host, h, State, Listen, Method, Prop } from '@stencil/core';
-import { ValidationError } from 'yup';
+import { Component, Host, h, State, Prop, Method } from '@stencil/core';
 import BillingFormSchema, { BillingFormFields } from './billing-form-schema';
 import StateOptions from '../../utils/state-options';
+import { FormController } from '../form/form';
 
 /**
  * @exportedPart label: Label for inputs
@@ -18,104 +18,114 @@ export class BillingForm {
    * (Optional) A label for the form.
    */
   @Prop({ mutable: true }) legend?: string;
-  @State() billingFields: BillingFormFields = {
-    name: '',
-    address_line1: '',
-    address_line2: '',
-    address_city: '',
-    address_state: '',
-    address_postal_code: '',
-  };
+  @State() formController: FormController;
+  @State() billingInfo: {}
+  @State() errors: any = {};
 
-  @State() billingFieldsErrors: any = {};
-
-  @Listen('fieldReceivedInput')
-  setFormValue(event) {
-    const data = event.detail;
-    const billingFieldsClone = { ...this.billingFields };
-    if (data.name) {
-      billingFieldsClone[data.name] = data.value;
-      this.billingFields = billingFieldsClone;
-    }
+  componentWillLoad() {
+    this.formController = new FormController(BillingFormSchema);
   }
 
-  /**
-   * Method for filling the form with provided data
-   * @argument {BillingFormFields} fields - The fields to fill the form with
-   */
+  componentDidLoad() {
+    this.formController.values.subscribe(values =>
+      this.billingInfo = { ...values }
+    );
+    this.formController.errors.subscribe(errors => {
+      this.errors = { ...errors };
+    });
+  }
+
+  inputHandler = (name: string, value: string) => {
+    this.formController.setValues({
+      ...this.formController.values.getValue(),
+      [name]: value,
+    });
+  }
+
+  @Method()
+  async getValues(): Promise<BillingFormFields> {
+    return this.formController.values.getValue();
+  }
+
   @Method()
   async fill(fields: BillingFormFields) {
-    this.billingFields = { ...fields };
+    this.formController.setValues(fields);
   }
 
-  /**
-   * Run validation on the form
-   */
   @Method()
-  async validate() {
-    const newErrors = {};
-    let isValid: boolean = true;
-
-    try {
-      await BillingFormSchema.validate(this.billingFields, { abortEarly: false });
-    } catch (err) {
-      isValid = false;
-      err.inner.map((item: ValidationError) => {
-        newErrors[item.path] = item.message;
-      });
-    }
-
-    this.billingFieldsErrors = newErrors;
-
+  async validate(): Promise<{ isValid: boolean }>{
+    let isValid: boolean = await this.formController.validate();
     return { isValid: isValid };
   }
 
-  /**
-   * Returns the values of the form as an object
-   * @returns {Promise<BillingFormFields>} The values of the form
-   */
-  @Method()
-  async getValues(): Promise<BillingFormFields> {
-    return this.billingFields;
-  }
-
   render() {
+
+    const billingFormDefaultValue = this.formController.getInitialValues();
+
     return (
       <Host exportparts="label,input,input-invalid">
-        <fieldset>
-          {this.legend && <legend>{this.legend}</legend>}
-          <div class="row gy-3">
-            <div class="col-12">
-              <text-input name="name" label="Full Name" defaultValue={this.billingFields.name} error={this.billingFieldsErrors.name} />
+        <form>
+          <fieldset>
+            {this.legend && <legend>{this.legend}</legend>}
+            <div class="row gy-3">
+              <div class="col-12">
+                <form-control-text
+                  name='name'
+                  label='Full Name'
+                  defaultValue={billingFormDefaultValue.name}
+                  error={this.errors.name}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12">
+                <form-control-text
+                  name='address_line1'
+                  label='Street Address'
+                  defaultValue={billingFormDefaultValue.address_line1}
+                  error={this.errors.address_line1}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12">
+                <form-control-text
+                  name='address_line2'
+                  label="Apartment, Suite, etc. (optional)"
+                  defaultValue={billingFormDefaultValue.address_line2}
+                  error={this.errors.address_line2}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12">
+                <form-control-text
+                  name='address_city'
+                  label="City"
+                  defaultValue={billingFormDefaultValue.address_city}
+                  error={this.errors.address_city}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12">
+                <form-control-select
+                  name='address_state'
+                  label='State'
+                  options={StateOptions}
+                  defaultValue={billingFormDefaultValue.address_state}
+                  error={this.errors.address_state}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12">
+                <form-control-text
+                  name='address_postal_code'
+                  label="ZIP"
+                  defaultValue={billingFormDefaultValue.address_postal_code}
+                  error={this.errors.address_postal_code}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
             </div>
-            <div class="col-12">
-              <text-input name="address_line1" label="Street Address" defaultValue={this.billingFields.address_line1} error={this.billingFieldsErrors.address_line1} />
-            </div>
-            <div class="col-12">
-              <text-input
-                name="address_line2"
-                label="Apartment, Suite, etc. (optional)"
-                defaultValue={this.billingFields.address_line2}
-                error={this.billingFieldsErrors.address_line2}
-              />
-            </div>
-            <div class="col-12">
-              <text-input name="address_city" label="City" defaultValue={this.billingFields.address_city} error={this.billingFieldsErrors.address_city} />
-            </div>
-            <div class="col-12">
-              <select-input
-                name="address_state"
-                label="State"
-                options={StateOptions}
-                defaultValue={this.billingFields.address_state}
-                error={this.billingFieldsErrors.address_state}
-              />
-            </div>
-            <div class="col-12">
-              <text-input name="address_postal_code" label="ZIP" defaultValue={this.billingFields.address_postal_code} error={this.billingFieldsErrors.address_postal_code} />
-            </div>
-          </div>
-        </fieldset>
+          </fieldset>
+        </form>
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/billing-form/billing-form.tsx
+++ b/packages/webcomponents/src/components/billing-form/billing-form.tsx
@@ -2,6 +2,7 @@ import { Component, Host, h, State, Prop, Method } from '@stencil/core';
 import BillingFormSchema, { BillingFormFields } from './billing-form-schema';
 import StateOptions from '../../utils/state-options';
 import { FormController } from '../form/form';
+import { filterPostalInput } from '../form/utils';
 
 /**
  * @exportedPart label: Label for inputs
@@ -121,6 +122,8 @@ export class BillingForm {
                   defaultValue={billingFormDefaultValue.address_postal_code}
                   error={this.errors.address_postal_code}
                   inputHandler={this.inputHandler}
+                  maxLength={5}
+                  keyDownHandler={filterPostalInput}
                 />
               </div>
             </div>

--- a/packages/webcomponents/src/components/billing-form/test/billing-form.spec.tsx
+++ b/packages/webcomponents/src/components/billing-form/test/billing-form.spec.tsx
@@ -20,7 +20,9 @@ describe('justifi-billing-form', () => {
     };
 
     await instance.fill(fields);
-    expect(instance.billingFields).toEqual(fields);
+    const values = await instance.getValues();
+
+    expect(values).toEqual(fields);
   });
 
   it('validates the form', async () => {


### PR DESCRIPTION
### Improve address validation billing form

Refactors the billing form to use `FormController`, and `form-control` inputs. 

Uses schema validations for address lines that we created for Business Form schemas. 

I didn't do it in this PR, but we should follow this one up, eventually, with a PR that deletes the old input components used in billing-form, and finds a new home for the schema validations in a top level directory to be shared with all components cleanly. 


Links
-----

Closes #526 

Developer considerations
--------------

- On any task
  - [x] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

