### PR TITLE
Form control checkbox component

### DIFF
--- a/packages/webcomponents/src/components/form/form-control-checkbox.scss
+++ b/packages/webcomponents/src/components/form/form-control-checkbox.scss
@@ -1,0 +1,14 @@
+@import 'reboot';
+@import 'forms';
+
+:host {
+  @include host-base-styles;
+  display: block;
+}
+
+input[type='checkbox'][disabled] {
+  color: var(--jfi-form-control-disabled-color);
+  background-color: var(--jfi-form-control-disabled-background-color);
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/packages/webcomponents/src/components/form/form-control-checkbox.tsx
+++ b/packages/webcomponents/src/components/form/form-control-checkbox.tsx
@@ -59,7 +59,7 @@ export class CheckboxInput {
           onInput={(event: any) => this.handleFormControlInput(event)}
           onBlur={() => this.formControlBlur.emit()}
           part={`input ${this.error ? 'input-invalid' : ''}`}
-          class={this.error ? 'form-select is-invalid' : 'form-select'}
+          class={this.error ? 'form-check-input is-invalid' : 'form-check-input'}
           disabled={this.disabled}
         />
         {this.error && <div class="invalid-feedback">{this.error}</div>}

--- a/packages/webcomponents/src/components/form/form-control-checkbox.tsx
+++ b/packages/webcomponents/src/components/form/form-control-checkbox.tsx
@@ -1,0 +1,69 @@
+import {
+  Component,
+  Host,
+  h,
+  Prop,
+  Event,
+  EventEmitter,
+  Watch,
+} from '@stencil/core';
+
+@Component({
+  tag: 'form-control-checkbox',
+  styleUrl: 'form-control-checkbox.scss',
+  shadow: true,
+})
+export class CheckboxInput {
+  checkboxElement!: HTMLInputElement;
+
+  @Prop() label: string;
+  @Prop() name: any;
+  @Prop() error: string;
+  @Prop() defaultValue: boolean;
+  @Prop() inputHandler: (name: string, value: boolean) => void;
+  @Prop() disabled: boolean;
+  @Event() formControlInput: EventEmitter<any>;
+  @Event() formControlBlur: EventEmitter<any>;
+
+  @Watch('defaultValue')
+  handleDefaultValueChange(newValue: boolean) {
+    this.updateInput(newValue);
+  }
+
+  updateInput(newValue: any) {
+    this.checkboxElement.checked = newValue;
+  }
+
+  handleFormControlInput(event: any) {
+    const target = event.target;
+    const name = target.getAttribute('name');
+    this.inputHandler(name, target.checked);
+    this.formControlInput.emit(target.checked);
+  }
+
+  componentDidLoad() {
+    this.updateInput(this.defaultValue);
+  }
+
+  render() {
+    return (
+      <Host exportparts="label,input,input-invalid">
+        <label part="label" class="form-label" htmlFor={this.name}>
+          {this.label}
+        </label>
+        <input
+          ref={el => (this.checkboxElement = el as HTMLInputElement)}
+          type="checkbox"
+          id={this.name}
+          name={this.name}
+          onInput={(event: any) => this.handleFormControlInput(event)}
+          onBlur={() => this.formControlBlur.emit()}
+          part={`input ${this.error ? 'input-invalid' : ''}`}
+          class={this.error ? 'form-select is-invalid' : 'form-select'}
+          disabled={this.disabled}
+        />
+        {this.error && <div class="invalid-feedback">{this.error}</div>}
+      </Host>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-checkbox.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-checkbox.spec.tsx.snap
@@ -6,7 +6,7 @@ exports[`form-control-checkbox renders with default props 1`] = `
     <label class="form-label" htmlfor="user ID" part="label">
       Select a checkbox
     </label>
-    <input class="form-select" id="user ID" name="user ID" part="input " type="checkbox">
+    <input class="form-check-input" id="user ID" name="user ID" part="input " type="checkbox">
   </mock:shadow-root>
 </form-control-checkbox>
 `;

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-checkbox.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-checkbox.spec.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form-control-checkbox renders with default props 1`] = `
+<form-control-checkbox exportparts="label,input,input-invalid" label="Select a checkbox" name="user ID">
+  <mock:shadow-root>
+    <label class="form-label" htmlfor="user ID" part="label">
+      Select a checkbox
+    </label>
+    <input class="form-select" id="user ID" name="user ID" part="input " type="checkbox">
+  </mock:shadow-root>
+</form-control-checkbox>
+`;

--- a/packages/webcomponents/src/components/form/test/form-control-checkbox.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-checkbox.spec.tsx
@@ -1,0 +1,62 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { CheckboxInput } from '../form-control-checkbox';
+
+describe('form-control-checkbox', () => {
+
+  it('renders with default props', async () => {
+    const page = await newSpecPage({
+      components: [CheckboxInput],
+      html: `<form-control-checkbox label="Select a checkbox" name="user ID"></form-control-checkbox>`,
+    });
+
+    expect(page.root).toMatchSnapshot();
+    expect(page.rootInstance.label).toBe('Select a checkbox');
+    expect(page.rootInstance.name).toBe('user ID');
+  });
+
+  it('renders with all props provided', async () => {
+    const page = await newSpecPage({
+      components: [CheckboxInput],
+      html: `
+        <form-control-checkbox
+          label="Select a checkbox"
+          name="email"
+          error="No checkbox selected"
+          disabled
+        ></form-control-checkbox>
+      `,
+    });
+
+    const inputElement = page.root.shadowRoot.querySelector('input');
+    expect(page.rootInstance.label).toBe('Select a checkbox');
+    expect(inputElement.disabled).toBeTruthy();
+  });
+
+  it('handles user input correctly', async () => {
+    const page = await newSpecPage({
+      components: [CheckboxInput],
+      html: `<form-control-checkbox></form-control-checkbox>`,
+    });
+
+    const inputElement = page.root.shadowRoot.querySelector('input');
+    const testValue = true;
+
+    inputElement.checked = testValue;
+    await inputElement.dispatchEvent(new Event('input'));
+
+    expect(inputElement.checked).toBe(testValue);
+  });
+
+  it('emits formControlInput event on input', async () => {
+    const page = await newSpecPage({
+      components: [CheckboxInput],
+      html: `<form-control-checkbox></form-control-checkbox>`,
+    });
+
+    // Set a mock inputHandler to prevent it from being undefined
+    page.rootInstance.inputHandler = jest.fn();
+
+    const inputEventSpy = jest.fn();
+    page.root.addEventListener('formControlInput', inputEventSpy);
+  });
+});


### PR DESCRIPTION
### Add form-control-checkbox component

Quick PR to add a new `form-control` component that renders checkbox input.

Probably will get some updates in the next PR, but this should make it easier to review the terms and conditions PR if we get this one out of the way now. 


Links
-----

Closes #547 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA



Developer QA steps
--------------------

- [ ] Tests are passing - that should be sufficient for now. 

We can do a more thorough QA when we render the terms and conditions form step which will actually use this checkbox component. For right now, I believe the test coverage is sufficient. 
