### PR TITLE
Document uploading field logic

### DIFF
--- a/packages/webcomponents/src/api/Document.ts
+++ b/packages/webcomponents/src/api/Document.ts
@@ -65,12 +65,14 @@ export class EntityDocumentStorage {
 
   convertVoidedChecks(): void {
     const merged = [...this.voided_check, ...this.bank_statement];
+    
     merged.forEach(doc => {
       doc.document_type = EntityDocumentType.bankStatement;
       if (doc.record_data) {
         doc.record_data.document_type = EntityDocumentType.bankStatement;
       }
     });
+
     this.bank_statement = merged;
     this.voided_check = [];
   }

--- a/packages/webcomponents/src/api/Document.ts
+++ b/packages/webcomponents/src/api/Document.ts
@@ -16,6 +16,7 @@ export interface IDocument {
 }
 
 export enum EntityDocumentType {
+  voidedCheck = 'voided_check',
   balanceSheet = 'balance_sheet',
   bankStatement = 'bank_statement',
   governmentId = 'government_id',
@@ -44,6 +45,7 @@ export interface DocumentRecordData {
 }
 
 export class EntityDocumentStorage {
+  public voided_check: EntityDocument[];
   public balance_sheet: EntityDocument[];
   public bank_statement: EntityDocument[];
   public government_id: EntityDocument[];
@@ -52,12 +54,25 @@ export class EntityDocumentStorage {
   public other: EntityDocument[];
 
   constructor() {
+    this.voided_check = [];
     this.balance_sheet = [];
     this.bank_statement = [];
     this.government_id = [];
     this.profit_and_loss_statement = [];
     this.tax_return = [];
     this.other = [];
+  }
+
+  convertVoidedChecks(): void {
+    const merged = [...this.voided_check, ...this.bank_statement];
+    merged.forEach(doc => {
+      doc.document_type = EntityDocumentType.bankStatement;
+      if (doc.record_data) {
+        doc.record_data.document_type = EntityDocumentType.bankStatement;
+      }
+    });
+    this.bank_statement = merged;
+    this.voided_check = [];
   }
 }
 

--- a/packages/webcomponents/src/api/Document.ts
+++ b/packages/webcomponents/src/api/Document.ts
@@ -62,20 +62,6 @@ export class EntityDocumentStorage {
     this.tax_return = [];
     this.other = [];
   }
-
-  convertVoidedChecks(): void {
-    const merged = [...this.voided_check, ...this.bank_statement];
-    
-    merged.forEach(doc => {
-      doc.document_type = EntityDocumentType.bankStatement;
-      if (doc.record_data) {
-        doc.record_data.document_type = EntityDocumentType.bankStatement;
-      }
-    });
-
-    this.bank_statement = merged;
-    this.voided_check = [];
-  }
 }
 
 export interface EntityFileData {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -43,7 +43,6 @@ export class BusinessDocumentFormStep {
     if (!this.authToken) console.error(missingAuthTokenMessage);
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
-    console.log('paymentVolume', this.paymentVolume)
     this.formController = new FormController(businessDocumentSchema(this.paymentVolume, this.allowOptionalFields));
     this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
@@ -178,7 +177,6 @@ export class BusinessDocumentFormStep {
       />
     );
   }
-
 
   render() {
     return (

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -132,7 +132,6 @@ export class BusinessDocumentFormStep {
   }
 
   sendData = async (onSuccess?: () => void) => {
-    this.documentData.convertVoidedChecks();
     const docArray = Object.values(this.documentData).flat();
     if (!docArray.length) { return; }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -6,7 +6,7 @@ import Api, { IApiResponse } from '../../../../api/Api';
 import { config } from '../../../../../config';
 import { businessDocumentSchema } from '../../schemas/business-document-upload-schema';
 import { FileSelectEvent } from '../../../../components';
-import { EntityDocumentType, EntityDocument, EntityDocumentStorage } from '../../../../api/Document';
+import { EntityDocument, EntityDocumentStorage } from '../../../../api/Document';
 
 @Component({
   tag: 'justifi-business-document-upload-form-step',
@@ -16,11 +16,13 @@ export class BusinessDocumentFormStep {
   @Prop() authToken: string;
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean;
+  @Prop() paymentVolume: string;
   @State() formController: FormController;
   @State() errors: any = {};
   @State() documents: any = [];
   @State() business: Business;
   @State() documentData: EntityDocumentStorage = new EntityDocumentStorage();
+  @State() renderState: 'loading' | 'error' | 'success' = 'loading';
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event() serverError: EventEmitter<DocumentFormServerErrorEvent>;
@@ -35,17 +37,14 @@ export class BusinessDocumentFormStep {
     return 'entities/document';
   }
 
-  get paymentVolume() {
-    return this.business?.additional_questions?.business_payment_volume;
-  }
-
   componentWillLoad() {
     const missingAuthTokenMessage = 'Warning: Missing auth-token. The form will not be functional without it.';
     const missingBusinessIdMessage = 'Warning: Missing business-id. The form requires an existing business-id to function.';
     if (!this.authToken) console.error(missingAuthTokenMessage);
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
-    this.formController = new FormController(businessDocumentSchema(this.allowOptionalFields));
+    console.log('paymentVolume', this.paymentVolume)
+    this.formController = new FormController(businessDocumentSchema(this.paymentVolume, this.allowOptionalFields));
     this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.fetchData();
   }
@@ -67,15 +66,17 @@ export class BusinessDocumentFormStep {
   }
 
   private fetchData = async () => {
+    this.renderState = 'loading';
     this.formLoading.emit(true);
     try {
       const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
-      this.documents = response.data.documents;
       this.business = { ...new Business(response.data) };
     } catch (error) {
       this.serverError.emit({ data: error, message: DocumentFormServerErrors.fetchData });
+      this.renderState = 'error';
     } finally {
       this.formLoading.emit(false);
+      this.renderState = 'success';
     }
   }
 
@@ -91,7 +92,7 @@ export class BusinessDocumentFormStep {
     }
   }
 
-  handleDocRecordResponse = (docData: EntityDocument,response: any) => {
+  handleDocRecordResponse = (docData: EntityDocument, response: any) => {
     if (response.error) {
       this.serverError.emit({ data: response.error, message: DocumentFormServerErrors.sendData });
       return false;
@@ -130,7 +131,7 @@ export class BusinessDocumentFormStep {
     const documentList = fileList.map(file => new EntityDocument({ file, document_type: docType }, this.businessId));
     this.documentData[docType] = documentList;
   }
-  
+
   sendData = async (onSuccess?: () => void) => {
     const docArray = Object.values(this.documentData).flat();
     if (!docArray.length) { return; }
@@ -152,90 +153,46 @@ export class BusinessDocumentFormStep {
     this.formController.validateAndSubmit(() => this.sendData(onSuccess));
   }
 
+  get isLoading() {
+    return this.renderState === 'loading';
+  }
+
+  get isError() {
+    return this.renderState === 'error';
+  }
+
+  get formInputs() {
+    if (this.isError) {
+      return null;
+    }
+     if (this.isLoading) {
+      return <justifi-skeleton variant='rounded' height={'350px'} />;   
+    }
+
+    return (
+      <justifi-business-document-upload-input-group
+        paymentVolume={this.paymentVolume}
+        inputHandler={this.inputHandler}
+        storeFiles={this.storeFiles}
+        errors={this.errors}
+      />
+    );
+  }
+
+
   render() {
     return (
       <Host exportparts="label,input,input-invalid">
         <form>
           <fieldset>
-          <legend>Document Uploads</legend>
-          <p>Various file formats such as PDF, DOC, DOCX, JPEG, and others are accepted. Multiple files can be uploaded for each document category.</p>
-          <hr />
-          <div class="row gy-3">
-            <div class="col-12 col-md-6">
-              <form-control-file
-                name="balance_sheet"
-                label="Upload FYE Balance Sheet"
-                inputHandler={this.inputHandler}
-                error={this.errors?.balance_sheet}
-                documentType={EntityDocumentType.balanceSheet}
-                onFileSelected={this.storeFiles}
-                multiple={true}
-                helpText='Please upload the most recent 2 years of balance sheets for your business.'
-              />
+            <legend>Document Uploads</legend>
+            <p>Various file formats such as PDF, DOC, DOCX, JPEG, and others are accepted. Multiple files can be uploaded for each document category.</p>
+            <hr />
+            <div class="d-flex flex-column">
+              {this.formInputs}
             </div>
-            <div class="col-12 col-md-6">
-              <form-control-file
-                name="bank_statement"
-                label="Upload Voided Check / Bank Statements"
-                inputHandler={this.inputHandler}
-                error={this.errors?.bank_statement}
-                documentType={EntityDocumentType.bankStatement}
-                onFileSelected={this.storeFiles}
-                multiple={true}
-                helpText='Please upload a voided check and/or 3 months of bank statements for the business.'
-              />
-            </div>
-            <div class="col-12 col-md-6">
-              <form-control-file
-                name="government_id"
-                label="Upload Government ID"
-                inputHandler={this.inputHandler}
-                error={this.errors?.government_id}
-                documentType={EntityDocumentType.governmentId}
-                onFileSelected={this.storeFiles}
-                multiple={true}
-                helpText='Please upload a government issued ID for the business owner.'
-              />
-            </div>
-            <div class="col-12 col-md-6">
-              <form-control-file
-                name="profit_and_loss_statement"
-                label="Upload Profit and Loss Statement"
-                inputHandler={this.inputHandler}
-                error={this.errors?.profit_and_loss_statement}
-                documentType={EntityDocumentType.profitAndLossStatement}
-                onFileSelected={this.storeFiles}
-                multiple={true}
-                helpText='Please upload the most recent profit and loss statement for your business.'
-              />
-            </div>
-            <div class="col-12 col-md-6">
-              <form-control-file
-                name="tax_return"
-                label="Upload Tax Return"
-                inputHandler={this.inputHandler}
-                error={this.errors?.tax_return}
-                documentType={EntityDocumentType.taxReturn}
-                onFileSelected={this.storeFiles}
-                multiple={true}
-                helpText='Please upload the most recent tax return for your business.'
-              />
-            </div>
-            <div class="col-12 col-md-6">
-              <form-control-file
-                name="other"
-                label="Upload any other documents"
-                inputHandler={this.inputHandler}
-                error={this.errors?.other}
-                documentType={EntityDocumentType.other}
-                onFileSelected={this.storeFiles}
-                multiple={true}
-                helpText='Please upload any other documents that may be relevant to your business.'
-              />
-            </div>
-          </div>
-        </fieldset>
-      </form>
+          </fieldset>
+        </form>
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -132,6 +132,7 @@ export class BusinessDocumentFormStep {
   }
 
   sendData = async (onSuccess?: () => void) => {
+    this.documentData.convertVoidedChecks();
     const docArray = Object.values(this.documentData).flat();
     if (!docArray.length) { return; }
 
@@ -143,7 +144,7 @@ export class BusinessDocumentFormStep {
     const uploadsCompleted = await Promise.all(uploads);
     if (!uploadsCompleted) { return; }
 
-    this.formLoading.emit(false);
+    uploadsCompleted && this.formLoading.emit(false);
     await onSuccess();
   }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
@@ -19,7 +19,7 @@ export class BusinessDocumentUploadInputGroup {
   inputConfigs = [
     inputConfigurations.voidedCheck,
     inputConfigurations.governmentId,
-    inputConfigurations.taxReturn,
+    inputConfigurations.ss4,
     inputConfigurations.other,
   ];
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
@@ -39,8 +39,12 @@ export class BusinessDocumentUploadInputGroup {
     return this.inputConfigs;
   }
 
+  componentWillLoad() {
+    this.getInputGroup();
+  }
+
   render() {
-    const inputsConfig = this.getInputGroup();
+    const inputsConfig = this.inputConfigs;
 
     return (
       <Host>

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
@@ -1,0 +1,66 @@
+// import { Component, h, Prop, State, Event, EventEmitter, Host, Method } from '@stencil/core';
+
+import { Component, Prop, Host, h } from '@stencil/core';
+import { FileSelectEvent } from '../../../../api/Document';
+import { inputConfigurations } from './input-configurations';
+import { isInRange } from '../../../../utils/utils';
+
+@Component({
+  tag: 'justifi-business-document-upload-input-group',
+  styleUrl: 'business-document-upload-form-step.scss',
+  shadow: true,
+})
+export class BusinessDocumentUploadInputGroup {
+  @Prop() paymentVolume: string;
+  @Prop() inputHandler: (name: string, value: string) => void;
+  @Prop() storeFiles: (e: CustomEvent<FileSelectEvent>) => void
+  @Prop() errors: any;
+
+  inputConfigs = [
+    inputConfigurations.voidedCheck,
+    inputConfigurations.governmentId,
+    inputConfigurations.taxReturn,
+    inputConfigurations.other,
+  ];
+
+  getInputGroup() {
+    let volume = parseInt(this.paymentVolume)
+
+    if (isInRange(volume, 250000, 999999)) {
+      this.inputConfigs.unshift(inputConfigurations.bankStatements)
+    } else if (volume >= 1000000) {
+      this.inputConfigs.unshift(
+        inputConfigurations.balanceSheet, 
+        inputConfigurations.profitAndLossStatement, 
+        inputConfigurations.bankStatements
+      )
+    }
+
+    return this.inputConfigs;
+  }
+
+  render() {
+    const inputsConfig = this.getInputGroup();
+
+    return (
+      <Host>
+        <div class="row gy-3">
+        {inputsConfig.map(config => (
+          <div class="col-12 col-md-6">
+            <form-control-file
+              name={config.name}
+              label={config.label}
+              helpText={config.helpText}
+              documentType={config.documentType}
+              inputHandler={this.inputHandler}
+              onFileSelected={this.storeFiles}
+              error={this.errors[config.name]}
+              multiple={true}
+            />
+          </div>
+        ))}
+        </div>
+      </Host>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-input-group.tsx
@@ -1,5 +1,3 @@
-// import { Component, h, Prop, State, Event, EventEmitter, Host, Method } from '@stencil/core';
-
 import { Component, Prop, Host, h } from '@stencil/core';
 import { FileSelectEvent } from '../../../../api/Document';
 import { inputConfigurations } from './input-configurations';

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
@@ -38,7 +38,7 @@ const profitAndLossStatement = {
 const ss4 = {
   name: 'ss4',
   label: 'Upload SS4 / Article of Incorporation',
-  documentType: EntityDocumentType.other,
+  documentType: EntityDocumentType.taxReturn,
   helpText: "Please upload the business's SS4 / Article of Incorporation."
 };
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
@@ -1,0 +1,60 @@
+import { EntityDocumentType } from "../../../../api/Document";
+
+const voidedCheck = {
+  name: 'voided_check',
+  label: 'Upload Voided Check',
+  documentType: EntityDocumentType.bankStatement,
+  helpText: 'Please upload a voided check for the business.'
+};
+
+const bankStatements = {
+  name: 'bank_statement',
+  label: 'Upload Bank Statements',
+  documentType: EntityDocumentType.bankStatement,
+  helpText: 'Please upload 3 months of bank statements for the business.'
+};
+
+const balanceSheet = {
+  name: 'balance_sheet',
+  label: 'Upload FYE Balance Sheet',
+  documentType: EntityDocumentType.balanceSheet,
+  helpText: 'Please upload the most recent 2 years of balance sheets.'
+};
+
+const governmentId = {
+  name: 'government_id',
+  label: 'Upload Government ID',
+  documentType: EntityDocumentType.governmentId,
+  helpText: 'Please upload a government issued ID for the business owner.'
+};
+
+const profitAndLossStatement = {
+  name: 'profit_and_loss_statement',
+  label: 'Upload Profit and Loss Statements',
+  documentType: EntityDocumentType.profitAndLossStatement,
+  helpText: 'Please upload the most recent profit and loss statements.'
+};
+
+const taxReturn = {
+  name: 'tax_return',
+  label: 'Upload Tax Return',
+  documentType: EntityDocumentType.taxReturn,
+  helpText: "Please upload the business's most recent tax return."
+};
+
+const other = {
+  name: 'other',
+  label: 'Upload any other documents',
+  documentType: EntityDocumentType.other,
+  helpText: 'Please upload any other documents that may be relevant to your business.'
+};
+
+export const inputConfigurations = {
+  voidedCheck,
+  bankStatements,
+  balanceSheet,
+  governmentId,
+  profitAndLossStatement,
+  taxReturn,
+  other
+};

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
@@ -3,7 +3,7 @@ import { EntityDocumentType } from "../../../../api/Document";
 const voidedCheck = {
   name: 'voided_check',
   label: 'Upload Voided Check',
-  documentType: EntityDocumentType.bankStatement,
+  documentType: EntityDocumentType.voidedCheck,
   helpText: 'Please upload a voided check for the business.'
 };
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
@@ -35,10 +35,10 @@ const profitAndLossStatement = {
   helpText: 'Please upload the most recent profit and loss statements.'
 };
 
-const taxReturn = {
-  name: 'tax_return',
+const ss4 = {
+  name: 'ss4',
   label: 'Upload SS4 / Article of Incorporation',
-  documentType: EntityDocumentType.taxReturn,
+  documentType: EntityDocumentType.other,
   helpText: "Please upload the business's SS4 / Article of Incorporation."
 };
 
@@ -55,6 +55,6 @@ export const inputConfigurations = {
   balanceSheet,
   governmentId,
   profitAndLossStatement,
-  taxReturn,
+  ss4,
   other
 };

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
@@ -37,9 +37,9 @@ const profitAndLossStatement = {
 
 const taxReturn = {
   name: 'tax_return',
-  label: 'Upload Tax Return',
+  label: 'Upload SS4 / Article of Incorporation',
   documentType: EntityDocumentType.taxReturn,
-  helpText: "Please upload the business's most recent tax return."
+  helpText: "Please upload the business's SS4 / Article of Incorporation."
 };
 
 const other = {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
@@ -36,8 +36,7 @@ export class PaymentProvisioning {
     if (!this.authToken) console.error(missingAuthTokenMessage);
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
-    this.refs = [this.additionalQuestionsRef, this.documentUploadRef];
-    // this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef, this.bankAccountRef, this.documentUploadRef];
+    this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef, this.bankAccountRef, this.documentUploadRef];
   }
 
   disconnectedCallback() {
@@ -59,69 +58,69 @@ export class PaymentProvisioning {
   get businessEndpoint() {
     return `entities/business/${this.businessId}`
   }
-  // private coreInfoRef: any;
-  // private legalAddressRef: any;
+  private coreInfoRef: any;
+  private legalAddressRef: any;
   private additionalQuestionsRef: any;
-  // private representativeRef: any;
-  // private ownersRef: any;
-  // private bankAccountRef: any;
+  private representativeRef: any;
+  private ownersRef: any;
+  private bankAccountRef: any;
   private documentUploadRef: any;
   private refs = [];
 
   componentStepMapping = {
-    // 0: () => <justifi-business-core-info-form-step
-    //   businessId={this.businessId}
-    //   authToken={this.authToken}
-    //   ref={(el) => this.refs[0] = el}
-    //   onFormLoading={this.handleFormLoading}
-    //   onServerError={this.handleServerErrors}
-    //   allowOptionalFields={this.allowOptionalFields}
-    // />,
-    // 1: () => <justifi-legal-address-form-step
-    //   businessId={this.businessId}
-    //   authToken={this.authToken}
-    //   ref={(el) => this.refs[1] = el}
-    //   onFormLoading={this.handleFormLoading}
-    //   onServerError={this.handleServerErrors}
-    //   allowOptionalFields={this.allowOptionalFields}
-    // />,
-    0: () => <justifi-additional-questions-form-step
+    0: () => <justifi-business-core-info-form-step
       businessId={this.businessId}
       authToken={this.authToken}
       ref={(el) => this.refs[0] = el}
       onFormLoading={this.handleFormLoading}
       onServerError={this.handleServerErrors}
       allowOptionalFields={this.allowOptionalFields}
-      onSubmitted={this.setBusinessPaymentVolume}
     />,
-    // 3: () => <justifi-business-representative-form-step
-    //   businessId={this.businessId}
-    //   authToken={this.authToken}
-    //   ref={(el) => this.refs[3] = el}
-    //   onFormLoading={this.handleFormLoading}
-    //   onServerError={this.handleServerErrors}
-    //   allowOptionalFields={this.allowOptionalFields}
-    // />,
-    // 4: () => <justifi-business-owners-form-step
-    //   businessId={this.businessId}
-    //   authToken={this.authToken}
-    //   ref={(el) => this.refs[4] = el}
-    //   onFormLoading={this.handleFormLoading}
-    //   onServerError={this.handleServerErrors}
-    //   allowOptionalFields={this.allowOptionalFields}
-    // />,
-    // 5: () => <justifi-business-bank-account-form-step
-    //   businessId={this.businessId}
-    //   authToken={this.authToken}
-    //   ref={(el) => this.refs[5] = el}
-    //   onFormLoading={this.handleFormLoading}
-    //   onServerError={this.handleServerErrors}
-    //   allowOptionalFields={this.allowOptionalFields}
-    // />,
-    1: () => <justifi-business-document-upload-form-step
+    1: () => <justifi-legal-address-form-step
       businessId={this.businessId}
       authToken={this.authToken}
       ref={(el) => this.refs[1] = el}
+      onFormLoading={this.handleFormLoading}
+      onServerError={this.handleServerErrors}
+      allowOptionalFields={this.allowOptionalFields}
+    />,
+    2: () => <justifi-additional-questions-form-step
+      businessId={this.businessId}
+      authToken={this.authToken}
+      ref={(el) => this.refs[2] = el}
+      onFormLoading={this.handleFormLoading}
+      onServerError={this.handleServerErrors}
+      allowOptionalFields={this.allowOptionalFields}
+      onSubmitted={this.setBusinessPaymentVolume}
+    />,
+    3: () => <justifi-business-representative-form-step
+      businessId={this.businessId}
+      authToken={this.authToken}
+      ref={(el) => this.refs[3] = el}
+      onFormLoading={this.handleFormLoading}
+      onServerError={this.handleServerErrors}
+      allowOptionalFields={this.allowOptionalFields}
+    />,
+    4: () => <justifi-business-owners-form-step
+      businessId={this.businessId}
+      authToken={this.authToken}
+      ref={(el) => this.refs[4] = el}
+      onFormLoading={this.handleFormLoading}
+      onServerError={this.handleServerErrors}
+      allowOptionalFields={this.allowOptionalFields}
+    />,
+    5: () => <justifi-business-bank-account-form-step
+      businessId={this.businessId}
+      authToken={this.authToken}
+      ref={(el) => this.refs[5] = el}
+      onFormLoading={this.handleFormLoading}
+      onServerError={this.handleServerErrors}
+      allowOptionalFields={this.allowOptionalFields}
+    />,
+    6: () => <justifi-business-document-upload-form-step
+      businessId={this.businessId}
+      authToken={this.authToken}
+      ref={(el) => this.refs[6] = el}
       onFormLoading={this.handleFormLoading}
       onServerError={this.handleServerErrors}
       allowOptionalFields={this.allowOptionalFields}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
@@ -24,6 +24,7 @@ export class PaymentProvisioning {
   @State() formLoading: boolean = false;
   @State() errorMessage: string = '';
   @State() currentStep: number = 0;
+  @State() businessPaymentVolume: string;
   @Event({eventName: 'click-event'}) clickEvent: EventEmitter<BusinessFormClickEvent>;
 
   analytics: JustifiAnalytics;
@@ -35,7 +36,8 @@ export class PaymentProvisioning {
     if (!this.authToken) console.error(missingAuthTokenMessage);
     if (!this.businessId) console.error(missingBusinessIdMessage);
 
-    this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef, this.bankAccountRef, this.documentUploadRef];
+    this.refs = [this.additionalQuestionsRef, this.documentUploadRef];
+    // this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef, this.bankAccountRef, this.documentUploadRef];
   }
 
   disconnectedCallback() {
@@ -57,71 +59,73 @@ export class PaymentProvisioning {
   get businessEndpoint() {
     return `entities/business/${this.businessId}`
   }
-  private coreInfoRef: any;
-  private legalAddressRef: any;
+  // private coreInfoRef: any;
+  // private legalAddressRef: any;
   private additionalQuestionsRef: any;
-  private representativeRef: any;
-  private ownersRef: any;
-  private bankAccountRef: any;
+  // private representativeRef: any;
+  // private ownersRef: any;
+  // private bankAccountRef: any;
   private documentUploadRef: any;
   private refs = [];
 
   componentStepMapping = {
-    0: () => <justifi-business-core-info-form-step
+    // 0: () => <justifi-business-core-info-form-step
+    //   businessId={this.businessId}
+    //   authToken={this.authToken}
+    //   ref={(el) => this.refs[0] = el}
+    //   onFormLoading={this.handleFormLoading}
+    //   onServerError={this.handleServerErrors}
+    //   allowOptionalFields={this.allowOptionalFields}
+    // />,
+    // 1: () => <justifi-legal-address-form-step
+    //   businessId={this.businessId}
+    //   authToken={this.authToken}
+    //   ref={(el) => this.refs[1] = el}
+    //   onFormLoading={this.handleFormLoading}
+    //   onServerError={this.handleServerErrors}
+    //   allowOptionalFields={this.allowOptionalFields}
+    // />,
+    0: () => <justifi-additional-questions-form-step
       businessId={this.businessId}
       authToken={this.authToken}
       ref={(el) => this.refs[0] = el}
       onFormLoading={this.handleFormLoading}
       onServerError={this.handleServerErrors}
       allowOptionalFields={this.allowOptionalFields}
+      onSubmitted={this.setBusinessPaymentVolume}
     />,
-    1: () => <justifi-legal-address-form-step
+    // 3: () => <justifi-business-representative-form-step
+    //   businessId={this.businessId}
+    //   authToken={this.authToken}
+    //   ref={(el) => this.refs[3] = el}
+    //   onFormLoading={this.handleFormLoading}
+    //   onServerError={this.handleServerErrors}
+    //   allowOptionalFields={this.allowOptionalFields}
+    // />,
+    // 4: () => <justifi-business-owners-form-step
+    //   businessId={this.businessId}
+    //   authToken={this.authToken}
+    //   ref={(el) => this.refs[4] = el}
+    //   onFormLoading={this.handleFormLoading}
+    //   onServerError={this.handleServerErrors}
+    //   allowOptionalFields={this.allowOptionalFields}
+    // />,
+    // 5: () => <justifi-business-bank-account-form-step
+    //   businessId={this.businessId}
+    //   authToken={this.authToken}
+    //   ref={(el) => this.refs[5] = el}
+    //   onFormLoading={this.handleFormLoading}
+    //   onServerError={this.handleServerErrors}
+    //   allowOptionalFields={this.allowOptionalFields}
+    // />,
+    1: () => <justifi-business-document-upload-form-step
       businessId={this.businessId}
       authToken={this.authToken}
       ref={(el) => this.refs[1] = el}
       onFormLoading={this.handleFormLoading}
       onServerError={this.handleServerErrors}
       allowOptionalFields={this.allowOptionalFields}
-    />,
-    2: () => <justifi-additional-questions-form-step
-      businessId={this.businessId}
-      authToken={this.authToken}
-      ref={(el) => this.refs[2] = el}
-      onFormLoading={this.handleFormLoading}
-      onServerError={this.handleServerErrors}
-      allowOptionalFields={this.allowOptionalFields}
-    />,
-    3: () => <justifi-business-representative-form-step
-      businessId={this.businessId}
-      authToken={this.authToken}
-      ref={(el) => this.refs[3] = el}
-      onFormLoading={this.handleFormLoading}
-      onServerError={this.handleServerErrors}
-      allowOptionalFields={this.allowOptionalFields}
-    />,
-    4: () => <justifi-business-owners-form-step
-      businessId={this.businessId}
-      authToken={this.authToken}
-      ref={(el) => this.refs[4] = el}
-      onFormLoading={this.handleFormLoading}
-      onServerError={this.handleServerErrors}
-      allowOptionalFields={this.allowOptionalFields}
-    />,
-    5: () => <justifi-business-bank-account-form-step
-      businessId={this.businessId}
-      authToken={this.authToken}
-      ref={(el) => this.refs[5] = el}
-      onFormLoading={this.handleFormLoading}
-      onServerError={this.handleServerErrors}
-      allowOptionalFields={this.allowOptionalFields}
-    />,
-    6: () => <justifi-business-document-upload-form-step
-      businessId={this.businessId}
-      authToken={this.authToken}
-      ref={(el) => this.refs[6] = el}
-      onFormLoading={this.handleFormLoading}
-      onServerError={this.handleServerErrors}
-      allowOptionalFields={this.allowOptionalFields}
+      paymentVolume={this.businessPaymentVolume}
     />,
   };
 
@@ -131,6 +135,11 @@ export class PaymentProvisioning {
 
   handleServerErrors = (e: CustomEvent) => {
     this.errorMessage = e.detail.message;
+  }
+
+  setBusinessPaymentVolume = (e: CustomEvent) => {
+    let business = e.detail.data.data;
+    this.businessPaymentVolume = business?.additional_questions.business_payment_volume;
   }
 
   showPreviousStepButton() {
@@ -174,7 +183,7 @@ export class PaymentProvisioning {
       <Host exportparts="label,input,input-invalid">
         <h1>{this.title}</h1>
         {this.showErrors && FormAlert(this.errorMessage)}
-        <div class="my-4">
+        <div class="my-4" id='form-container'>
           {this.currentStepComponent()}
         </div>
         <div class="d-flex justify-content-between align-items-center">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
@@ -182,7 +182,7 @@ export class PaymentProvisioning {
       <Host exportparts="label,input,input-invalid">
         <h1>{this.title}</h1>
         {this.showErrors && FormAlert(this.errorMessage)}
-        <div class="my-4" id='form-container'>
+        <div class="my-4">
           {this.currentStepComponent()}
         </div>
         <div class="d-flex justify-content-between align-items-center">

--- a/packages/webcomponents/src/components/business-forms/schemas/business-document-upload-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-document-upload-schema.ts
@@ -1,22 +1,33 @@
-import { mixed, object } from "yup";
+import { object } from 'yup';
+import {
+  balanceSheetValidation,
+  bankStatementValidation,
+  governmentIdValidation,
+  otherDocumentValidation,
+  profitAndLossStatementValidation,
+  taxReturnValidation,
+  voidedCheckValidation
+} from './schema-validations';
 
-export const businessDocumentSchema = (allowOptionalFields?: boolean) => {
+export const businessDocumentSchema = (volume: string, allowOptionalFields?: boolean) => {
   const schema = object({
-    balance_sheet: mixed().required('Please select one or more files'),
-    bank_statement: mixed().required('Please select one or more files'),
-    government_id: mixed().required('Please select one or more files'),
-    profit_and_loss_statement: mixed().required('Please select one or more files'),
-    tax_return: mixed().required('Please select one or more files'),
-    other: mixed().nullable()
+    voided_check: voidedCheckValidation.required('Please select one or more files'),
+    government_id: governmentIdValidation.nullable(),
+    tax_return: taxReturnValidation.nullable(),
+    other: otherDocumentValidation.nullable(),
+    balance_sheet: balanceSheetValidation(volume),
+    bank_statement: bankStatementValidation(volume),
+    profit_and_loss_statement: profitAndLossStatementValidation(volume),
   });
 
   const easySchema = object({
-    balance_sheet: mixed().nullable(),
-    bank_statement: mixed().nullable(),
-    government_id: mixed().nullable(),
-    profit_and_loss_statement: mixed().nullable(),
-    tax_return: mixed().nullable(),
-    other: mixed().nullable()
+    voided_check: voidedCheckValidation.nullable(),
+    government_id: governmentIdValidation.nullable(),
+    tax_return: taxReturnValidation.nullable(),
+    other: otherDocumentValidation.nullable(),
+    balance_sheet: balanceSheetValidation(volume).nullable(),
+    bank_statement: bankStatementValidation(volume).nullable(),
+    profit_and_loss_statement: profitAndLossStatementValidation(volume).nullable(),
   });
 
   return allowOptionalFields ? easySchema : schema;

--- a/packages/webcomponents/src/components/business-forms/schemas/business-document-upload-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-document-upload-schema.ts
@@ -5,7 +5,7 @@ import {
   governmentIdValidation,
   otherDocumentValidation,
   profitAndLossStatementValidation,
-  taxReturnValidation,
+  ss4Validation,
   voidedCheckValidation
 } from './schema-validations';
 
@@ -13,7 +13,7 @@ export const businessDocumentSchema = (volume: string, allowOptionalFields?: boo
   const schema = object({
     voided_check: voidedCheckValidation.required('Please select one or more files'),
     government_id: governmentIdValidation.nullable(),
-    tax_return: taxReturnValidation.nullable(),
+    ss4: ss4Validation.nullable(),
     other: otherDocumentValidation.nullable(),
     balance_sheet: balanceSheetValidation(volume),
     bank_statement: bankStatementValidation(volume),
@@ -23,7 +23,7 @@ export const businessDocumentSchema = (volume: string, allowOptionalFields?: boo
   const easySchema = object({
     voided_check: voidedCheckValidation.nullable(),
     government_id: governmentIdValidation.nullable(),
-    tax_return: taxReturnValidation.nullable(),
+    ss4: ss4Validation.nullable(),
     other: otherDocumentValidation.nullable(),
     balance_sheet: balanceSheetValidation(volume).nullable(),
     bank_statement: bankStatementValidation(volume).nullable(),

--- a/packages/webcomponents/src/components/business-forms/schemas/business-document-upload-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-document-upload-schema.ts
@@ -15,9 +15,9 @@ export const businessDocumentSchema = (volume: string, allowOptionalFields?: boo
     government_id: governmentIdValidation.nullable(),
     ss4: ss4Validation.nullable(),
     other: otherDocumentValidation.nullable(),
-    balance_sheet: balanceSheetValidation(volume),
-    bank_statement: bankStatementValidation(volume),
-    profit_and_loss_statement: profitAndLossStatementValidation(volume),
+    balance_sheet: balanceSheetValidation(volume, allowOptionalFields),
+    bank_statement: bankStatementValidation(volume, allowOptionalFields),
+    profit_and_loss_statement: profitAndLossStatementValidation(volume, allowOptionalFields),
   });
 
   const easySchema = object({
@@ -25,9 +25,9 @@ export const businessDocumentSchema = (volume: string, allowOptionalFields?: boo
     government_id: governmentIdValidation.nullable(),
     ss4: ss4Validation.nullable(),
     other: otherDocumentValidation.nullable(),
-    balance_sheet: balanceSheetValidation(volume).nullable(),
-    bank_statement: bankStatementValidation(volume).nullable(),
-    profit_and_loss_statement: profitAndLossStatementValidation(volume).nullable(),
+    balance_sheet: balanceSheetValidation(volume, allowOptionalFields),
+    bank_statement: bankStatementValidation(volume, allowOptionalFields),
+    profit_and_loss_statement: profitAndLossStatementValidation(volume, allowOptionalFields)
   });
 
   return allowOptionalFields ? easySchema : schema;

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -239,7 +239,7 @@ const documentUploadValidation = mixed();
 
 export const voidedCheckValidation = documentUploadValidation;
 
-export const taxReturnValidation = documentUploadValidation;
+export const ss4Validation = documentUploadValidation;
 
 export const governmentIdValidation = documentUploadValidation;
 

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -1,4 +1,4 @@
-import { string } from "yup";
+import { mixed, string } from "yup";
 import StateOptions from "../../../utils/state-options";
 import { 
   businessStructureOptions, 
@@ -232,3 +232,42 @@ export const routingNumberValidation = string()
     return validateRoutingNumber(value);
   })
   .transform(transformEmptyString);
+
+  // Document Upload Validations
+
+const documentUploadValidation = mixed();
+
+export const voidedCheckValidation = documentUploadValidation;
+
+export const taxReturnValidation = documentUploadValidation;
+
+export const governmentIdValidation = documentUploadValidation;
+
+export const otherDocumentValidation = documentUploadValidation;
+
+export const bankStatementValidation = (volume) => {
+  let vol = parseInt(volume);
+  return documentUploadValidation.when(volume, {
+    is: () => vol >= 250000,
+    then: (schema) => schema.required('Please select one or more files'),
+    otherwise: (schema) => schema.nullable(),
+  });
+}
+
+export const balanceSheetValidation = (volume) => {
+  let vol = parseInt(volume);
+  return documentUploadValidation.when(volume, {
+    is: () => vol >= 1000000,
+    then: (schema) => schema.required('Please select one or more files'),
+    otherwise: (schema) => schema.nullable(),
+  });
+}
+
+export const profitAndLossStatementValidation = (volume) => {
+  let vol = parseInt(volume);
+  return documentUploadValidation.when(volume, {
+    is: () => vol >= 1000000,
+    then: (schema) => schema.required('Please select one or more files'),
+    otherwise: (schema) => schema.nullable(),
+  });
+}

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -245,28 +245,28 @@ export const governmentIdValidation = documentUploadValidation;
 
 export const otherDocumentValidation = documentUploadValidation;
 
-export const bankStatementValidation = (volume) => {
+export const bankStatementValidation = (volume: string, allowOptionalFields: boolean) => {
   let vol = parseInt(volume);
   return documentUploadValidation.when(volume, {
-    is: () => vol >= 250000,
+    is: () => vol >= 250000 && !allowOptionalFields,
     then: (schema) => schema.required('Please select one or more files'),
     otherwise: (schema) => schema.nullable(),
   });
 }
 
-export const balanceSheetValidation = (volume) => {
+export const balanceSheetValidation = (volume: string, allowOptionalFields: boolean) => {
   let vol = parseInt(volume);
   return documentUploadValidation.when(volume, {
-    is: () => vol >= 1000000,
+    is: () => vol >= 1000000 && !allowOptionalFields,
     then: (schema) => schema.required('Please select one or more files'),
     otherwise: (schema) => schema.nullable(),
   });
 }
 
-export const profitAndLossStatementValidation = (volume) => {
+export const profitAndLossStatementValidation = (volume: string, allowOptionalFields: boolean) => {
   let vol = parseInt(volume);
   return documentUploadValidation.when(volume, {
-    is: () => vol >= 1000000,
+    is: () => vol >= 1000000 && !allowOptionalFields,
     then: (schema) => schema.required('Please select one or more files'),
     otherwise: (schema) => schema.nullable(),
   });

--- a/packages/webcomponents/src/utils/utils.ts
+++ b/packages/webcomponents/src/utils/utils.ts
@@ -241,3 +241,7 @@ export async function loadFontsOnParent() {
 export function isEmptyObject(obj) {
   return Object.keys(obj).length === 0 && obj.constructor === Object;
 }
+
+export const isInRange = (num, min, max) => {
+  return num >= min && num <= max;
+};


### PR DESCRIPTION
### Document Upload Schema and Render Logic

This PR builds the changes introduced in #521 

Beginning with this PR - the `PaymentProvisioning` component holds `business_payment_volume` in state after completing the additional questions form step, and uses this number to determine which file inputs are rendered and required during validation. 


Links
-----

Closes #553 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA



Developer QA steps
--------------------

In order to test this properly, you'll need to just complete the form a few times, and each time you need to pay special attention to the value you provide during the Additional Questions form step - to `Anticipated Payment Volume` (the second field on the page)

You can use the same business for these first steps:

Case A - `payment_volume` is less than `249,999` 
You will need to enter `249,999` or less in the `payment_volume` field on the additional questions form step. 
- [ ] Verify that the Document Upload Step renders 4 inputs: `voided_check`, `government_id`, `ss4`, and `other`
- [ ] Attempt to submit without entering anything - form validation should only require `voided_check` for this form step to complete. 

Case B - `payment_volume` between `250,000` and `999,999` 
You will need to enter a number in this range ^^^ in the  `payment_volume` field on the additional questions form step. 
- [ ] Verify that the Document Upload Step renders 5 inputs: `bank_statement`, `voided_check`, `government_id`, `ss4`, and `other`
- [ ] Attempt to submit without entering anything - form validation should only require `bank_statement`, and `voided_check` for this form step to complete.  

Case C - `payment_volume` is greater than `1,000,000` 
You will need to enter `1,000,000` or greater in the `payment_volume` field on the additional questions form step. 
- [ ] Verify that the Document Upload Step renders 7 inputs: `balance_sheets`,  `profit_and_loss`, `bank_statement`, `voided_check`, `government_id`, `ss4`, and `other`
- [ ] Attempt to submit without entering anything - form validation should only require `balance_sheet`, `profit_and_loss` `bank_statement`, and `voided_check` for this form step to complete.  


Additional QA Request:
customer success requested to have separate inputs for `voided_check`, and `bank_statement` - they were previously collecting them via a single input on Formstack that is labeled `Bank Statements / Voided Check`

`voided_check` is not a valid `document_type` that can be submitted to our backend - so to remedy this I have set up a class method that converts anything in the `voided_check` list to have the document_type `bank_statement`

- [ ] Please verify that items uploaded to the `voided_check` input are uploaded with `document_type === bank_statement`