### PR TITLE
add docs section for importing components using ES modules

### DIFF
--- a/apps/docs/stories/frameworks/angular.stories.mdx
+++ b/apps/docs/stories/frameworks/angular.stories.mdx
@@ -1,10 +1,10 @@
-import { Meta, Source } from "@storybook/addon-docs";
+import { Meta, Source } from '@storybook/addon-docs';
 import {
   SummaryElement,
   extractWebcomponentsVersion,
   CSSVars,
-} from "./../utils";
-import dedent from "ts-dedent";
+} from './../utils';
+import dedent from 'ts-dedent';
 
 <Meta title="Frameworks/Angular" />
 
@@ -38,6 +38,27 @@ To integrate Justifi web components into your Angular application, use the `@jus
       <script type='module'
         src='https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${extractWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js'></script>
     </head>
+  `)}
+/>
+
+Or install it from NPM and import in your Angular application:
+
+<Source
+  language="bash"
+  dark
+  code={dedent(`
+    npm install --save @justifi/webcomponents
+  `)}
+/>
+
+for instance, to use the `justifi-card-form` web component:
+
+<Source
+  language="javascript"
+  dark
+  code={dedent(`
+    import '@justifi/webcomponents/dist/module/justifi-card-form.js';
+    import '@justifi/webcomponents/dist/webcomponents/webcomponents.css';
   `)}
 />
 

--- a/apps/docs/stories/frameworks/react.stories.mdx
+++ b/apps/docs/stories/frameworks/react.stories.mdx
@@ -1,10 +1,10 @@
-import { Meta, Source } from "@storybook/addon-docs";
-import dedent from "ts-dedent";
+import { Meta, Source } from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
 import {
   SummaryElement,
   extractWebcomponentsVersion,
   CSSVars,
-} from "./../utils";
+} from './../utils';
 
 <Meta title="Frameworks/React" />
 
@@ -41,6 +41,29 @@ To use the web-components in a React app you need to add the CDN script and the 
   `}
 />
 
+or install it from NPM and import in your React application:
+
+<Source
+  language="bash"
+  dark
+  format={false}
+  code={dedent`
+    npm install --save @justifi/webcomponents
+  `}
+/>
+
+For instance, to use the `justifi-card-form` web component:
+
+<Source
+  language="javascript"
+  dark
+  format={false}
+  code={dedent`
+    import '@justifi/webcomponents/dist/module/justifi-card-form.js';
+    import '@justifi/webcomponents/dist/webcomponents/webcomponents.css';
+  `}
+/>
+
 Then you can use the components as any other HTML element:
 
 <Source
@@ -66,15 +89,21 @@ To integrate with TypeScript, declare the component in the JSX.IntrinsicElements
   dark
   format={false}
   code={dedent`
-    import React, { useState, DOMAttributes } from 'react';
+    // create a file called "register-web-components.ts"
+    import { JSX as LocalJSX } from '@justifi/webcomponents/dist/loader';
+    import { HTMLAttributes } from 'react';
 
-    type CustomElement<T> = Partial<T & DOMAttributes<T> & { children?: React.ReactNode }>;
+    type StencilToReact<T> = {
+      [P in keyof T]?: T[P] &
+        Omit<HTMLAttributes<Element>, 'className'> & {
+          class?: string;
+        };
+    };
 
     declare global {
-      namespace JSX {
-        interface IntrinsicElements {
-          'justifi-payment-form': CustomElement<any>; // Specify more specific types as needed
-        }
+      export namespace JSX {
+        interface IntrinsicElements
+          extends StencilToReact<LocalJSX.IntrinsicElements> {}
       }
     }
 

--- a/apps/docs/stories/frameworks/vue.stories.mdx
+++ b/apps/docs/stories/frameworks/vue.stories.mdx
@@ -1,6 +1,6 @@
-import { Meta, Source } from "@storybook/addon-docs";
-import dedent from "ts-dedent";
-import { CSSVars, extractWebcomponentsVersion } from "./../utils";
+import { Meta, Source } from '@storybook/addon-docs';
+import dedent from 'ts-dedent';
+import { CSSVars, extractWebcomponentsVersion } from './../utils';
 
 <Meta title="Frameworks/Vue 3" />
 
@@ -28,6 +28,27 @@ Add the web components script and stylesheet to your project's `index.html` file
       <script type='module'
         src='https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${extractWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js'></script>
     </head>
+  `)}
+/>
+
+or install it from NPM and import the component module in your Vue application:
+
+<Source
+  language="bash"
+  dark
+  code={dedent(`
+    npm install --save @justifi/webcomponents
+  `)}
+/>
+
+For instance, to use the `justifi-card-form` web component, import it in your Vue component.
+
+<Source
+  language="javascript"
+  dark
+  code={dedent(`
+    import '@justifi/webcomponents/dist/module/justifi-card-form.js';
+    import '@justifi/webcomponents/dist/webcomponents/webcomponents.css';
   `)}
 />
 

--- a/apps/docs/stories/intro.stories.mdx
+++ b/apps/docs/stories/intro.stories.mdx
@@ -61,6 +61,17 @@ It can also be installed as a package with `npm` or `yarn`
   `}
 />
 
+and import the component module using ES modules.
+
+<Source
+  language="html"
+  dark
+  format={false}
+  code={dedent`
+      import '@justifi/webcomponents/dist/module/justifi-payment-form.js';
+  `}
+/>
+
 ### Default styling
 
 In both cases, you most likely will also want to include the `CSS` file for the components to have their default styling (that you can override).
@@ -87,37 +98,16 @@ If you want to include it from the `node_modules` you'll need to get this file t
   `}
 />
 
-## React
-
-To use the React version of the web components, you need to install the package:
+Or import it in your `JS` file:
 
 <Source
-  language="bash"
+  language="javascript"
   dark
   format={false}
   code={dedent`
-    npm install --save @justifi/react-components
+    import '@justifi/webcomponents/dist/webcomponents/webcomponents.css';
   `}
 />
-
-Then import it and use it as a normal React component, for a more in-depth explanation you can search the sidebar for the component you want to use:
-
-<Source
-  language='jsx'
-  dark
-  format={false}
-  code={dedent`
-    import { JustifiCardForm } from '@justifi/react-components';
-
-    <JustifiCardForm
-      ref={cardFormRef}
-      onCardFormReady={onPaymentMethodReady}
-    />
-
-`}
-/>
-
-### For a detailed explanation of how to use the React components, [See the React page](/docs/react--docs)
 
 # Styling
 


### PR DESCRIPTION
This PR adds to the docs some instructions on how to install the package from NPM and how to import component modules in a ES module way.

This also removes the instructions about using `@justifi/react-components` in the intro docs, hence this React package is no longer supported/recommended.


Links
-----
#551 

Developer considerations
-------------


Developer QA steps
--------------------
The only thing that changed here was the docs. So nothing will break. Anyways, the new instructions can be tested in any local demo-app 

