### PR TITLE
Add 'custom-styled' prop to baseArgs

### DIFF
--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -1,18 +1,26 @@
-import { mergeConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import { mergeConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 const config = {
-  framework: "@storybook/web-components-vite",
-  stories: ["../stories/**/*.stories.@(mdx|ts|tsx)"],
+  framework: '@storybook/web-components-vite',
+  stories: ['../stories/**/*.stories.@(mdx|ts|tsx)'],
   addons: [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials",
-    "@storybook/addon-docs",
+    '@storybook/addon-links',
+    {
+      name: '@storybook/addon-essentials',
+      options: {
+        measure: false,
+        outline: false,
+        backgrounds: false,
+        viewport: false,
+      },
+    },
+    '@storybook/addon-docs',
   ],
   docs: {
     autodocs: true,
   },
-  staticDirs: ["../public"],
+  staticDirs: ['../public'],
   async viteFinal(config) {
     const storybookMocksEnabled = process.env.VITE_STORYBOOK_MOCKS_ENABLED;
     const storybookChromaticBuild = process.env.VITE_STORYBOOK_CHROMATIC_BUILD;

--- a/apps/docs/.storybook/manager.ts
+++ b/apps/docs/.storybook/manager.ts
@@ -4,4 +4,7 @@ import './styles.css';
 
 addons.setConfig({
   theme: theme,
+  toolbar: {
+    zoom: { hidden: true },
+  },
 });

--- a/apps/docs/stories/components/bank-account-form-docs.stories.mdx
+++ b/apps/docs/stories/components/bank-account-form-docs.stories.mdx
@@ -29,7 +29,7 @@ Component to render the necessary fields to enter proper bank account informatio
 
 ---
 
-<ArgTypes />
+<ArgTypes exclude={['theme']} />
 
 <Authorization
   actions={['write']}

--- a/apps/docs/stories/components/bank-account-form.stories.tsx
+++ b/apps/docs/stories/components/bank-account-form.stories.tsx
@@ -4,7 +4,7 @@ import { CSSVarsExample, paymentMethodFormComponentMethods, StoryBaseArgs } from
 
 import '@justifi/webcomponents/dist/module/justifi-bank-account-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin', 'theme']);
 storyBaseArgs.argTypes['client-id'].table.disable = true;
 storyBaseArgs.argTypes['account-id'].table.disable = true;
 
@@ -18,17 +18,9 @@ const meta: Meta = {
   component: 'justifi-bank-account-form',
   args: {
     ...storyBaseArgs.args,
-    'theme': 'basic'
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'theme': {
-      options: ['basic', 'custom'],
-      control: { type: 'select' },
-      table: {
-        category: 'theming'
-      }
-    },
     'validation-mode': {
       options: ['all', 'onBlur', 'onChange', 'onSubmit', 'onTouched'],
       control: { type: 'select' },

--- a/apps/docs/stories/components/bank-account-form.stories.tsx
+++ b/apps/docs/stories/components/bank-account-form.stories.tsx
@@ -130,6 +130,6 @@ const Template = (args: any) => {
 // This fixes a typescript error
 Template.args = { ...storyBaseArgs.args, 'css-variables': CSSVarsExample };
 
-export const Basic = Template;
+export const Example = Template;
 
 export default meta;

--- a/apps/docs/stories/components/bank-account-form.stories.tsx
+++ b/apps/docs/stories/components/bank-account-form.stories.tsx
@@ -4,18 +4,31 @@ import { CSSVarsExample, paymentMethodFormComponentMethods, StoryBaseArgs } from
 
 import '@justifi/webcomponents/dist/module/justifi-bank-account-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin', 'custom-styled']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin']);
 storyBaseArgs.argTypes['client-id'].table.disable = true;
 storyBaseArgs.argTypes['account-id'].table.disable = true;
+
+const themes: { [key: string]: any } = {
+  basic: {},
+  custom: CSSVarsExample,
+};
 
 const meta: Meta = {
   title: 'Payment Facilitation/Payments/Bank Account Form',
   component: 'justifi-bank-account-form',
   args: {
     ...storyBaseArgs.args,
+    'theme': 'basic'
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'theme': {
+      options: ['basic', 'custom'],
+      control: { type: 'select' },
+      table: {
+        category: 'theming'
+      }
+    },
     'validation-mode': {
       options: ['all', 'onBlur', 'onChange', 'onSubmit', 'onTouched'],
       control: { type: 'select' },
@@ -65,9 +78,24 @@ const meta: Meta = {
     },
   },
   decorators: [
-    story => `
-    ${story()}
-    <script>${addEvents()}</script>`,
+    (_story, context) => {
+      const { args } = context;
+      return `
+        <div>
+          <style>
+          :root {
+            ${themes[args.theme]}
+          }
+          </style>
+          <justifi-bank-account-form
+            data-testid="bank-account-form-iframe"
+            validation-mode="${args['validation-mode'] || 'onSubmit'}"
+          />
+        </div >
+        ${FormButtons}
+      
+        <script>${addEvents()}</script>`;
+    },
     // @ts-ignore
     withActions
   ],
@@ -110,26 +138,6 @@ const FormButtons = `
     <button id="tokenize-btn">Test Tokenize</button>
   </div>`;
 
-const Template = (args: any) => {
-  return `
-    <div>
-      <style>
-      :root {
-        ${args['custom-styled'] ? args['css-variables'] : ''}
-      }
-      </style>
-      <justifi-bank-account-form
-        data-testid="bank-account-form-iframe"
-        validation-mode="${args['validation-mode'] || 'onSubmit'}"
-      />
-    </div>
-    ${FormButtons}
-  `;
-};
-
-// This fixes a typescript error
-Template.args = { ...storyBaseArgs.args, 'css-variables': CSSVarsExample };
-
-export const Example = Template;
+export const Example = {};
 
 export default meta;

--- a/apps/docs/stories/components/bank-account-form.stories.tsx
+++ b/apps/docs/stories/components/bank-account-form.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta } from '@storybook/web-components';
 import { withActions } from '@storybook/addon-actions/decorator';
-import { paymentMethodFormComponentMethods, StoryBaseArgs } from '../utils';
+import { CSSVarsExample, paymentMethodFormComponentMethods, StoryBaseArgs } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-bank-account-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin', 'custom-styled']);
 storyBaseArgs.argTypes['client-id'].table.disable = true;
 storyBaseArgs.argTypes['account-id'].table.disable = true;
 
@@ -12,15 +12,10 @@ const meta: Meta = {
   title: 'Payment Facilitation/Payments/Bank Account Form',
   component: 'justifi-bank-account-form',
   args: {
-    ...storyBaseArgs.args
+    ...storyBaseArgs.args,
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'css-variables': {
-      table: {
-        disable: true
-      },
-    },
     'validation-mode': {
       options: ['all', 'onBlur', 'onChange', 'onSubmit', 'onTouched'],
       control: { type: 'select' },
@@ -54,7 +49,7 @@ const meta: Meta = {
         category: 'events'
       }
     },
-    ...paymentMethodFormComponentMethods
+    ...paymentMethodFormComponentMethods,
   },
   parameters: {
     actions: {
@@ -105,42 +100,6 @@ const addEvents = () => {
   addEventListener('bankAccountFormReady', handleReady);
 };
 
-const CSSVars = `
---jfi-load-google-font: 'Roboto Mono:wght@200;400;700;900&family=Agdasima';
---jfi-layout-font-family: Roboto Mono;
---jfi-layout-padding: 4px;
---jfi-layout-form-control-spacing-x: .5rem;
---jfi-layout-form-control-spacing-y: 1rem;
---jfi-form-label-font-weight: 700;
---jfi-form-label-font-family: sans-serif;
---jfi-form-label-margin: 0 0 .5rem 0;
---jfi-form-control-background-color: #F4F4F6;
---jfi-form-control-background-color-hover: #EEEEF5;
---jfi-form-control-border-color: rgba(0, 0, 0, 0.42);
---jfi-form-control-border-color-hover: rgba(0, 0, 0, 0.62);
---jfi-form-control-border-color-focus: #fccc32;
---jfi-form-control-border-color-error: #C12727;
---jfi-form-control-border-top-width: 0;
---jfi-form-control-border-left-width: 0;
---jfi-form-control-border-bottom-width: 1px;
---jfi-form-control-border-right-width: 0;
---jfi-form-control-border-radius: 4px 4px 0 0;
---jfi-form-control-border-style: solid;
---jfi-form-control-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
---jfi-form-control-box-shadow-focus: none;
---jfi-form-control-box-shadow-error-focus: none;
---jfi-form-control-border-style: solid;
---jfi-form-control-color: #212529;
---jfi-form-control-font-size: 1rem;
---jfi-form-control-font-weight: 400;
---jfi-form-control-line-height: 2;
---jfi-form-control-margin: 0;
---jfi-form-control-padding: .5rem .875rem;
---jfi-error-message-color: #C12727;
---jfi-error-message-margin: .25rem 0 0 0;
---jfi-error-message-font-size: .875rem;
-`;
-
 const FormButtons = `
   <style>
     .button-bar { margin-top: 10px;}
@@ -156,7 +115,7 @@ const Template = (args: any) => {
     <div>
       <style>
       :root {
-        ${args['css-variables'] || ''}
+        ${args['custom-styled'] ? args['css-variables'] : ''}
       }
       </style>
       <justifi-bank-account-form
@@ -169,13 +128,8 @@ const Template = (args: any) => {
 };
 
 // This fixes a typescript error
-Template.args = { ...storyBaseArgs.args, 'css-variables': '' };
+Template.args = { ...storyBaseArgs.args, 'css-variables': CSSVarsExample };
 
-export const Basic = Template.bind({});
-
-export const Styled = Template.bind({});
-Styled.args = {
-  'css-variables': CSSVars
-};
+export const Basic = Template;
 
 export default meta;

--- a/apps/docs/stories/components/business-details.stories.tsx
+++ b/apps/docs/stories/components/business-details.stories.tsx
@@ -39,6 +39,6 @@ const meta: Meta = {
   ],
 };
 
-export const Basic: Story = {};
+export const Example: Story = {};
 
 export default meta;

--- a/apps/docs/stories/components/business-form.stories.tsx
+++ b/apps/docs/stories/components/business-form.stories.tsx
@@ -88,6 +88,6 @@ const meta: Meta = {
   ],
 };
 
-export const Basic: Story = {};
+export const Example: Story = {};
 
 export default meta;

--- a/apps/docs/stories/components/card-form-docs.stories.mdx
+++ b/apps/docs/stories/components/card-form-docs.stories.mdx
@@ -31,7 +31,7 @@ Component to render the necessary fields to enter proper credit card information
 
 ---
 
-<ArgTypes exclude={['css-variables']} />
+<ArgTypes exclude={['css-variables', 'theme']} />
 
 <Authorization
   actions={['write']}

--- a/apps/docs/stories/components/card-form.stories.tsx
+++ b/apps/docs/stories/components/card-form.stories.tsx
@@ -4,17 +4,30 @@ import { CSSVarsExample, StoryBaseArgs, paymentMethodFormComponentMethods } from
 
 import '@justifi/webcomponents/dist/module/justifi-card-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin', 'custom-styled']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin']);
 storyBaseArgs.argTypes['client-id'].table.disable = true;
+
+const themes: { [key: string]: any } = {
+  basic: {},
+  custom: CSSVarsExample,
+}
 
 const meta: Meta = {
   title: 'Payment Facilitation/Payments/Card Form',
   component: 'justifi-card-form',
   args: {
     ...storyBaseArgs.args,
+    'theme': 'basic'
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'theme': {
+      options: ['basic', 'custom'],
+      control: { type: 'select' },
+      table: {
+        category: 'theming'
+      }
+    },
     'single-line': {
       type: 'boolean',
       description: '`boolean` indicating if the Card Form should render in a single line layout',
@@ -74,9 +87,25 @@ const meta: Meta = {
     },
   },
   decorators: [
-    story => `
-    ${story()}
-    <script>${addEvents()}</script>`,
+    (_story, context) => {
+      const includeButtons = true;
+      const { args } = context;
+      return `
+        <div>
+          <style>
+          :root {
+            ${themes[args.theme]}
+          }
+          </style>
+          <justifi-card-form
+            data-testid="card-form-iframe"
+            validation-mode="${args['validation-mode'] || 'onSubmit'}"
+            single-line="${args['single-line']}"
+          />
+        </div>
+        ${includeButtons ? FormButtons : ''}
+        <script>${addEvents()}</script>`;
+    },
     // @ts-ignore
     withActions
   ],
@@ -117,28 +146,7 @@ const FormButtons = `
     <button id="tokenize-btn">Test Tokenize</button>
   </div>`;
 
-const Template = (args: any) => {
-  const includeButtons = true;
 
-  return `
-    <div>
-      <style>
-      :root {
-        ${args['custom-styled'] ? args['css-variables'] : ''}
-      }
-      </style>
-      <justifi-card-form
-        data-testid="card-form-iframe"
-        validation-mode="${args['validation-mode'] || 'onSubmit'}"
-        single-line="${args['single-line']}"
-      />
-    </div>
-    ${includeButtons ? FormButtons : ''}
-  `;
-};
-
-Template.args = { ...storyBaseArgs.args, 'css-variables': CSSVarsExample };
-
-export const Example = Template;
+export const Example = {};
 
 export default meta;

--- a/apps/docs/stories/components/card-form.stories.tsx
+++ b/apps/docs/stories/components/card-form.stories.tsx
@@ -4,7 +4,7 @@ import { CSSVarsExample, StoryBaseArgs, paymentMethodFormComponentMethods } from
 
 import '@justifi/webcomponents/dist/module/justifi-card-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin', 'theme']);
 storyBaseArgs.argTypes['client-id'].table.disable = true;
 
 const themes: { [key: string]: any } = {
@@ -17,17 +17,9 @@ const meta: Meta = {
   component: 'justifi-card-form',
   args: {
     ...storyBaseArgs.args,
-    'theme': 'basic'
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'theme': {
-      options: ['basic', 'custom'],
-      control: { type: 'select' },
-      table: {
-        category: 'theming'
-      }
-    },
     'single-line': {
       type: 'boolean',
       description: '`boolean` indicating if the Card Form should render in a single line layout',

--- a/apps/docs/stories/components/card-form.stories.tsx
+++ b/apps/docs/stories/components/card-form.stories.tsx
@@ -139,6 +139,6 @@ const Template = (args: any) => {
 
 Template.args = { ...storyBaseArgs.args, 'css-variables': CSSVarsExample };
 
-export const Basic = Template;
+export const Example = Template;
 
 export default meta;

--- a/apps/docs/stories/components/card-form.stories.tsx
+++ b/apps/docs/stories/components/card-form.stories.tsx
@@ -1,10 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import type { Meta } from '@storybook/web-components';
 import { withActions } from '@storybook/addon-actions/decorator';
-import { StoryBaseArgs, paymentMethodFormComponentMethods } from '../utils';
+import { CSSVarsExample, StoryBaseArgs, paymentMethodFormComponentMethods } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-card-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'iframe-origin', 'custom-styled']);
 storyBaseArgs.argTypes['client-id'].table.disable = true;
 
 const meta: Meta = {
@@ -15,11 +15,6 @@ const meta: Meta = {
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'css-variables': {
-      table: {
-        disable: true
-      },
-    },
     'single-line': {
       type: 'boolean',
       description: '`boolean` indicating if the Card Form should render in a single line layout',
@@ -129,7 +124,7 @@ const Template = (args: any) => {
     <div>
       <style>
       :root {
-        ${args['css-variables'] || ''}
+        ${args['custom-styled'] ? args['css-variables'] : ''}
       }
       </style>
       <justifi-card-form
@@ -142,58 +137,8 @@ const Template = (args: any) => {
   `;
 };
 
-export const Basic: StoryObj = {
-  args: { ...storyBaseArgs.args, 'single-line': false },
-  render: Template,
-};
+Template.args = { ...storyBaseArgs.args, 'css-variables': CSSVarsExample };
 
-export const SingleLine: StoryObj = {
-  args: { ...storyBaseArgs.args, 'single-line': true },
-  render: Template,
-};
-
-const styledVariables = `
-  --jfi-load-google-font: 'Inter:wght@200;400;700;900&family=Agdasima';
-  --jfi-layout-font-family: Agdasima;
-  --jfi-layout-padding: 4px;
-  --jfi-layout-form-control-spacing-x: .5rem;
-  --jfi-layout-form-control-spacing-y: 1rem;
-  --jfi-form-label-font-weight: 100;
-  --jfi-form-label-font-family: Inter;
-  --jfi-form-label-margin: 0 0 .5rem 0;
-  --jfi-form-control-background-color: #F4F4F6;
-  --jfi-form-control-background-color-hover: #EEEEF5;
-  --jfi-form-control-border-color: rgba(0, 0, 0, 0.42);
-  --jfi-form-control-border-color-hover: rgba(0, 0, 0, 0.62);
-  --jfi-form-control-border-color-focus: #fccc32;
-  --jfi-form-control-border-color-error: #C12727;
-  --jfi-form-control-border-top-width: 0;
-  --jfi-form-control-border-left-width: 0;
-  --jfi-form-control-border-bottom-width: 1px;
-  --jfi-form-control-border-right-width: 0;
-  --jfi-form-control-border-radius: 4px 4px 0 0;
-  --jfi-form-control-border-style: solid;
-  --jfi-form-control-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-  --jfi-form-control-box-shadow-focus: none;
-  --jfi-form-control-box-shadow-error-focus: none;
-  --jfi-form-control-border-style: solid;
-  --jfi-form-control-color: #212529;
-  --jfi-form-control-font-size: 1rem;
-  --jfi-form-control-font-weight: 400;
-  --jfi-form-control-line-height: 2;
-  --jfi-form-control-margin: 0;
-  --jfi-form-control-padding: .5rem .875rem;
-  --jfi-error-message-color: #C12727;
-  --jfi-error-message-margin: .25rem 0 0 0;
-  --jfi-error-message-font-size: .875rem;
-`;
-
-export const Styled: StoryObj = {
-  args: {
-    ...storyBaseArgs.args,
-    'css-variables': styledVariables
-  },
-  render: Template,
-};
+export const Basic = Template;
 
 export default meta;

--- a/apps/docs/stories/components/checkout-docs.stories.mdx
+++ b/apps/docs/stories/components/checkout-docs.stories.mdx
@@ -28,7 +28,7 @@ and process a payment.
 
 ---
 
-<ArgTypes exclude={['css-variables']} />
+<ArgTypes exclude={['Theme']} />
 
 <h1>Authorization</h1>
 <hr />

--- a/apps/docs/stories/components/checkout.stories.tsx
+++ b/apps/docs/stories/components/checkout.stories.tsx
@@ -132,8 +132,8 @@ const meta: Meta = {
   }
 }
 
-export const Basic: StoryObj = {};
-Basic.decorators = [
+export const Example: StoryObj = {};
+Example.decorators = [
   (story: any, storyArgs: any) => {
     setUpMocks();
 

--- a/apps/docs/stories/components/checkout.stories.tsx
+++ b/apps/docs/stories/components/checkout.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta = {
   argTypes: {
     ...storyBaseArgs.argTypes,
     'Theme': {
-      description: 'Select a theme to preview the component in',
+      description: 'Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling-components-with-variables)',
       options: Object.values(ThemeNames),
       control: {
         type: 'select',

--- a/apps/docs/stories/components/gross-payment-chart.stories.tsx
+++ b/apps/docs/stories/components/gross-payment-chart.stories.tsx
@@ -40,6 +40,6 @@ const meta: Meta = {
   ]
 };
 
-export const Basic: Story = {};
+export const Example: Story = {};
 
 export default meta;

--- a/apps/docs/stories/components/payment-details.stories.tsx
+++ b/apps/docs/stories/components/payment-details.stories.tsx
@@ -39,6 +39,6 @@ const meta: Meta = {
   ],
 };
 
-export const Basic: Story = {};
+export const Example: Story = {};
 
 export default meta;

--- a/apps/docs/stories/components/payment-form-docs.stories.mdx
+++ b/apps/docs/stories/components/payment-form-docs.stories.mdx
@@ -30,7 +30,7 @@ account, a submit button and all fields required for proper use.
 
 ---
 
-<ArgTypes exclude={['css-variables']} />
+<ArgTypes exclude={['theme']} />
 
 <Authorization
   actions={['write']}

--- a/apps/docs/stories/components/payment-form.stories.tsx
+++ b/apps/docs/stories/components/payment-form.stories.tsx
@@ -4,7 +4,12 @@ import { CSSVarsExample, StoryBaseArgs, getAttributesString } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-payment-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'auth-token', 'custom-styled']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'auth-token']);
+
+const themes: { [key: string]: any } = {
+  basic: {},
+  custom: CSSVarsExample,
+};
 
 const meta: Meta = {
   title: 'Payment Facilitation/Payments/Payment Form',
@@ -13,9 +18,19 @@ const meta: Meta = {
     ...storyBaseArgs.args,
     'email': 'test@test.com',
     'submit-button-text': 'Submit Payment',
+    'theme': 'basic',
+    'card': true,
+    'bank-account': true,
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'theme': {
+      options: ['basic', 'custom'],
+      control: { type: 'select' },
+      table: {
+        category: 'theming'
+      }
+    },
     'bank-account': {
       type: 'boolean',
       description: 'Boolean indicating if the Payment Form should render Bank Account inputs `boolean`',
@@ -120,7 +135,7 @@ const Template = (args: any) => {
     </div>
     <style>
       :root {
-        ${args['custom-styled'] ? args['css-variables'] : ''}
+        ${themes[args.theme]}
       }
     </style>
     <script>
@@ -136,13 +151,6 @@ const Template = (args: any) => {
     })()
     </script>
   `;
-};
-
-Template.args = {
-  ...storyBaseArgs.args,
-  'card': true,
-  'bank-account': true,
-  'css-variables': CSSVarsExample
 };
 
 export const Example = Template;

--- a/apps/docs/stories/components/payment-form.stories.tsx
+++ b/apps/docs/stories/components/payment-form.stories.tsx
@@ -145,6 +145,6 @@ Template.args = {
   'css-variables': CSSVarsExample
 };
 
-export const Basic = Template;
+export const Example = Template;
 
 export default meta;

--- a/apps/docs/stories/components/payment-form.stories.tsx
+++ b/apps/docs/stories/components/payment-form.stories.tsx
@@ -4,7 +4,7 @@ import { CSSVarsExample, StoryBaseArgs, getAttributesString } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-payment-form';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'auth-token', 'theme']);
 
 const themes: { [key: string]: any } = {
   basic: {},
@@ -18,19 +18,11 @@ const meta: Meta = {
     ...storyBaseArgs.args,
     'email': 'test@test.com',
     'submit-button-text': 'Submit Payment',
-    'theme': 'basic',
     'card': true,
     'bank-account': true,
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'theme': {
-      options: ['basic', 'custom'],
-      control: { type: 'select' },
-      table: {
-        category: 'theming'
-      }
-    },
     'bank-account': {
       type: 'boolean',
       description: 'Boolean indicating if the Payment Form should render Bank Account inputs `boolean`',

--- a/apps/docs/stories/components/payment-form.stories.tsx
+++ b/apps/docs/stories/components/payment-form.stories.tsx
@@ -1,12 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import type { Meta } from '@storybook/web-components';
 import { withActions } from '@storybook/addon-actions/decorator';
-import { StoryBaseArgs, getAttributesString } from '../utils';
+import { CSSVarsExample, StoryBaseArgs, getAttributesString } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-payment-form';
 
-type Story = StoryObj;
-
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'client-id', 'auth-token', 'custom-styled']);
 
 const meta: Meta = {
   title: 'Payment Facilitation/Payments/Payment Form',
@@ -122,7 +120,7 @@ const Template = (args: any) => {
     </div>
     <style>
       :root {
-        ${args.cssVariables}
+        ${args['custom-styled'] ? args['css-variables'] : ''}
       }
     </style>
     <script>
@@ -140,88 +138,13 @@ const Template = (args: any) => {
   `;
 };
 
-export const Basic: Story = {
-  args: { ...storyBaseArgs.args, 'card': true, 'bank-account': true },
-  render: Template,
+Template.args = {
+  ...storyBaseArgs.args,
+  'card': true,
+  'bank-account': true,
+  'css-variables': CSSVarsExample
 };
 
-export const Styled: Story = {
-  args: {
-    ...storyBaseArgs.args,
-    card: true,
-    'bank-account': true,
-    cssVariables: `
-    --jfi-primary-color: #212529;
-    --jfi-load-google-font: 'Roboto Mono:wght@200;400;700;900';
-    --jfi-layout-font-family: Roboto Mono, Calibri, sans-serif;
-    --jfi-layout-padding: 4px;
-    --jfi-layout-form-control-spacing-x: .5rem;
-    --jfi-layout-form-control-spacing-y: 1rem;
-    --jfi-form-label-font-weight: 700;
-    --jfi-form-label-font-family: Calibri, sans-serif;
-    --jfi-form-label-margin: 0 0 .5rem 0;
-    --jfi-form-control-background-color: #F4F4F6;
-    --jfi-form-control-background-color-hover: #EEEEF5;
-    --jfi-form-control-border-color: rgba(0, 0, 0, 0.42);
-    --jfi-form-control-border-color-hover: rgba(0, 0, 0, 0.62);
-    --jfi-form-control-border-color-focus: #fccc32;
-    --jfi-form-control-border-color-error: #C12727;
-    --jfi-form-control-border-top-width: 0;
-    --jfi-form-control-border-left-width: 0;
-    --jfi-form-control-border-bottom-width: 1px;
-    --jfi-form-control-border-right-width: 0;
-    --jfi-form-control-border-radius: 4px 4px 0 0;
-    --jfi-form-control-border-style: solid;
-    --jfi-form-control-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    --jfi-form-control-box-shadow-focus: none;
-    --jfi-form-control-box-shadow-error-focus: none;
-    --jfi-form-control-border-style: solid;
-    --jfi-form-control-color: #212529;
-    --jfi-form-control-font-size: 1rem;
-    --jfi-form-control-font-weight: 400;
-    --jfi-form-control-line-height: 2;
-    --jfi-form-control-margin: 0;
-    --jfi-form-control-padding: .5rem .875rem;
-    --jfi-error-message-color: #C12727;
-    --jfi-error-message-margin: .25rem 0 0 0;
-    --jfi-error-message-font-size: .875rem;
-
-    --jfi-submit-button-color: white;
-    --jfi-submit-button-background-color: #3F3F47;
-    --jfi-submit-button-border-color: var(--jfi-primary-color);
-    --jfi-submit-button-padding: 0.375rem 0.75rem;
-    --jfi-submit-button-font-size: 1rem;
-    --jfi-submit-button-border-radius: 1px;
-    --jfi-submit-button-color-hover: white;
-    --jfi-submit-button-background-color-hover: var(--jfi-primary-color);
-    --jfi-submit-button-border-color-hover: var(--jfi-primary-color);
-    --jfi-submit-button-color-focus: white;
-    --jfi-submit-button-background-color-focus: var(--jfi-primary-color);
-    --jfi-submit-button-border-color-focus: var(--jfi-primary-color);
-    --jfi-submit-button-color-active: white;
-    --jfi-submit-button-background-color-active: var(--jfi-primary-color);
-    --jfi-submit-button-border-color-active: var(--jfi-primary-color);
-    --jfi-submit-button-width: 100%;
-    --jfi-submit-button-box-shadow: rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px;
-
-    --jfi-radio-button-color: var(--jfi-primary-color);
-    --jfi-radio-button-background-color: transparent;
-    --jfi-radio-button-color-selected: white;
-    --jfi-radio-button-background-color-selected: var(--jfi-primary-color);
-    --jfi-radio-button-border-color: var(--jfi-primary-color);
-    --jfi-radio-button-border-color-selected: var(--jfi-primary-color);
-    --jfi-radio-button-padding: 0.375rem 0.75rem;
-    --jfi-radio-button-font-size: 1rem;
-    --jfi-radio-button-color-hover: var(--jfi-primary-color);
-    --jfi-radio-button-color-selected-hover: white;
-    --jfi-radio-button-background-color-hover: transparent;
-    --jfi-radio-button-background-color-selected-hover: var(--jfi-primary-color);
-    --jfi-radio-button-border-color-selected-hover: var(--jfi-primary-color);
-    --jfi-radio-button-border-color-hover: var(--jfi-primary-color);
-    --jfi-radio-button-group-width: 100%;
-  `,
-  },
-  render: Template,
-};
+export const Basic = Template;
 
 export default meta;

--- a/apps/docs/stories/components/payment-provisioning.stories.tsx
+++ b/apps/docs/stories/components/payment-provisioning.stories.tsx
@@ -92,6 +92,6 @@ const meta: Meta = {
   ],
 };
 
-export const Basic: Story = {};
+export const Example: Story = {};
 
 export default meta;

--- a/apps/docs/stories/components/payments-list-docs.stories.mdx
+++ b/apps/docs/stories/components/payments-list-docs.stories.mdx
@@ -33,7 +33,7 @@ Component to render a formated list of payments for the requested account.
 
 ---
 
-<ArgTypes exclude={['css-variables']} />
+<ArgTypes exclude={['theme']} />
 
 <Authorization
   actions={['read', 'write']}

--- a/apps/docs/stories/components/payments-list.stories.tsx
+++ b/apps/docs/stories/components/payments-list.stories.tsx
@@ -1,12 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import type { Meta } from '@storybook/web-components';
 import { withActions } from '@storybook/addon-actions/decorator';
 import { StoryBaseArgs, customStoryDecorator } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-payments-list';
 
-type Story = StoryObj;
-
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token', 'custom-styled']);
 
 const meta: Meta = {
   title: 'Payment Facilitation/Merchant Tools/Payments List',
@@ -46,10 +44,9 @@ const meta: Meta = {
   ],
 };
 
-export const Basic: Story = {};
-
-export const Styled: Story = {
+export const Basic = {
   args: {
+    ...storyBaseArgs.args,
     style: {
       'justifi-payments-list::part(table-head)': {},
       'justifi-payments-list::part(table-head-row)': {},

--- a/apps/docs/stories/components/payments-list.stories.tsx
+++ b/apps/docs/stories/components/payments-list.stories.tsx
@@ -4,16 +4,76 @@ import { StoryBaseArgs, customStoryDecorator } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-payments-list';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token', 'custom-styled']);
+const themes = {
+  basic: {},
+  custom: {
+    'justifi-payments-list::part(table-head)': {},
+    'justifi-payments-list::part(table-head-row)': {},
+    'justifi-payments-list::part(table-head-cell)': {
+      'background-color': '#fff',
+      'font-weight': '600',
+      'font-size': '0.8rem',
+      'text-transform': 'uppercase',
+      'letter-spacing': '0.1em',
+    },
+    'justifi-payments-list::part(table-body)': {},
+    'justifi-payments-list::part(table-row)': {},
+    'justifi-payments-list::part(table-row):hover': {
+      'cursor': 'pointer',
+    },
+    'justifi-payments-list::part(table-row-even)': {},
+    'justifi-payments-list::part(table-row-odd)': {},
+    'justifi-payments-list::part(table-cell)': {
+      'background-color': 'transparent',
+      'font-weight': 'normal',
+      'font-size': '0.8rem',
+    },
+    'justifi-payments-list::part(loading-state-cell)': {},
+    'justifi-payments-list::part(loading-state-spinner)': {
+      'color': '#ccc',
+    },
+    'justifi-payments-list::part(error-state)': {},
+    'justifi-payments-list::part(empty-state)': {},
+    'justifi-payments-list::part(pagination-bar)': {
+      'background-color': '#fff',
+      'border-bottom': 'none',
+    },
+    'justifi-payments-list::part(page-button)': {
+      'border': 'none',
+      'background-color': 'transparent',
+      'text-transform': 'uppercase',
+      'font-weight': 'normal',
+      'font-size': '0.8rem',
+    },
+    'justifi-payments-list::part(page-button-disabled)': {
+      'opacity': '0.5',
+      'cursor': 'not-allowed',
+    },
+    'justifi-payments-list::part(page-arrow)': {
+      'display': 'none',
+    },
+    'justifi-payments-list::part(page-button-text)': {},
+  }
+}
+
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
 
 const meta: Meta = {
   title: 'Payment Facilitation/Merchant Tools/Payments List',
   component: 'justifi-payments-list',
   args: {
     ...storyBaseArgs.args,
+    'theme': 'basic',
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'theme': {
+      options: ['basic', 'custom'],
+      control: { type: 'select' },
+      table: {
+        category: 'theming'
+      }
+    },
     'payment-row-clicked': {
       description: '`PaymentRowClicked`',
       table: {
@@ -28,16 +88,6 @@ const meta: Meta = {
       },
       action: true,
     },
-    'style': {
-      description: 'Component style overrides',
-      table: {
-        category: 'styles',
-      },
-      if: {
-        arg: 'custom-styled',
-        truthy: true,
-      }
-    },
   },
   parameters: {
     actions: {
@@ -46,6 +96,7 @@ const meta: Meta = {
     chromatic: {
       delay: 2000,
     },
+    themes
   },
   decorators: [
     customStoryDecorator,
@@ -54,58 +105,6 @@ const meta: Meta = {
   ],
 };
 
-export const Example = {
-  args: {
-    ...storyBaseArgs.args,
-    style: {
-      'justifi-payments-list::part(table-head)': {},
-      'justifi-payments-list::part(table-head-row)': {},
-      'justifi-payments-list::part(table-head-cell)': {
-        'background-color': '#fff',
-        'font-weight': '600',
-        'font-size': '0.8rem',
-        'text-transform': 'uppercase',
-        'letter-spacing': '0.1em',
-      },
-      'justifi-payments-list::part(table-body)': {},
-      'justifi-payments-list::part(table-row)': {},
-      'justifi-payments-list::part(table-row):hover': {
-        'cursor': 'pointer',
-      },
-      'justifi-payments-list::part(table-row-even)': {},
-      'justifi-payments-list::part(table-row-odd)': {},
-      'justifi-payments-list::part(table-cell)': {
-        'background-color': 'transparent',
-        'font-weight': 'normal',
-        'font-size': '0.8rem',
-      },
-      'justifi-payments-list::part(loading-state-cell)': {},
-      'justifi-payments-list::part(loading-state-spinner)': {
-        'color': '#ccc',
-      },
-      'justifi-payments-list::part(error-state)': {},
-      'justifi-payments-list::part(empty-state)': {},
-      'justifi-payments-list::part(pagination-bar)': {
-        'background-color': '#fff',
-        'border-bottom': 'none',
-      },
-      'justifi-payments-list::part(page-button)': {
-        'border': 'none',
-        'background-color': 'transparent',
-        'text-transform': 'uppercase',
-        'font-weight': 'normal',
-        'font-size': '0.8rem',
-      },
-      'justifi-payments-list::part(page-button-disabled)': {
-        'opacity': '0.5',
-        'cursor': 'not-allowed',
-      },
-      'justifi-payments-list::part(page-arrow)': {
-        'display': 'none',
-      },
-      'justifi-payments-list::part(page-button-text)': {},
-    }
-  }
-};
+export const Example = {};
 
 export default meta;

--- a/apps/docs/stories/components/payments-list.stories.tsx
+++ b/apps/docs/stories/components/payments-list.stories.tsx
@@ -28,6 +28,16 @@ const meta: Meta = {
       },
       action: true,
     },
+    'style': {
+      description: 'Component style overrides',
+      table: {
+        category: 'styles',
+      },
+      if: {
+        arg: 'custom-styled',
+        truthy: true,
+      }
+    },
   },
   parameters: {
     actions: {
@@ -44,7 +54,7 @@ const meta: Meta = {
   ],
 };
 
-export const Basic = {
+export const Example = {
   args: {
     ...storyBaseArgs.args,
     style: {

--- a/apps/docs/stories/components/payments-list.stories.tsx
+++ b/apps/docs/stories/components/payments-list.stories.tsx
@@ -56,24 +56,16 @@ const themes = {
   }
 }
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token', 'theme']);
 
 const meta: Meta = {
   title: 'Payment Facilitation/Merchant Tools/Payments List',
   component: 'justifi-payments-list',
   args: {
     ...storyBaseArgs.args,
-    'theme': 'basic',
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'theme': {
-      options: ['basic', 'custom'],
-      control: { type: 'select' },
-      table: {
-        category: 'theming'
-      }
-    },
     'payment-row-clicked': {
       description: '`PaymentRowClicked`',
       table: {

--- a/apps/docs/stories/components/payout-details.stories.tsx
+++ b/apps/docs/stories/components/payout-details.stories.tsx
@@ -39,6 +39,6 @@ const meta: Meta = {
   ],
 };
 
-export const Basic: Story = {};
+export const Example: Story = {};
 
 export default meta;

--- a/apps/docs/stories/components/payouts-list-docs.stories.mdx
+++ b/apps/docs/stories/components/payouts-list-docs.stories.mdx
@@ -29,7 +29,7 @@ Component to render a formated list of payouts for the requested account.
 
 ---
 
-<ArgTypes exclude={['css-variables']} />
+<ArgTypes exclude={['theme']} />
 
 <Authorization
   actions={['read', 'write']}

--- a/apps/docs/stories/components/payouts-list.stories.tsx
+++ b/apps/docs/stories/components/payouts-list.stories.tsx
@@ -4,16 +4,76 @@ import { StoryBaseArgs, customStoryDecorator } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-payouts-list';
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token', 'custom-styled']);
+const themes: { [key: string]: any } = {
+  basic: {},
+  custom: {
+    'justifi-payouts-list::part(table-head)': {},
+    'justifi-payouts-list::part(table-head-row)': {},
+    'justifi-payouts-list::part(table-head-cell)': {
+      'background-color': '#fff',
+      'font-weight': '600',
+      'font-size': '0.8rem',
+      'text-transform': 'uppercase',
+      'letter-spacing': '0.1em',
+    },
+    'justifi-payouts-list::part(table-body)': {},
+    'justifi-payouts-list::part(table-row)': {},
+    'justifi-payouts-list::part(table-row):hover': {
+      'cursor': 'pointer',
+    },
+    'justifi-payouts-list::part(table-row-even)': {},
+    'justifi-payouts-list::part(table-row-odd)': {},
+    'justifi-payouts-list::part(table-cell)': {
+      'background-color': 'transparent',
+      'font-weight': 'normal',
+      'font-size': '0.8rem',
+    },
+    'justifi-payouts-list::part(loading-state-cell)': {},
+    'justifi-payouts-list::part(loading-state-spinner)': {
+      'color': '#ccc',
+    },
+    'justifi-payouts-list::part(error-state)': {},
+    'justifi-payouts-list::part(empty-state)': {},
+    'justifi-payouts-list::part(pagination-bar)': {
+      'background-color': '#fff',
+      'border-bottom': 'none',
+    },
+    'justifi-payouts-list::part(page-button)': {
+      'border': 'none',
+      'background-color': 'transparent',
+      'text-transform': 'uppercase',
+      'font-weight': 'normal',
+      'font-size': '0.8rem',
+    },
+    'justifi-payouts-list::part(page-button-disabled)': {
+      'opacity': '0.5',
+      'cursor': 'not-allowed',
+    },
+    'justifi-payouts-list::part(page-arrow)': {
+      'display': 'none',
+    },
+    'justifi-payouts-list::part(page-button-text)': {},
+  }
+};
+
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
 
 const meta: Meta = {
   title: 'Payment Facilitation/Merchant Tools/Payouts List',
   component: 'justifi-payouts-list',
   args: {
     ...storyBaseArgs.args,
+    'theme': 'basic',
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    'theme': {
+      options: ['basic', 'custom'],
+      control: { type: 'select' },
+      table: {
+        category: 'theming',
+      },
+    },
     'payout-row-clicked': {
       description: '`PayoutRowClicked`',
       table: {
@@ -28,16 +88,6 @@ const meta: Meta = {
       },
       action: true,
     },
-    'style': {
-      description: 'Component style overrides',
-      table: {
-        category: 'styles',
-      },
-      if: {
-        arg: 'custom-styled',
-        truthy: true,
-      }
-    },
   },
   parameters: {
     actions: {
@@ -46,6 +96,7 @@ const meta: Meta = {
     chromatic: {
       delay: 2000,
     },
+    themes
   },
   decorators: [
     customStoryDecorator,
@@ -54,58 +105,6 @@ const meta: Meta = {
   ],
 };
 
-export const Example = {
-  args: {
-    ...storyBaseArgs.args,
-    style: {
-      'justifi-payouts-list::part(table-head)': {},
-      'justifi-payouts-list::part(table-head-row)': {},
-      'justifi-payouts-list::part(table-head-cell)': {
-        'background-color': '#fff',
-        'font-weight': '600',
-        'font-size': '0.8rem',
-        'text-transform': 'uppercase',
-        'letter-spacing': '0.1em',
-      },
-      'justifi-payouts-list::part(table-body)': {},
-      'justifi-payouts-list::part(table-row)': {},
-      'justifi-payouts-list::part(table-row):hover': {
-        'cursor': 'pointer',
-      },
-      'justifi-payouts-list::part(table-row-even)': {},
-      'justifi-payouts-list::part(table-row-odd)': {},
-      'justifi-payouts-list::part(table-cell)': {
-        'background-color': 'transparent',
-        'font-weight': 'normal',
-        'font-size': '0.8rem',
-      },
-      'justifi-payouts-list::part(loading-state-cell)': {},
-      'justifi-payouts-list::part(loading-state-spinner)': {
-        'color': '#ccc',
-      },
-      'justifi-payouts-list::part(error-state)': {},
-      'justifi-payouts-list::part(empty-state)': {},
-      'justifi-payouts-list::part(pagination-bar)': {
-        'background-color': '#fff',
-        'border-bottom': 'none',
-      },
-      'justifi-payouts-list::part(page-button)': {
-        'border': 'none',
-        'background-color': 'transparent',
-        'text-transform': 'uppercase',
-        'font-weight': 'normal',
-        'font-size': '0.8rem',
-      },
-      'justifi-payouts-list::part(page-button-disabled)': {
-        'opacity': '0.5',
-        'cursor': 'not-allowed',
-      },
-      'justifi-payouts-list::part(page-arrow)': {
-        'display': 'none',
-      },
-      'justifi-payouts-list::part(page-button-text)': {},
-    }
-  }
-};
+export const Example = {};
 
 export default meta;

--- a/apps/docs/stories/components/payouts-list.stories.tsx
+++ b/apps/docs/stories/components/payouts-list.stories.tsx
@@ -1,12 +1,10 @@
-import type { Meta, StoryObj } from '@storybook/web-components';
+import type { Meta } from '@storybook/web-components';
 import { withActions } from '@storybook/addon-actions/decorator';
 import { StoryBaseArgs, customStoryDecorator } from '../utils';
 
 import '@justifi/webcomponents/dist/module/justifi-payouts-list';
 
-type Story = StoryObj;
-
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token', 'custom-styled']);
 
 const meta: Meta = {
   title: 'Payment Facilitation/Merchant Tools/Payouts List',
@@ -46,10 +44,9 @@ const meta: Meta = {
   ],
 };
 
-export const Basic: Story = {};
-
-export const Styled: Story = {
+export const Basic = {
   args: {
+    ...storyBaseArgs.args,
     style: {
       'justifi-payouts-list::part(table-head)': {},
       'justifi-payouts-list::part(table-head-row)': {},

--- a/apps/docs/stories/components/payouts-list.stories.tsx
+++ b/apps/docs/stories/components/payouts-list.stories.tsx
@@ -56,24 +56,16 @@ const themes: { [key: string]: any } = {
   }
 };
 
-const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token']);
+const storyBaseArgs = new StoryBaseArgs(['account-id', 'auth-token', 'theme']);
 
 const meta: Meta = {
   title: 'Payment Facilitation/Merchant Tools/Payouts List',
   component: 'justifi-payouts-list',
   args: {
     ...storyBaseArgs.args,
-    'theme': 'basic',
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
-    'theme': {
-      options: ['basic', 'custom'],
-      control: { type: 'select' },
-      table: {
-        category: 'theming',
-      },
-    },
     'payout-row-clicked': {
       description: '`PayoutRowClicked`',
       table: {

--- a/apps/docs/stories/components/payouts-list.stories.tsx
+++ b/apps/docs/stories/components/payouts-list.stories.tsx
@@ -28,6 +28,16 @@ const meta: Meta = {
       },
       action: true,
     },
+    'style': {
+      description: 'Component style overrides',
+      table: {
+        category: 'styles',
+      },
+      if: {
+        arg: 'custom-styled',
+        truthy: true,
+      }
+    },
   },
   parameters: {
     actions: {
@@ -44,7 +54,7 @@ const meta: Meta = {
   ],
 };
 
-export const Basic = {
+export const Example = {
   args: {
     ...storyBaseArgs.args,
     style: {

--- a/apps/docs/stories/utils/base-args.ts
+++ b/apps/docs/stories/utils/base-args.ts
@@ -95,7 +95,7 @@ const argTypes: ArgTypes = {
       type: 'boolean',
     },
     table: {
-      category: 'props',
+      category: 'styles',
     },
   },
 };

--- a/apps/docs/stories/utils/base-args.ts
+++ b/apps/docs/stories/utils/base-args.ts
@@ -5,7 +5,8 @@ type ArgNames =
   | 'client-id'
   | 'iframe-origin'
   | 'payment-id'
-  | 'payout-id';
+  | 'payout-id'
+  | 'theme';
 type ArgValues = { [key in ArgNames]?: any };
 type ArgTypes = { [key in ArgNames]?: any };
 
@@ -17,6 +18,7 @@ const args: ArgValues = {
   'client-id': 'test_df97f04afebc3c018de30df3562d7cdd',
   'payment-id': 'py_1NNeEnf4FbelxDCQN2RHcE',
   'payout-id': 'po_17745yESnHyEgWNeunmhmR',
+  theme: 'basic',
 };
 
 const argTypes: ArgTypes = {
@@ -84,6 +86,15 @@ const argTypes: ArgTypes = {
     },
     table: {
       category: 'props',
+    },
+  },
+  theme: {
+    options: ['basic', 'custom'],
+    control: { type: 'select' },
+    description:
+      'Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling-components-with-variables)',
+    table: {
+      category: 'theming',
     },
   },
 };

--- a/apps/docs/stories/utils/base-args.ts
+++ b/apps/docs/stories/utils/base-args.ts
@@ -5,8 +5,7 @@ type ArgNames =
   | 'client-id'
   | 'iframe-origin'
   | 'payment-id'
-  | 'payout-id'
-  | 'custom-styled';
+  | 'payout-id';
 type ArgValues = { [key in ArgNames]?: any };
 type ArgTypes = { [key in ArgNames]?: any };
 
@@ -18,7 +17,6 @@ const args: ArgValues = {
   'client-id': 'test_df97f04afebc3c018de30df3562d7cdd',
   'payment-id': 'py_1NNeEnf4FbelxDCQN2RHcE',
   'payout-id': 'po_17745yESnHyEgWNeunmhmR',
-  'custom-styled': false,
 };
 
 const argTypes: ArgTypes = {
@@ -86,16 +84,6 @@ const argTypes: ArgTypes = {
     },
     table: {
       category: 'props',
-    },
-  },
-  'custom-styled': {
-    type: 'boolean',
-    description: 'Use custom styles `boolean`',
-    control: {
-      type: 'boolean',
-    },
-    table: {
-      category: 'styles',
     },
   },
 };

--- a/apps/docs/stories/utils/base-args.ts
+++ b/apps/docs/stories/utils/base-args.ts
@@ -1,14 +1,24 @@
-type ArgNames = 'auth-token' | 'account-id' | 'business-id' | 'client-id' | 'iframe-origin' | 'payment-id' | 'payout-id';
-type ArgValues = { [key in ArgNames]?: string; };
-type ArgTypes = { [key in ArgNames]?: any; }
+type ArgNames =
+  | 'auth-token'
+  | 'account-id'
+  | 'business-id'
+  | 'client-id'
+  | 'iframe-origin'
+  | 'payment-id'
+  | 'payout-id'
+  | 'custom-styled';
+type ArgValues = { [key in ArgNames]?: any };
+type ArgTypes = { [key in ArgNames]?: any };
 
 const args: ArgValues = {
   'account-id': 'acc_5Et9iXrSSAZR2KSouQGAWi',
-  'auth-token': 'eyJraWQiOiJqdXN0aWZpLWUyNDgyMmU3ODE1MmEzZjRkMjU1IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2F1dGguanVzdGlmaS5haS8iLCJhenAiOiJ3Y3RfNXpYcUpqRm1JZzJTa2ZpOGlVZUMwTyIsInN1YiI6IndjdF81elhxSmpGbUlnMlNrZmk4aVVlQzBPQHNlc3Npb25zIiwiYXVkIjoiaHR0cHM6Ly9hcGkuanVzdGlmaS5haS92MSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyIsInBlcm1pc3Npb25zIjpbInJlYWQ6YWNjb3VudDphY2NfNUV0OWlYclNTQVpSMktTb3VRR0FXaSIsInJlYWQ6YnVzaW5lc3M6Yml6XzNiaDY5YnExcmszZG1YTm9BS1ZvbnUiXSwiZXhwIjoxNzI1OTgyNDc0LCJpYXQiOjE3MTgyMDY0NzQsInBsYXRmb3JtX2FjY291bnRfaWQiOiJhY2NfM3JlTmI0YU5ZeTJpV0RaUVZjem14NCJ9.EVnfeXD9-OYAm45GhJR9pTTA3o3Uf3iU2RGS4Yf-SrTeLaswZE6KmyuVIw_K2q-cqh4Cwe85QCMUh5HXKefLNjnJOGax35x_br1c3Tdl5kErqV1xMkXvdFdC_jdhaLzk9LbEAtQufPey5h-Wg5c8oosA_m7OK_OhqcJsABigzA1Ma0w585LH0Y1fhl_qHYFpg2HSMHLG1kGuXMOTMgJH4z9sA-OwDpvSKX8_yF_NlGR-SdymbM0vS7BCMi4uwlrSqAdafWYTFRIjNaPc9ncKLuageFm1k3xFk9gt3fzjzLpk7or7QOaRMHTrQTXT3l-g-g6PZc6dMFKVhWWkaK4S5w',
+  'auth-token':
+    'eyJraWQiOiJqdXN0aWZpLWUyNDgyMmU3ODE1MmEzZjRkMjU1IiwidHlwIjoiSldUIiwiYWxnIjoiUlMyNTYifQ.eyJpc3MiOiJodHRwczovL2F1dGguanVzdGlmaS5haS8iLCJhenAiOiJ3Y3RfNXpYcUpqRm1JZzJTa2ZpOGlVZUMwTyIsInN1YiI6IndjdF81elhxSmpGbUlnMlNrZmk4aVVlQzBPQHNlc3Npb25zIiwiYXVkIjoiaHR0cHM6Ly9hcGkuanVzdGlmaS5haS92MSIsImd0eSI6ImNsaWVudC1jcmVkZW50aWFscyIsInBlcm1pc3Npb25zIjpbInJlYWQ6YWNjb3VudDphY2NfNUV0OWlYclNTQVpSMktTb3VRR0FXaSIsInJlYWQ6YnVzaW5lc3M6Yml6XzNiaDY5YnExcmszZG1YTm9BS1ZvbnUiXSwiZXhwIjoxNzI1OTgyNDc0LCJpYXQiOjE3MTgyMDY0NzQsInBsYXRmb3JtX2FjY291bnRfaWQiOiJhY2NfM3JlTmI0YU5ZeTJpV0RaUVZjem14NCJ9.EVnfeXD9-OYAm45GhJR9pTTA3o3Uf3iU2RGS4Yf-SrTeLaswZE6KmyuVIw_K2q-cqh4Cwe85QCMUh5HXKefLNjnJOGax35x_br1c3Tdl5kErqV1xMkXvdFdC_jdhaLzk9LbEAtQufPey5h-Wg5c8oosA_m7OK_OhqcJsABigzA1Ma0w585LH0Y1fhl_qHYFpg2HSMHLG1kGuXMOTMgJH4z9sA-OwDpvSKX8_yF_NlGR-SdymbM0vS7BCMi4uwlrSqAdafWYTFRIjNaPc9ncKLuageFm1k3xFk9gt3fzjzLpk7or7QOaRMHTrQTXT3l-g-g6PZc6dMFKVhWWkaK4S5w',
   'business-id': 'biz_3bh69bq1rk3dmXNoAKVonu',
   'client-id': 'test_df97f04afebc3c018de30df3562d7cdd',
   'payment-id': 'py_1NNeEnf4FbelxDCQN2RHcE',
   'payout-id': 'po_17745yESnHyEgWNeunmhmR',
+  'custom-styled': false,
 };
 
 const argTypes: ArgTypes = {
@@ -19,8 +29,8 @@ const argTypes: ArgTypes = {
       type: 'text',
     },
     table: {
-      category: 'props'
-    }
+      category: 'props',
+    },
   },
   'account-id': {
     type: 'string',
@@ -29,18 +39,19 @@ const argTypes: ArgTypes = {
       type: 'text',
     },
     table: {
-      category: 'props'
-    }
+      category: 'props',
+    },
   },
   'business-id': {
     type: 'string',
-    description: 'Business ID `string`, the id of the business you create via API',
+    description:
+      'Business ID `string`, the id of the business you create via API',
     control: {
       type: 'text',
     },
     table: {
-      category: 'props'
-    }
+      category: 'props',
+    },
   },
   'client-id': {
     type: 'string',
@@ -49,12 +60,12 @@ const argTypes: ArgTypes = {
       type: 'text',
     },
     table: {
-      category: 'props'
-    }
+      category: 'props',
+    },
   },
   'iframe-origin': {
     table: {
-      disable: true
+      disable: true,
     },
   },
   'payment-id': {
@@ -64,8 +75,8 @@ const argTypes: ArgTypes = {
       type: 'text',
     },
     table: {
-      category: 'props'
-    }
+      category: 'props',
+    },
   },
   'payout-id': {
     type: 'string',
@@ -74,17 +85,27 @@ const argTypes: ArgTypes = {
       type: 'text',
     },
     table: {
-      category: 'props'
-    }
+      category: 'props',
+    },
   },
-}
+  'custom-styled': {
+    type: 'boolean',
+    description: 'Use custom styles `boolean`',
+    control: {
+      type: 'boolean',
+    },
+    table: {
+      category: 'props',
+    },
+  },
+};
 
 export class StoryBaseArgs {
   args: ArgValues = {};
   argTypes: ArgTypes = {};
 
   constructor(argKeys: ArgNames[]) {
-    argKeys.forEach(key => {
+    argKeys.forEach((key) => {
       this.args[key] = args[key];
       this.argTypes[key] = argTypes[key];
     });
@@ -92,22 +113,25 @@ export class StoryBaseArgs {
 }
 
 export const paymentMethodFormComponentMethods = {
-  'resize': {
-    description: 'Triggers the iframe to compute it\'s height based on it\'s content and resize. This method is deprecated and will be removed in a future release in favor of better automatic resizing',
+  resize: {
+    description:
+      "Triggers the iframe to compute it's height based on it's content and resize. This method is deprecated and will be removed in a future release in favor of better automatic resizing",
     table: {
       category: 'methods',
-    }
+    },
   },
-  'validate': {
-    description: 'Asynchronous. Triggers validation on the form and shows errors if any, and returns a promise that resolves with `{ isValid: <boolean> }`',
+  validate: {
+    description:
+      'Asynchronous. Triggers validation on the form and shows errors if any, and returns a promise that resolves with `{ isValid: <boolean> }`',
     table: {
-      category: 'methods'
-    }
+      category: 'methods',
+    },
   },
-  'tokenize': {
-    description: 'Asynchronous. Triggers validation, then tokenization of payment method information if it passes client side validation. Returns a promise that resolves with the [tokenization request response body](https://developer.justifi.ai/tag/Payments#operation/CreatePayment). `tokenize(CLIENT_ID, PAYMENT_METHOD_METADATA, ACCOUNT_ID)`',
+  tokenize: {
+    description:
+      'Asynchronous. Triggers validation, then tokenization of payment method information if it passes client side validation. Returns a promise that resolves with the [tokenization request response body](https://developer.justifi.ai/tag/Payments#operation/CreatePayment). `tokenize(CLIENT_ID, PAYMENT_METHOD_METADATA, ACCOUNT_ID)`',
     table: {
-      category: 'methods'
-    }
-  }
+      category: 'methods',
+    },
+  },
 };

--- a/apps/docs/stories/utils/css-variables.tsx
+++ b/apps/docs/stories/utils/css-variables.tsx
@@ -105,3 +105,74 @@ export const CSSVars = () => (
   `}
   />
 );
+
+export const CSSVarsExample = `
+  --jfi-primary-color: #212529;
+  --jfi-load-google-font: 'Roboto Mono:wght@200;400;700;900';
+  --jfi-layout-font-family: Roboto Mono, Calibri, sans-serif;
+  --jfi-layout-padding: 4px;
+  --jfi-layout-form-control-spacing-x: .5rem;
+  --jfi-layout-form-control-spacing-y: 1rem;
+  --jfi-form-label-font-weight: 700;
+  --jfi-form-label-font-family: Calibri, sans-serif;
+  --jfi-form-label-margin: 0 0 .5rem 0;
+  --jfi-form-control-background-color: #F4F4F6;
+  --jfi-form-control-background-color-hover: #EEEEF5;
+  --jfi-form-control-border-color: rgba(0, 0, 0, 0.42);
+  --jfi-form-control-border-color-hover: rgba(0, 0, 0, 0.62);
+  --jfi-form-control-border-color-focus: #fccc32;
+  --jfi-form-control-border-color-error: #C12727;
+  --jfi-form-control-border-top-width: 0;
+  --jfi-form-control-border-left-width: 0;
+  --jfi-form-control-border-bottom-width: 1px;
+  --jfi-form-control-border-right-width: 0;
+  --jfi-form-control-border-radius: 4px 4px 0 0;
+  --jfi-form-control-border-style: solid;
+  --jfi-form-control-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  --jfi-form-control-box-shadow-focus: none;
+  --jfi-form-control-box-shadow-error-focus: none;
+  --jfi-form-control-border-style: solid;
+  --jfi-form-control-color: #212529;
+  --jfi-form-control-font-size: 1rem;
+  --jfi-form-control-font-weight: 400;
+  --jfi-form-control-line-height: 2;
+  --jfi-form-control-margin: 0;
+  --jfi-form-control-padding: .5rem .875rem;
+  --jfi-error-message-color: #C12727;
+  --jfi-error-message-margin: .25rem 0 0 0;
+  --jfi-error-message-font-size: .875rem;
+
+  --jfi-submit-button-color: white;
+  --jfi-submit-button-background-color: #3F3F47;
+  --jfi-submit-button-border-color: var(--jfi-primary-color);
+  --jfi-submit-button-padding: 0.375rem 0.75rem;
+  --jfi-submit-button-font-size: 1rem;
+  --jfi-submit-button-border-radius: 1px;
+  --jfi-submit-button-color-hover: white;
+  --jfi-submit-button-background-color-hover: var(--jfi-primary-color);
+  --jfi-submit-button-border-color-hover: var(--jfi-primary-color);
+  --jfi-submit-button-color-focus: white;
+  --jfi-submit-button-background-color-focus: var(--jfi-primary-color);
+  --jfi-submit-button-border-color-focus: var(--jfi-primary-color);
+  --jfi-submit-button-color-active: white;
+  --jfi-submit-button-background-color-active: var(--jfi-primary-color);
+  --jfi-submit-button-border-color-active: var(--jfi-primary-color);
+  --jfi-submit-button-width: 100%;
+  --jfi-submit-button-box-shadow: rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px;
+
+  --jfi-radio-button-color: var(--jfi-primary-color);
+  --jfi-radio-button-background-color: transparent;
+  --jfi-radio-button-color-selected: white;
+  --jfi-radio-button-background-color-selected: var(--jfi-primary-color);
+  --jfi-radio-button-border-color: var(--jfi-primary-color);
+  --jfi-radio-button-border-color-selected: var(--jfi-primary-color);
+  --jfi-radio-button-padding: 0.375rem 0.75rem;
+  --jfi-radio-button-font-size: 1rem;
+  --jfi-radio-button-color-hover: var(--jfi-primary-color);
+  --jfi-radio-button-color-selected-hover: white;
+  --jfi-radio-button-background-color-hover: transparent;
+  --jfi-radio-button-background-color-selected-hover: var(--jfi-primary-color);
+  --jfi-radio-button-border-color-selected-hover: var(--jfi-primary-color);
+  --jfi-radio-button-border-color-hover: var(--jfi-primary-color);
+  --jfi-radio-button-group-width: 100%;
+`;

--- a/apps/docs/stories/utils/decorators.ts
+++ b/apps/docs/stories/utils/decorators.ts
@@ -5,13 +5,16 @@ type Props = { name: string; value: any }[];
 const getPropsAndStyles = (storyContext: any) => {
   const args = storyContext.args;
   const argNames = Object.keys(args);
-  const nonStyleArgs = argNames.filter((arg) => arg !== 'style');
+  const nonStyleArgs = argNames.filter(
+    (arg) => arg !== 'style' && arg !== 'custom-styled'
+  );
   const props: Props = nonStyleArgs.map((arg) => {
     return { name: arg, value: args[arg] };
   });
   const styleArg = args.style;
+  const customStyled = args['custom-styled'];
 
-  return { props: props, styleArg: styleArg }
+  return { props, styleArg, customStyled };
 };
 
 const applyArgsToStoryComponent = (storyComponent: any, props: Props) => {
@@ -28,36 +31,41 @@ const generateStyleBlock = (styleArg: any) => {
   const styleBlock = document.createElement('style');
   const styleArgKeys = Object.keys(styleArg);
 
-  styleBlock.innerHTML = styleArgKeys.map((styleArgKey) => {
+  styleBlock.innerHTML = styleArgKeys
+    .map((styleArgKey) => {
       const selector = styleArgKey;
       const cssProperties = styleArg[styleArgKey];
-    const cssRules = Object.keys(cssProperties).map((cssProperty) => {
+      const cssRules = Object.keys(cssProperties)
+        .map((cssProperty) => {
           return `${cssProperty}: ${cssProperties[cssProperty]};`;
         })
         .join('');
 
-    return (`
+      return `
       ${selector} {
         ${cssRules}
       }
-    `);
-  }).join('');
+    `;
+    })
+    .join('');
 
   return styleBlock;
-}
+};
 
-export const customStoryDecorator = (storyComponent: any, storyContext: any) => {
+export const customStoryDecorator = (
+  storyComponent: any,
+  storyContext: any
+) => {
   const fragment = new DocumentFragment();
-  const { props, styleArg } = getPropsAndStyles(storyContext);
-
+  const { props, styleArg, customStyled } = getPropsAndStyles(storyContext);
   setUpMocks();
 
   const component = applyArgsToStoryComponent(storyComponent, props);
 
-  if (styleArg) {
+  if (customStyled && styleArg) {
     const styleBlock = generateStyleBlock(styleArg);
-    fragment.prepend(styleBlock)
-  };
+    fragment.prepend(styleBlock);
+  }
 
   fragment.appendChild(component);
   return fragment;

--- a/apps/docs/stories/utils/decorators.ts
+++ b/apps/docs/stories/utils/decorators.ts
@@ -3,18 +3,22 @@ import { setUpMocks } from './mockAllServices';
 type Props = { name: string; value: any }[];
 
 const getPropsAndStyles = (storyContext: any) => {
-  const args = storyContext.args;
+  const {
+    args,
+    parameters: { themes } = { themes: {} }, // Default themes to an empty object if it's not present
+  } = storyContext;
+
   const argNames = Object.keys(args);
-  const nonStyleArgs = argNames.filter(
-    (arg) => arg !== 'style' && arg !== 'custom-styled'
-  );
-  const props: Props = nonStyleArgs.map((arg) => {
+  const nonThemeArgs = argNames.filter((arg) => arg !== 'theme');
+
+  const props: Props = nonThemeArgs.map((arg) => {
     return { name: arg, value: args[arg] };
   });
-  const styleArg = args.style;
-  const customStyled = args['custom-styled'];
 
-  return { props, styleArg, customStyled };
+  // Check if args['component-theme'] and themes are defined before accessing
+  const styleArg = args.theme && themes ? themes[args.theme] : undefined;
+
+  return { props, styleArg };
 };
 
 const applyArgsToStoryComponent = (storyComponent: any, props: Props) => {
@@ -57,12 +61,12 @@ export const customStoryDecorator = (
   storyContext: any
 ) => {
   const fragment = new DocumentFragment();
-  const { props, styleArg, customStyled } = getPropsAndStyles(storyContext);
+  const { props, styleArg } = getPropsAndStyles(storyContext);
   setUpMocks();
 
   const component = applyArgsToStoryComponent(storyComponent, props);
 
-  if (customStyled && styleArg) {
+  if (styleArg) {
     const styleBlock = generateStyleBlock(styleArg);
     fragment.prepend(styleBlock);
   }

--- a/packages/webcomponents/src/components/business-list/business-list.stories.ts
+++ b/packages/webcomponents/src/components/business-list/business-list.stories.ts
@@ -3,7 +3,7 @@ import { config } from '../../../config';
 export default {
   title: 'dev/Components/BusinessList',
   component: 'justifi-business-list',
-  parameters: {}
+  parameters: {},
 };
 
 class BusinessListArgs {
@@ -17,17 +17,17 @@ class BusinessListArgs {
 }
 
 const Template = (args: BusinessListArgs) => {
-  return (`
+  return `
     <justifi-business-list
       data-testid="justifi-business-list"
       auth-token="${args['auth-token']}"
       account-id="${args['account-id']}"
     />
-  `);
+  `;
 };
 
-export const Basic = Template.bind({});
-Basic.args = new BusinessListArgs({});
+export const Example = Template.bind({});
+Example.args = new BusinessListArgs({});
 
 export const Styled = Template.bind({});
 Styled.args = new BusinessListArgs({});
@@ -63,8 +63,8 @@ Styled.decorators = [
         background-color: #F4F4F6;
       }
     </style>
-  `
-]
+  `,
+];
 
 export const Contained = Template.bind({});
 Contained.decorators = [
@@ -72,6 +72,6 @@ Contained.decorators = [
     <div style="position: relative; width: 900px; height: 300px; overflow-x: hidden;">
       ${Story()}
     </div>
-  `
-]
+  `,
+];
 Contained.args = new BusinessListArgs({});

--- a/packages/webcomponents/src/components/payment-balance-transactions/payment-balance-transactions.stories.ts
+++ b/packages/webcomponents/src/components/payment-balance-transactions/payment-balance-transactions.stories.ts
@@ -1,4 +1,4 @@
-import { config } from "../../../config";
+import { config } from '../../../config';
 
 export default {
   title: 'dev/Components/PaymentBalanceTransactions',
@@ -11,7 +11,7 @@ class PaymentBalanceTransactionsArgs {
   'payment-id': string;
   'account-id': string;
 
-  'constructor'(args) {
+  constructor(args) {
     this['auth-token'] = args['auth-token'] || config.proxyAuthToken;
     this['payment-id'] = args['payment-id'] || config.examplePaymentId;
     this['account-id'] = args['account-id'] || config.exampleAccountId;
@@ -29,13 +29,13 @@ const Template = (args: PaymentBalanceTransactionsArgs) => {
   `;
 };
 
-export const Basic = Template.bind({});
-Basic.args = new PaymentBalanceTransactionsArgs({});
+export const Example = Template.bind({});
+Example.args = new PaymentBalanceTransactionsArgs({});
 
 export const Styled = Template.bind({});
 Styled.args = new PaymentBalanceTransactionsArgs({});
 Styled.decorators = [
-  Story => `
+  (Story) => `
     ${Story()}
   `,
 ];

--- a/packages/webcomponents/src/components/proceeds-list/proceeds-list.stories.ts
+++ b/packages/webcomponents/src/components/proceeds-list/proceeds-list.stories.ts
@@ -12,8 +12,8 @@ export default {
           console.log(e);
         })
       </script>
-    `
-  ]
+    `,
+  ],
 };
 
 class ProceedsListArgs {
@@ -27,17 +27,17 @@ class ProceedsListArgs {
 }
 
 const Template = (args: ProceedsListArgs) => {
-  return (`
+  return `
     <justifi-proceeds-list
       data-testid="justifi-proceeds-list"
       auth-token="${args['auth-token']}"
       account-id="${args['account-id']}"
     />
-  `);
+  `;
 };
 
-export const Basic = Template.bind({});
-Basic.args = new ProceedsListArgs({});
+export const Example = Template.bind({});
+Example.args = new ProceedsListArgs({});
 
 export const Styled = Template.bind({});
 Styled.args = new ProceedsListArgs({});
@@ -73,5 +73,5 @@ Styled.decorators = [
         background-color: #F4F4F6;
       }
     </style>
-  `
-]
+  `,
+];

--- a/packages/webcomponents/src/components/refund-form/refund-form.stories.ts
+++ b/packages/webcomponents/src/components/refund-form/refund-form.stories.ts
@@ -105,8 +105,8 @@ const RefundFormTemplate = ({
   `;
 };
 
-export const Basic = RefundFormTemplate.bind({});
-Basic.args = {
+export const Example = RefundFormTemplate.bind({});
+Example.args = {
   authToken: '',
   paymentId: '',
   amount: 0,

--- a/packages/webcomponents/src/components/subaccount-details/subaccount-details.stories.ts
+++ b/packages/webcomponents/src/components/subaccount-details/subaccount-details.stories.ts
@@ -3,7 +3,7 @@ import { config } from '../../../config';
 export default {
   title: 'dev/Components/SubaccountDetails',
   component: 'justifi-subaccount-details',
-  parameters: {}
+  parameters: {},
 };
 
 class SubaccountDetailsArgs {
@@ -19,15 +19,15 @@ class SubaccountDetailsArgs {
 }
 
 const Template = (args: SubaccountDetailsArgs) => {
-  return (`
+  return `
     <justifi-subaccount-details
       data-testid="justifi-subaccounts-details"
       auth-token="${args['auth-token']}"
       account-id="${args['account-id']}"
       subaccount-id="${args['subaccount-id']}"
     />
-  `);
+  `;
 };
 
-export const Basic = Template.bind({});
-Basic.args = new SubaccountDetailsArgs({});
+export const Example = Template.bind({});
+Example.args = new SubaccountDetailsArgs({});

--- a/packages/webcomponents/src/components/subaccounts-list/subaccounts-list.stories.ts
+++ b/packages/webcomponents/src/components/subaccounts-list/subaccounts-list.stories.ts
@@ -12,8 +12,8 @@ export default {
           console.log(e);
         })
       </script>
-    `
-  ]
+    `,
+  ],
 };
 
 class SubaccountsListArgs {
@@ -22,22 +22,22 @@ class SubaccountsListArgs {
 
   constructor(args) {
     this['auth-token'] = args['auth-token'] || config.privateAuthToken;
-    this['account-id'] = args['account-id'] || ''
+    this['account-id'] = args['account-id'] || '';
   }
 }
 
 const Template = (args: SubaccountsListArgs) => {
-  return (`
+  return `
     <justifi-subaccounts-list
       data-testid="justifi-subaccounts-list"
       auth-token="${args['auth-token']}"
       account-id="${args['account-id']}"
     />
-  `);
+  `;
 };
 
-export const Basic = Template.bind({});
-Basic.args = new SubaccountsListArgs({});
+export const Example = Template.bind({});
+Example.args = new SubaccountsListArgs({});
 
 export const Styled = Template.bind({});
 Styled.args = new SubaccountsListArgs({});
@@ -73,5 +73,5 @@ Styled.decorators = [
         background-color: #F4F4F6;
       }
     </style>
-  `
-]
+  `,
+];


### PR DESCRIPTION
**Description**

This adds the `theme` prop to base-args in order to be possible to switch between "basic" and "custom" styles on the story controls.

As a consequence of this change, the "custom" extra stories for each component were removed. Now we have only the "basic" story with a "theme" prop under "theming" section on the story controls.

* In the prop description, added a link to the [Introduction](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling-components-with-variables) to show an example of the CSS variables available.

![image](https://github.com/justifi-tech/web-component-library/assets/22480988/3f6a411f-cd4b-4009-ae7c-956d7b6919ff)

(top toolbar buttons) 
* ~~The top toolbar buttons are default and it seems that they cannot be removed.~~ Yes they got removed 👍 


Links
-----
#525 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------

[ ] - Styleable components should now display just 'basic' story with a `theme` prop to switch the styles.

Components: 
- Payments List
- Payouts List
- Bank Account Form
- Card Form
- Payment Form
- Checkout ('light' and 'dark')

