### PR TITLE
Payment provisioning component error event

### DIFF
--- a/.changeset/chilled-dancers-pretend.md
+++ b/.changeset/chilled-dancers-pretend.md
@@ -1,0 +1,7 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Updated error handling for network requests in `PaymentProvisioning` component. 
+  -Component no longer renders visible alert in cases where network requests fail. It now emits an event, `error-event`, in line with other web components, allowing implementing developers to handle server errors as they see fit. 
+  - Removed prop `hideErrors` from `PaymentProvisioning` as it is no longer applicable. 

--- a/apps/docs/stories/components/payment-provisioning.stories.tsx
+++ b/apps/docs/stories/components/payment-provisioning.stories.tsx
@@ -12,8 +12,7 @@ const meta: Meta = {
   title: 'Entities/Payment Provisioning (BETA)',
   component: 'justifi-payment-provisioning',
   args: {
-    ...storyBaseArgs.args,
-    'test-mode': true
+    ...storyBaseArgs.args
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
@@ -31,17 +30,6 @@ const meta: Meta = {
     'remove-title': {
       type: 'boolean',
       description: 'This prop removes the title displayed at the top of the form.',
-      control: {
-        type: 'boolean',
-      },
-      table: {
-        category: 'props',
-        defaultValue: { summary: 'false' }
-      }
-    },
-    'hide-errors': {
-      type: 'boolean',
-      description: 'When set to `true`, this prop will hide all error alerts from the form, allowing developers more control over how they wish to handle errors.',
       control: {
         type: 'boolean',
       },

--- a/apps/docs/stories/components/payment-provisioning.stories.tsx
+++ b/apps/docs/stories/components/payment-provisioning.stories.tsx
@@ -78,7 +78,8 @@ const meta: Meta = {
     actions: {
       handles: [
         'submitted',
-        'click-event'
+        'click-event',
+        'error-event'
       ]
     },
     chromatic: {

--- a/packages/webcomponents/src/api/ComponentError.ts
+++ b/packages/webcomponents/src/api/ComponentError.ts
@@ -1,6 +1,8 @@
 export enum ComponentErrorCodes {
   MISSING_PROPS = 'missing-props',
   FETCH_ERROR = 'fetch-error',
+  PATCH_ERROR = 'patch-error',
+  POST_ERROR = 'post-error',
   UNKNOWN_ERROR = 'unknown-error',
   TOKENIZE_ERROR = 'tokenize-error',
   NOT_AUTHENTICATED = 'not-authenticated'

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.scss
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.scss
@@ -1,5 +1,4 @@
 @import 'reboot';
-@import 'alert';
 @import 'grid';
 @import 'buttons';
 @import 'spinners';

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning.tsx
@@ -4,7 +4,6 @@ import { BusinessFormClickActions, BusinessFormClickEvent } from '../utils/busin
 import JustifiAnalytics from '../../../api/Analytics';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../api/ComponentError';
 
-
 /**
  * @exportedPart label: Label for inputs
  * @exportedPart input: The input fields
@@ -17,17 +16,17 @@ import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../
   shadow: true
 })
 export class PaymentProvisioning {
+  @State() formLoading: boolean = false;
+  @State() currentStep: number = 0;
+  @State() errorMessage: string;
+  
   @Prop() authToken: string;
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean = false;
   @Prop() formTitle?: string = 'Business Information';
   @Prop() removeTitle?: boolean = false;
  
-  @State() formLoading: boolean = false;
-  @State() currentStep: number = 0;
-  @State() errorMessage: string;
-
-  @Event({eventName: 'click-event' }) clickEvent: EventEmitter<BusinessFormClickEvent>;
+  @Event({ eventName: 'click-event' }) clickEvent: EventEmitter<BusinessFormClickEvent>;
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 
   analytics: JustifiAnalytics;

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
@@ -1,26 +1,27 @@
 import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { BusinessFormServerErrorEvent, BusinessFormServerErrors, BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { config } from '../../../../../config';
 import { businessTermsConditionsSchema } from '../../schemas/business-terms-conditions-schema';
 import { Api, IApiResponse } from '../../../../api';
 import { IBusiness } from '../../../../api/Business';
+import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
 
 @Component({
   tag: 'justifi-business-terms-conditions-form-step'
 })
 export class BusinessTermsConditionsFormStep {
+  @State() formController: FormController;
+  @State() errors: any = {};
+  @State() acceptedTermsBefore: boolean;
+  
   @Prop() authToken: string;
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean;
   
-  @State() formController: FormController;
-  @State() errors: any = {};
-  @State() acceptedTermsBefore: boolean;
-
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event() formLoading: EventEmitter<boolean>;
-  @Event() serverError: EventEmitter<BusinessFormServerErrorEvent>;
+  @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
   private api: any;
 
@@ -45,14 +46,11 @@ export class BusinessTermsConditionsFormStep {
   }
 
   async componentWillLoad() {
-    const missingAuthTokenMessage = 'Warning: Missing auth-token. The form will not be functional without it.';
-    const missingBusinessIdMessage = 'Warning: Missing business-id. The form requires an existing business-id to function.';
-    if (!this.authToken) console.error(missingAuthTokenMessage);
-    if (!this.businessId) console.error(missingBusinessIdMessage);
-
     this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
     this.formController = new FormController(businessTermsConditionsSchema(this.allowOptionalFields));
-    this.fetchData();
+    if (this.businessId && this.authToken) {
+      this.fetchData();
+    }
   }
 
   private fetchData = async () => {
@@ -61,7 +59,12 @@ export class BusinessTermsConditionsFormStep {
       const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
       this.acceptedTermsBefore = response.data.terms_conditions_accepted;
     } catch (error) {
-      this.serverError.emit({ data: error, message: BusinessFormServerErrors.fetchData });
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.FETCH_ERROR,
+        message: error.message,
+        severity: ComponentErrorSeverity.ERROR,
+        data: error,
+      })
     } finally {
       this.formLoading.emit(false);
     }
@@ -74,7 +77,12 @@ export class BusinessTermsConditionsFormStep {
       const response = await this.api.post(this.termsConditionsEndpoint, payload);
       this.handleResponse(response, onSuccess);
     } catch (error) {
-      this.serverError.emit({ data: error, message: BusinessFormServerErrors.patchData });
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.POST_ERROR,
+        message: error.message,
+        severity: ComponentErrorSeverity.ERROR,
+        data: error,
+      })
     } finally {
       this.formLoading.emit(false);
     }
@@ -82,7 +90,12 @@ export class BusinessTermsConditionsFormStep {
 
   handleResponse(response, onSuccess) {
     if (response.error) {
-      this.serverError.emit({ data: response.error, message: BusinessFormServerErrors.patchData });
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.POST_ERROR,
+        message: response.error.message,
+        severity: ComponentErrorSeverity.ERROR,
+        data: response.error,
+      })
     } else {
       onSuccess();
     }

--- a/packages/webcomponents/src/components/business-forms/utils/helpers.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/helpers.ts
@@ -21,7 +21,8 @@ export function constructDate(year: string, month: string, day: string): string 
   return `${year}-${filterNumber(month)}-${filterNumber(day)}`;
 }
 
-export function deconstructDate(date: string): { dob_year: string, dob_month: string, dob_day: string } {
-  const [dob_year, dob_month, dob_day] = date.split('-');
+export function deconstructDate(formInput: any): { dob_year: string, dob_month: string, dob_day: string } {
+  const dateString = formInput.value;
+  const [dob_year, dob_month, dob_day] = dateString.split('-');
   return { dob_year, dob_month, dob_day };
 }


### PR DESCRIPTION
### Emit error-event in PaymentProvisioning component

This PR commits the following changes:

- No longer render `form-alert` in `PaymentProvisioning` on server / API errors
- Emit `error-event` typed as `ComponentError` to be in step with other component error handling
  - emits on load if there is no auth token or business id, and emits on failure to fetch or send data. 
- Removes prop `hideErrors` from `PaymentProvisioning` since there are no longer any alerts to show or hide in this component. 



Links
-----

Closes #454 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [x] Attempt to load `PaymentProvisioning` component without auth token or Business ID prop and verify that `error-event` is emitted with the correct message: `Invalid business id or auth token`
- [x] Failed network requests for fetching or sending data in any form step of `PaymentProvisioning` will no longer show an alert component and render the component in an error state. `error-event` should be emitted instead with the error response from the server contained as the message. 

