### PR TITLE
Refactor CoreInfo form step to use core component structure

### DIFF
--- a/.changeset/small-paws-hammer.md
+++ b/.changeset/small-paws-hammer.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Optimized render logic for core info form step (first form step) in `PaymentProvisioning` for better efficiency, stability, and performance.

--- a/.changeset/small-paws-hammer.md
+++ b/.changeset/small-paws-hammer.md
@@ -1,5 +1,0 @@
----
-"@justifi/webcomponents": patch
----
-
-- Optimized render logic for core info form step (first form step) in `PaymentProvisioning` for better efficiency, stability, and performance.

--- a/packages/webcomponents/src/api/services/business.service.ts
+++ b/packages/webcomponents/src/api/services/business.service.ts
@@ -17,4 +17,13 @@ export class BusinessService implements IBusinessService {
     const endpoint = `entities/business/${businessId}`;
     return Api({ authToken, apiOrigin: config.proxyApiOrigin }).get(endpoint);
   }
+
+  async patchBusiness(
+    authToken: string,
+    businessId: string,
+    payload: Partial<IBusiness>
+  ): Promise<IApiResponse<IBusiness>> {
+    const endpoint = `entities/business/${businessId}`;
+    return Api({ authToken, apiOrigin: config.proxyApiOrigin }).patch(endpoint, payload);
+  }
 }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -66,22 +66,26 @@ export class BusinessCoreInfoFormStepCore {
   }
 
   private sendData = (onSuccess: () => void) => {
+    let submittedData;
     this.formLoading.emit(true);
     this.patchBusiness({
       payload: JSON.stringify(this.patchPayload),
       onSuccess: (response) => {
-        this.submitted.emit({ data: { response } });
+        submittedData = response;
         onSuccess();
       },
       onError: ({ error, code, severity }) => {
-        this.submitted.emit({ data: { error } });
+        submittedData = error;
         this.errorEvent.emit({
           message: error,
           errorCode: code,
           severity: severity
         });
       },
-      final: () => this.formLoading.emit(false)
+      final: () => {
+        this.submitted.emit({ data: { submittedData } });
+        this.formLoading.emit(false)
+      }
     });
   }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -33,7 +33,8 @@ export class BusinessCoreInfoFormStepCore {
   };
 
   get patchPayload() {
-    return parseCoreInfo(flattenNestedObject(this.formController.values.getValue()));
+    let formValues = parseCoreInfo(flattenNestedObject(this.formController.values.getValue()));
+    return JSON.stringify(formValues);
   }
 
   componentWillLoad() {
@@ -69,7 +70,7 @@ export class BusinessCoreInfoFormStepCore {
     let submittedData;
     this.formLoading.emit(true);
     this.patchBusiness({
-      payload: JSON.stringify(this.patchPayload),
+      payload: this.patchPayload,
       onSuccess: (response) => {
         submittedData = response;
         onSuccess();

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -1,0 +1,195 @@
+import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
+import { businessCoreInfoSchema } from "../../schemas/business-core-info-schema";
+import { FormController } from "../../../form/form";
+import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
+import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { ComponentError } from '../../../../api/ComponentError';
+import { businessClassificationOptions } from '../../utils/business-form-options';
+import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
+import { parseCoreInfo } from '../../utils/payload-parsers';
+import { flattenNestedObject } from '../../../../utils/utils';
+
+@Component({
+  tag: "justifi-business-core-info-form-step-core",
+})
+export class BusinessCoreInfoFormStepCore {
+  @State() formController: FormController;
+  @State() errors: any = {};
+  @State() coreInfo: ICoreBusinessInfo = {};
+
+  @Prop() authToken: string;
+  @Prop() businessId: string;
+  @Prop() getBusiness: Function;
+  @Prop() patchBusiness: Function;
+  @Prop() allowOptionalFields?: boolean;
+
+  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
+  @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
+
+  @Method()
+  async validateAndSubmit({ onSuccess }) {
+    this.formController.validateAndSubmit(() => this.sendData(onSuccess));
+  };
+
+  get patchPayload() {
+    return parseCoreInfo(flattenNestedObject(this.formController.values.getValue()));
+  }
+
+  componentWillLoad() {
+    this.getBusiness && this.getData();
+    this.formController = new FormController(businessCoreInfoSchema(this.allowOptionalFields));
+  }
+
+  componentDidLoad() {
+    this.formController.errors.subscribe(errors => {
+      this.errors = { ...errors };
+    });
+  }
+
+  private getData = () => {
+    this.formLoading.emit(true);
+    this.getBusiness({
+      onSuccess: (response) => {
+        this.coreInfo = new CoreBusinessInfo(response.data);
+        this.formController.setInitialValues({ ...this.coreInfo });
+      },
+      onError: ({ error, code, severity }) => {
+        this.errorEvent.emit({
+          message: error,
+          errorCode: code,
+          severity: severity
+        });
+      },
+      final: () => this.formLoading.emit(false)
+    });
+  }
+
+  private sendData = (onSuccess: () => void) => {
+    this.formLoading.emit(true);
+    this.patchBusiness({
+      payload: JSON.stringify(this.patchPayload),
+      onSuccess: (response) => {
+        this.submitted.emit({ data: { response } });
+        onSuccess();
+      },
+      onError: ({ error, code, severity }) => {
+        this.submitted.emit({ data: { error } });
+        this.errorEvent.emit({
+          message: error,
+          errorCode: code,
+          severity: severity
+        });
+      },
+      final: () => this.formLoading.emit(false)
+    });
+  }
+
+  inputHandler = (name: string, value: string) => {
+    this.formController.setValues({
+      ...this.formController.values.getValue(),
+      [name]: value,
+    });
+  }
+
+  render() {
+    const coreInfoDefaultValue = this.formController.getInitialValues();
+
+    return (
+      <Host exportparts="label,input,input-invalid">
+        <form>
+          <fieldset>
+            <legend>General Info</legend>
+            <hr />
+            <div class="row gy-3">
+              <div class="col-12">
+                <form-control-text
+                  name="legal_name"
+                  label="Legal Name"
+                  defaultValue={coreInfoDefaultValue.legal_name}
+                  errorText={this.errors.legal_name}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12">
+                <form-control-text
+                  name="doing_business_as"
+                  label="Doing Business As (DBA)"
+                  defaultValue={coreInfoDefaultValue.doing_business_as}
+                  errorText={this.errors.doing_business_as}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-8">
+                <form-control-select
+                  name="classification"
+                  label="Business Classification"
+                  options={businessClassificationOptions}
+                  defaultValue={coreInfoDefaultValue.classification}
+                  errorText={this.errors.classification}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-4">
+                <form-control-date
+                  name="date_of_incorporation"
+                  label="Date of Incorporation"
+                  defaultValue={coreInfoDefaultValue.date_of_incorporation}
+                  errorText={this.errors.date_of_incorporation}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-6">
+                <form-control-text
+                  name="industry"
+                  label="Industry"
+                  defaultValue={coreInfoDefaultValue.industry}
+                  errorText={this.errors.industry}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-6">
+                <form-control-number-masked
+                  name="tax_id"
+                  label="Tax ID"
+                  defaultValue={coreInfoDefaultValue.tax_id}
+                  errorText={this.errors.tax_id}
+                  inputHandler={this.inputHandler}
+                  mask={TAX_ID_MASKS.US}
+                />
+              </div>
+              <div class="col-12">
+                <form-control-text
+                  name="website_url"
+                  label="Website URL"
+                  defaultValue={coreInfoDefaultValue.website_url}
+                  errorText={this.errors.website_url}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-6">
+                <form-control-text
+                  name="email"
+                  label="Email Address"
+                  defaultValue={coreInfoDefaultValue.email}
+                  errorText={this.errors.email}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class="col-12 col-md-6">
+                <form-control-number-masked
+                  name="phone"
+                  label="Phone Number"
+                  defaultValue={coreInfoDefaultValue.phone}
+                  errorText={this.errors.phone}
+                  inputHandler={this.inputHandler}
+                  mask={PHONE_MASKS.US}
+                />
+              </div>
+            </div>
+          </fieldset>
+        </form>
+      </Host>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
-import { businessCoreInfoSchema } from "../../schemas/business-core-info-schema";
-import { FormController } from "../../../form/form";
+import { businessCoreInfoSchema } from '../../schemas/business-core-info-schema';
+import { FormController } from '../../../form/form';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
@@ -10,7 +10,7 @@ import { parseCoreInfo } from '../../utils/payload-parsers';
 import { flattenNestedObject } from '../../../../utils/utils';
 
 @Component({
-  tag: "justifi-business-core-info-form-step-core",
+  tag: 'justifi-business-core-info-form-step-core',
 })
 export class BusinessCoreInfoFormStepCore {
   @State() formController: FormController;
@@ -100,90 +100,90 @@ export class BusinessCoreInfoFormStepCore {
     const coreInfoDefaultValue = this.formController.getInitialValues();
 
     return (
-      <Host exportparts="label,input,input-invalid">
+      <Host exportparts='label,input,input-invalid'>
         <form>
           <fieldset>
             <legend>General Info</legend>
             <hr />
-            <div class="row gy-3">
-              <div class="col-12">
+            <div class='row gy-3'>
+              <div class='col-12'>
                 <form-control-text
-                  name="legal_name"
-                  label="Legal Name"
+                  name='legal_name'
+                  label='Legal Name'
                   defaultValue={coreInfoDefaultValue.legal_name}
                   errorText={this.errors.legal_name}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12">
+              <div class='col-12'>
                 <form-control-text
-                  name="doing_business_as"
-                  label="Doing Business As (DBA)"
+                  name='doing_business_as'
+                  label='Doing Business As (DBA)'
                   defaultValue={coreInfoDefaultValue.doing_business_as}
                   errorText={this.errors.doing_business_as}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-8">
+              <div class='col-12 col-md-8'>
                 <form-control-select
-                  name="classification"
-                  label="Business Classification"
+                  name='classification'
+                  label='Business Classification'
                   options={businessClassificationOptions}
                   defaultValue={coreInfoDefaultValue.classification}
                   errorText={this.errors.classification}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-4">
+              <div class='col-12 col-md-4'>
                 <form-control-date
-                  name="date_of_incorporation"
-                  label="Date of Incorporation"
+                  name='date_of_incorporation'
+                  label='Date of Incorporation'
                   defaultValue={coreInfoDefaultValue.date_of_incorporation}
                   errorText={this.errors.date_of_incorporation}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-text
-                  name="industry"
-                  label="Industry"
+                  name='industry'
+                  label='Industry'
                   defaultValue={coreInfoDefaultValue.industry}
                   errorText={this.errors.industry}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-number-masked
-                  name="tax_id"
-                  label="Tax ID"
+                  name='tax_id'
+                  label='Tax ID'
                   defaultValue={coreInfoDefaultValue.tax_id}
                   errorText={this.errors.tax_id}
                   inputHandler={this.inputHandler}
                   mask={TAX_ID_MASKS.US}
                 />
               </div>
-              <div class="col-12">
+              <div class='col-12'>
                 <form-control-text
-                  name="website_url"
-                  label="Website URL"
+                  name='website_url'
+                  label='Website URL'
                   defaultValue={coreInfoDefaultValue.website_url}
                   errorText={this.errors.website_url}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-text
-                  name="email"
-                  label="Email Address"
+                  name='email'
+                  label='Email Address'
                   defaultValue={coreInfoDefaultValue.email}
                   errorText={this.errors.email}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-number-masked
-                  name="phone"
-                  label="Phone Number"
+                  name='phone'
+                  label='Phone Number'
                   defaultValue={coreInfoDefaultValue.phone}
                   errorText={this.errors.phone}
                   inputHandler={this.inputHandler}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -2,23 +2,17 @@ import { Component, h, Prop, State, Event, EventEmitter, Watch, Method } from '@
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
 import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
 import { BusinessService } from '../../../../api/services/business.service';
-import { BusinessCoreInfoFormStepCore } from './business-core-info-form-step-core';
 
 /**
- *
- * The difference between this component and business-generic-info-details
- * is that this component is meant to be a form and send data
- * and the other one  is meant to be just read only.
- *
  * @exportedPart label: Label for inputs
  * @exportedPart input: The input fields
- * @exportedPart input-invalid: Invalid state for inputfs
+ * @exportedPart input-invalid: Invalid state for inputs
  */
 @Component({
   tag: 'justifi-business-core-info-form-step'
 })
 export class BusinessCoreInfoFormStep {
-  coreComponent: BusinessCoreInfoFormStepCore;
+  coreComponent: HTMLJustifiBusinessCoreInfoFormStepCoreElement;
 
   @State() getBusiness: Function;
   @State() patchBusiness: Function;
@@ -73,7 +67,7 @@ export class BusinessCoreInfoFormStep {
         getBusiness={this.getBusiness}
         patchBusiness={this.patchBusiness}
         allowOptionalFields={this.allowOptionalFields}
-        ref={(el) => this.coreComponent = el as any}
+        ref={el => this.coreComponent = el}
       />
     );
   }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -1,15 +1,8 @@
-import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
-import { FormController } from '../../../form/form';
-import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
-import { CoreBusinessInfo, IBusiness, ICoreBusinessInfo } from '../../../../api/Business';
-import { Api, IApiResponse } from '../../../../api';
-import { businessCoreInfoSchema } from '../../schemas/business-core-info-schema';
-import { config } from '../../../../../config';
-import { parseCoreInfo } from '../../utils/payload-parsers';
-import { flattenNestedObject } from '../../../../utils/utils';
-import { BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
-import { businessClassificationOptions } from '../../utils/business-form-options';
+import { Component, h, Prop, State, Event, EventEmitter, Watch, Method } from '@stencil/core';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
+import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
+import { BusinessService } from '../../../../api/services/business.service';
+import { BusinessCoreInfoFormStepCore } from './business-core-info-form-step-core';
 
 /**
  *
@@ -25,201 +18,63 @@ import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../
   tag: 'justifi-business-core-info-form-step'
 })
 export class BusinessCoreInfoFormStep {
-  @State() formController: FormController;
-  @State() errors: any = {};
-  @State() coreInfo: ICoreBusinessInfo = {};
+  coreComponent: BusinessCoreInfoFormStepCore;
+
+  @State() getBusiness: Function;
+  @State() patchBusiness: Function;
   
   @Prop() authToken: string;
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean;
+
+  @Watch('authToken')
+  @Watch('businessId')
+  propChanged() {
+    this.initializeApi();
+  }
   
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
-
-  private api: any;
-
-  get businessEndpoint() {
-    return `entities/business/${this.businessId}`
-  }
-
-  private fetchData = async () => {
-    this.formLoading.emit(true);
-    try {
-      const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
-      this.coreInfo = new CoreBusinessInfo(response.data);
-      this.formController.setInitialValues({ ...this.coreInfo });
-    } catch (error) {
-      this.errorEvent.emit({
-        errorCode: ComponentErrorCodes.FETCH_ERROR,
-        message: error.message,
-        severity: ComponentErrorSeverity.ERROR,
-        data: error,
-      })
-    } finally {
-      this.formLoading.emit(false);
-    }
-  }
-
-  private sendData = async (onSuccess?: () => void) => {
-    this.formLoading.emit(true);
-    try {
-      const payload = parseCoreInfo(flattenNestedObject(this.formController.values.getValue()));
-      const response = await this.api.patch(this.businessEndpoint, JSON.stringify(payload));
-      this.handleResponse(response, onSuccess);
-    } catch (error) {
-      this.errorEvent.emit({
-        errorCode: ComponentErrorCodes.PATCH_ERROR,
-        message: error.message,
-        severity: ComponentErrorSeverity.ERROR,
-        data: error,
-      })
-    } finally {
-      this.formLoading.emit(false);
-    }
-  }
-
-  handleResponse(response, onSuccess) {
-    if (response.error) {
-      this.errorEvent.emit({
-        errorCode: ComponentErrorCodes.PATCH_ERROR,
-        message: response.error.message,
-        severity: ComponentErrorSeverity.ERROR,
-        data: response.error,
-      })
-    } else {
-      onSuccess();
-    }
-    this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.coreInfo } });
-  }
 
   @Method()
   async validateAndSubmit({ onSuccess }) {
-    this.formController.validateAndSubmit(() => this.sendData(onSuccess));
-  };
+    this.coreComponent.validateAndSubmit({ onSuccess });
+  }
 
   componentWillLoad() {
-    this.formController = new FormController(businessCoreInfoSchema(this.allowOptionalFields));
-    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
-    if (this.businessId && this.authToken) {
-      this.fetchData();
+    this.initializeApi();
+  }
+
+  private initializeApi() {
+    if (this.authToken && this.businessId) {
+      this.getBusiness = makeGetBusiness({
+        authToken: this.authToken,
+        businessId: this.businessId,
+        service: new BusinessService()
+      });
+      this.patchBusiness = makePatchBusiness({
+        authToken: this.authToken,
+        businessId: this.businessId,
+        service: new BusinessService()
+      });
+    } else {
+      this.errorEvent.emit({
+        message: 'Missing required props',
+        errorCode: ComponentErrorCodes.MISSING_PROPS,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   }
 
-  componentDidLoad() {
-    this.formController.values.subscribe(values =>
-      this.coreInfo = { ...values }
-    );
-    this.formController.errors.subscribe(errors => {
-      this.errors = { ...errors };
-    });
-  }
-
-  inputHandler = (name: string, value: string) => {
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      [name]: value,
-    });
-  }
-
   render() {
-    const coreInfoDefaultValue = this.formController.getInitialValues();
-
     return (
-      <Host exportparts="label,input,input-invalid">
-        <form>
-          <fieldset>
-            <legend>General Info</legend>
-            <hr />
-            <div class="row gy-3">
-              <div class="col-12">
-                <form-control-text
-                  name="legal_name"
-                  label="Legal Name"
-                  defaultValue={coreInfoDefaultValue.legal_name}
-                  errorText={this.errors.legal_name}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12">
-                <form-control-text
-                  name="doing_business_as"
-                  label="Doing Business As (DBA)"
-                  defaultValue={coreInfoDefaultValue.doing_business_as}
-                  errorText={this.errors.doing_business_as}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-8">
-                <form-control-select
-                  name="classification"
-                  label="Business Classification"
-                  options={businessClassificationOptions}
-                  defaultValue={coreInfoDefaultValue.classification}
-                  errorText={this.errors.classification}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-4">
-                <form-control-date
-                  name="date_of_incorporation"
-                  label="Date of Incorporation"
-                  defaultValue={coreInfoDefaultValue.date_of_incorporation}
-                  errorText={this.errors.date_of_incorporation}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-6">
-                <form-control-text
-                  name="industry"
-                  label="Industry"
-                  defaultValue={coreInfoDefaultValue.industry}
-                  errorText={this.errors.industry}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-6">
-                <form-control-number-masked
-                  name="tax_id"
-                  label="Tax ID"
-                  defaultValue={coreInfoDefaultValue.tax_id}
-                  errorText={this.errors.tax_id}
-                  inputHandler={this.inputHandler}
-                  mask={TAX_ID_MASKS.US}
-                />
-              </div>
-              <div class="col-12">
-                <form-control-text
-                  name="website_url"
-                  label="Website URL"
-                  defaultValue={coreInfoDefaultValue.website_url}
-                  errorText={this.errors.website_url}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-6">
-                <form-control-text
-                  name="email"
-                  label="Email Address"
-                  defaultValue={coreInfoDefaultValue.email}
-                  errorText={this.errors.email}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class="col-12 col-md-6">
-                <form-control-number-masked
-                  name="phone"
-                  label="Phone Number"
-                  defaultValue={coreInfoDefaultValue.phone}
-                  errorText={this.errors.phone}
-                  inputHandler={this.inputHandler}
-                  mask={PHONE_MASKS.US}
-                />
-              </div>
-            </div>
-          </fieldset>
-        </form>
-      </Host>
+      <justifi-business-core-info-form-step-core 
+        authToken={this.authToken}
+        businessId={this.businessId}
+        getBusiness={this.getBusiness}
+        patchBusiness={this.patchBusiness}
+        allowOptionalFields={this.allowOptionalFields}
+        ref={(el) => this.coreComponent = el as any}
+      />
     );
   }
 }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
@@ -5,19 +5,15 @@
 <!-- Auto Generated Below -->
 
 
-## Overview
-
-The difference between this component and business-generic-info-details
-is that this component is meant to be a form and send data
-and the other one  is meant to be just read only.
-
 ## Properties
 
-| Property              | Attribute               | Description | Type      | Default     |
-| --------------------- | ----------------------- | ----------- | --------- | ----------- |
-| `allowOptionalFields` | `allow-optional-fields` |             | `boolean` | `undefined` |
-| `authToken`           | `auth-token`            |             | `string`  | `undefined` |
-| `businessId`          | `business-id`           |             | `string`  | `undefined` |
+| Property              | Attribute               | Description | Type       | Default     |
+| --------------------- | ----------------------- | ----------- | ---------- | ----------- |
+| `allowOptionalFields` | `allow-optional-fields` |             | `boolean`  | `undefined` |
+| `authToken`           | `auth-token`            |             | `string`   | `undefined` |
+| `businessId`          | `business-id`           |             | `string`   | `undefined` |
+| `getBusiness`         | --                      |             | `Function` | `undefined` |
+| `patchBusiness`       | --                      |             | `Function` | `undefined` |
 
 
 ## Events
@@ -52,7 +48,7 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [justifi-payment-provisioning-form-steps](..)
+ - [justifi-business-core-info-form-step](.)
 
 ### Depends on
 
@@ -64,10 +60,10 @@ Type: `Promise<void>`
 ### Graph
 ```mermaid
 graph TD;
-  justifi-business-core-info-form-step --> form-control-text
-  justifi-business-core-info-form-step --> form-control-select
-  justifi-business-core-info-form-step --> form-control-date
-  justifi-business-core-info-form-step --> form-control-number-masked
+  justifi-business-core-info-form-step-core --> form-control-text
+  justifi-business-core-info-form-step-core --> form-control-select
+  justifi-business-core-info-form-step-core --> form-control-date
+  justifi-business-core-info-form-step-core --> form-control-number-masked
   form-control-text --> form-control-help-text
   form-control-text --> form-control-error-text
   form-control-select --> form-control-help-text
@@ -76,8 +72,8 @@ graph TD;
   form-control-date --> form-control-error-text
   form-control-number-masked --> form-control-help-text
   form-control-number-masked --> form-control-error-text
-  justifi-payment-provisioning-form-steps --> justifi-business-core-info-form-step
-  style justifi-business-core-info-form-step fill:#f9f,stroke:#333,stroke-width:4px
+  justifi-business-core-info-form-step --> justifi-business-core-info-form-step-core
+  style justifi-business-core-info-form-step-core fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
 ----------------------------------------------

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-actions.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-actions.ts
@@ -2,7 +2,7 @@ import { ComponentErrorSeverity } from "../../../api/ComponentError";
 import { getErrorCode, getErrorMessage } from "../../../api/services/utils";
 
 export const makeGetBusiness = ({ authToken, businessId, service }) =>
-  async ({ onSuccess, onError }) => {
+  async ({ onSuccess, onError, final = () => {} }) => {
     try {
       const response = await service.fetchBusiness(businessId, authToken);
 
@@ -24,6 +24,36 @@ export const makeGetBusiness = ({ authToken, businessId, service }) =>
         code,
         severity: ComponentErrorSeverity.ERROR,
       });
+    } finally {
+      return final()
+    }
+  };
+
+export const makePatchBusiness = ({ authToken, businessId, service }) =>
+  async ({ payload, onSuccess, onError, final = () => {} }) => {
+    try {
+      const response = await service.patchBusiness(authToken, businessId, payload);
+
+      if (!response.error) {
+        onSuccess(response);
+      } else {
+        const responseError = getErrorMessage(response.error);
+        const code = getErrorCode(response.error?.code);
+        return onError({
+          error: responseError,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
+      }
+    } catch (error) {
+      const code = getErrorCode(error?.code);
+      return onError({
+        error: error.message || error,
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
+    } finally {
+      return final()
     }
   };
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-core.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, State, Event, EventEmitter, Host } from '@stencil/core';
+import { Component, h, Prop, State, Event, EventEmitter, Host, Listen } from '@stencil/core';
 import { BusinessFormClickActions, BusinessFormClickEvent, BusinessFormSubmitEvent } from '../utils/business-form-types';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../api/ComponentError';
 import { checkProvisioningStatus } from '../utils/helpers';
@@ -7,7 +7,7 @@ import { checkProvisioningStatus } from '../utils/helpers';
   tag: 'justifi-payment-provisioning-core',
 })
 export class PaymentProvisioningCore {
-  @State() formLoading: boolean = false;
+  @State() loading: boolean = false;
   @State() businessProvisioned: boolean = false;
   @State() currentStep: number = 0;
   @State() errorMessage: string;
@@ -82,7 +82,7 @@ export class PaymentProvisioningCore {
   }
 
   get formDisabled() {
-    return this.formLoading || this.businessProvisioned;
+    return this.loading || this.businessProvisioned;
   }
 
   get totalSteps() {
@@ -93,8 +93,9 @@ export class PaymentProvisioningCore {
     return `${this.currentStep + 1} of ${this.totalSteps + 1}`;
   }
 
-  handleFormLoading = (e: CustomEvent) => {
-    this.formLoading = e.detail;
+  @Listen('formLoading')
+  handleFormLoading(event: CustomEvent) {
+    this.loading = event.detail;
   }
   
   incrementSteps = () => {
@@ -139,7 +140,7 @@ export class PaymentProvisioningCore {
             <justifi-payment-provisioning-form-buttons 
               currentStep={this.currentStep}
               totalSteps={this.totalSteps}
-              formLoading={this.formLoading}
+              formLoading={this.loading}
               formDisabled={this.formDisabled}
               previousStepButtonOnClick={this.previousStepButtonOnClick}
               nextStepButtonOnClick={this.nextStepButtonOnClick}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
@@ -22,7 +22,6 @@ export class PaymentProvisioningFormSteps {
       businessId={this.businessId}
       authToken={this.authToken}
       ref={(el) => this.refs[0] = el}
-      onFormLoading={this.handleFormLoading}
       allowOptionalFields={this.allowOptionalFields}
     />,
     1: () => <justifi-legal-address-form-step

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
@@ -52,10 +52,11 @@ graph TD;
   justifi-payment-provisioning-form-steps --> justifi-business-bank-account-form-step
   justifi-payment-provisioning-form-steps --> justifi-business-document-upload-form-step
   justifi-payment-provisioning-form-steps --> justifi-business-terms-conditions-form-step
-  justifi-business-core-info-form-step --> form-control-text
-  justifi-business-core-info-form-step --> form-control-select
-  justifi-business-core-info-form-step --> form-control-date
-  justifi-business-core-info-form-step --> form-control-number-masked
+  justifi-business-core-info-form-step --> justifi-business-core-info-form-step-core
+  justifi-business-core-info-form-step-core --> form-control-text
+  justifi-business-core-info-form-step-core --> form-control-select
+  justifi-business-core-info-form-step-core --> form-control-date
+  justifi-business-core-info-form-step-core --> form-control-number-masked
   form-control-text --> form-control-help-text
   form-control-text --> form-control-error-text
   form-control-select --> form-control-help-text

--- a/packages/webcomponents/src/components/form/readme.md
+++ b/packages/webcomponents/src/components/form/readme.md
@@ -44,7 +44,7 @@
  - [justifi-billing-form](../billing-form)
  - [justifi-business-bank-account-form-step](../business-forms/payment-provisioning/bank-account)
  - [justifi-business-core-info](../business-forms/business-form/business-core-info)
- - [justifi-business-core-info-form-step](../business-forms/payment-provisioning/business-core-info)
+ - [justifi-business-core-info-form-step-core](../business-forms/payment-provisioning/business-core-info)
  - [justifi-business-representative](../business-forms/business-form/business-representative)
  - [justifi-business-representative-form-step](../business-forms/payment-provisioning/business-representative)
  - [justifi-identity-address-form](../business-forms/owner-form/identity-address)
@@ -68,7 +68,7 @@ graph TD;
   justifi-billing-form --> form-control-text
   justifi-business-bank-account-form-step --> form-control-text
   justifi-business-core-info --> form-control-text
-  justifi-business-core-info-form-step --> form-control-text
+  justifi-business-core-info-form-step-core --> form-control-text
   justifi-business-representative --> form-control-text
   justifi-business-representative-form-step --> form-control-text
   justifi-identity-address-form --> form-control-text


### PR DESCRIPTION
### Refactor core info form step core component

This PR commits the following changes:

- Refactors `BusinessCoreInfoFormStep` into base component and core component structure
- Add `patchBusiness` functionality to `business.service.ts`
- Use Stencil `Listen` method to listen for `form-loading` event instead handling it in the component attributes
  - this will be done for each of the form-step components as we refactor them in these PRs.

Links
-----

Closes #605 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------

Ideally everything should function as it did before. This PR only changes the first form step, the core info data, so you only need to test the first step for this PR. 

- [x] Unit tests are passing
- [x] Verify that data loads and fills properly for business with existing data
- [x] Verify that form validation is firing correctly if attempting to submit without completing required fields
- [x] Verify that data submits and patches business properly when required data is filled and user clicks `Next` button. 

