### PR TITLE
Add an error bound

### DIFF
--- a/.changeset/beige-lions-draw.md
+++ b/.changeset/beige-lions-draw.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix a console error caused by Analytics

--- a/packages/webcomponents/src/api/Analytics.ts
+++ b/packages/webcomponents/src/api/Analytics.ts
@@ -64,12 +64,15 @@ class JustifiAnalytics {
 
     // for each event, add an event listener
     this.eventEmitters.forEach((eventName) => {
-      this.componentInstance.addEventListener(eventName, (event: any) =>
-        this.handleCustomEvent({
-          event_type: eventName,
-          data: { ...this.basicData, error: event.detail },
-        })
-      );
+      // if this.componentInstance.addEventListener is a function add the event listener
+      if (typeof this.componentInstance.addEventListener === 'function') {
+        this.componentInstance.addEventListener(eventName, (event: any) =>
+          this.handleCustomEvent({
+            event_type: eventName,
+            data: { ...this.basicData, error: event.detail },
+          })
+        );
+      }
     });
   }
 

--- a/packages/webcomponents/src/components/checkout/checkout.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout.tsx
@@ -25,7 +25,7 @@ export class Checkout {
   analytics: JustifiAnalytics;
 
   componentWillLoad() {
-    // this.analytics = new JustifiAnalytics(this);
+    this.analytics = new JustifiAnalytics(this);
     this.initializeGetCheckout();
   }
 


### PR DESCRIPTION
After some debugging it seems that the error os only caused because at some point the Analytics is called before the component is instantiated. I attempted to call Analytics in other life cycles but the error continued happening. 
Adding the validation to only call `addEventListener` when it's actually a function fixed the error without breaking the Analytics functioning

**Note: This bug was only reproducible on a demo-app**

* This adds an error bound to prevent addEventListener to be called on undefined

Links
-----
#594 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------

[ ] - Run a demo app (any) and add a symlink to the web-components. Any error regarding `addEventListener` is not a function should be visible on the console. Also a network request to Analytics should have happened on the network tab 