### PR TITLE
Fix component links on documentation

### DIFF
--- a/apps/docs/stories/components/BankAccountForm/Docs.mdx
+++ b/apps/docs/stories/components/BankAccountForm/Docs.mdx
@@ -16,7 +16,7 @@ import * as JustifiBankAccountForm from './index.stories.tsx';
 
 Component to render the necessary fields to enter proper bank account information.
 
-> **Note**: While it's possible to implement the **CardForm**, **BankAccountForm** and **BillingForm** individually - the **[PaymentForm](/docs/components-paymentform--docs)** is preferred as it combines the three components together and handles validating and passing data between them, and ultimately takes less implementation time. For most use-cases: the JustiFi Team officially recommends that developers choose the **[PaymentForm](/docs/components-paymentform--docs)** component when implementing components for payment processing.
+> **Note**: While it's possible to implement the **CardForm**, **BankAccountForm** and **BillingForm** individually - the **[PaymentForm](?path=/docs/payment-facilitation-payments-payment-form--docs)** is preferred as it combines the three components together and handles validating and passing data between them, and ultimately takes less implementation time. For most use-cases: the JustiFi Team officially recommends that developers choose the **[PaymentForm](?path=/docs/payment-facilitation-payments-payment-form--docs)** component when implementing components for payment processing.
 
 # Index
 

--- a/apps/docs/stories/components/CardForm/Docs.mdx
+++ b/apps/docs/stories/components/CardForm/Docs.mdx
@@ -20,7 +20,7 @@ import * as JustifiCardForm from './index.stories.tsx';
 
 Component to render the necessary fields to enter proper credit card information.
 
-> **Note**: While it's possible to implement the **CardForm**, **BankAccountForm** and **BillingForm** individually - the **[PaymentForm](/docs/components-paymentform--docs)** is preferred as it combines the three components together and handles validating and passing data between them, and ultimately takes less implementation time. For most use-cases: the JustiFi Team officially recommends that developers choose the **[PaymentForm](/docs/components-paymentform--docs)** component when implementing components for payment processing.
+> **Note**: While it's possible to implement the **CardForm**, **BankAccountForm** and **BillingForm** individually - the **[PaymentForm](?path=/docs/payment-facilitation-payments-payment-form--docs)** is preferred as it combines the three components together and handles validating and passing data between them, and ultimately takes less implementation time. For most use-cases: the JustiFi Team officially recommends that developers choose the **[PaymentForm](?path=/docs/payment-facilitation-payments-payment-form--docs)** component when implementing components for payment processing.
 
 # Index
 

--- a/apps/docs/stories/frameworks/react.mdx
+++ b/apps/docs/stories/frameworks/react.mdx
@@ -12,11 +12,11 @@ import {
 
 # Index
 
-* [Usage](#usage)
-* [Usage details](#usage-details)
-  * [Calling methods](#calling-methods)
-  * [Listening to events](#listening-to-events)
-* [Styling exported parts](#styling-exported-parts)
+- [Usage](#usage)
+- [Usage details](#usage-details)
+  - [Calling methods](#calling-methods)
+  - [Listening to events](#listening-to-events)
+- [Styling exported parts](#styling-exported-parts)
 
 # Usage
 
@@ -198,9 +198,9 @@ Styling works similarly to the vanilla web components.
 
 The following components can only be styled through CSS variables:
 
-* [BankAccountForm](?path=/docs/components-bankaccountform--docs)
-* [CardForm](?path=/docs/components-cardform--docs)
-* [PaymentForm](?path=/docs/components-paymentform--docs)
+- [BankAccountForm](?path=/docs/payment-facilitation-payments-bank-account-form--docs)
+- [CardForm](?path=/docs/payment-facilitation-payments-card-form--docs)
+- [PaymentForm](?path=/docs/payment-facilitation-payments-payment-form--docs)
 
 You can easily override the variables in a `<style>` tag in any place of your App, both in the `<head>` of your root `index.html` or at any component level.
 

--- a/apps/docs/stories/intro.mdx
+++ b/apps/docs/stories/intro.mdx
@@ -15,14 +15,14 @@ Latest Version: <code>{extractWebcomponentsVersion()}</code>
 
 # Index
 
-* [Usage](#usage)
-* [Default Styling](#default-styling)
-* [React](#react)
-* [Styling](#styling)
-  * [Styling iFramed components with variables](#styling-components-with-variables)
-    * [Loading Google Fonts](#loading-google-fonts)
-  * [Styling components with custom css](#styling-components-with-custom-css)
-* [Changelog](/docs/changelog--docs)
+- [Usage](#usage)
+- [Default Styling](#default-styling)
+- [React](#react)
+- [Styling](#styling)
+  - [Styling iFramed components with variables](#styling-components-with-variables)
+    - [Loading Google Fonts](#loading-google-fonts)
+  - [Styling components with custom css](#styling-components-with-custom-css)
+- [Changelog](/docs/changelog--docs)
 
 # Usage
 
@@ -115,11 +115,11 @@ Or import it in your `JS` file:
 
 ## Styling components with variables
 
-The following components need to be styled by overriding `CSS variables`, since they are scoped within an iFrame:
+The following components need to be styled by overriding `CSS variables`, since they are scoped within an iFrame
 
-* [BankAccountForm](?path=/docs/components-bankaccountform--docs)
-* [CardForm](?path=/docs/components-cardform--docs)
-* [PaymentForm](?path=/docs/components-paymentform--docs)
+- [BankAccountForm](?path=/docs/payment-facilitation-payments-bank-account-form--docs)
+- [CardForm](?path=/docs/payment-facilitation-payments-card-form--docs)
+- [PaymentForm](?path=/docs/payment-facilitation-payments-payment-form--docs)
 
 This is a complete list of variables as defined in this project's `root.scss`:
 
@@ -127,18 +127,14 @@ This is a complete list of variables as defined in this project's `root.scss`:
   <CSSVars />
 </SummaryElement>
 
-<Markdown>
-  {`
-    **Note:** When customizing the \`--jfi-form-control-box-shadow\` variable, ensure that the \`--jfi-layout-padding\` is not set to \`0\`. This prevents the box-shadow of the last input from being inset into the iframe container, ensuring it remains visible. Additionally, to create enough room around the inputs and prevent them from getting cut off, the layout padding should be set to at least the size of the box shadow
-  `}
-</Markdown>
+> **Note:** When customizing the `--jfi-form-control-box-shadow` variable, ensure that the `--jfi-layout-padding` is not set to `0`. This prevents the box-shadow of the last input from being inset into the iframe container, ensuring it remains visible. Additionally, to create enough room around the inputs and prevent them from getting cut off, the layout padding should be set to at least the size of the box shadow
 
 ## Loading Google fonts
 
 In order to load custom fonts in the iFramed components, there's a special CSS variable that can be used: `--jfi-load-google-font`.
 The value provided should be a string commpatible with what's described in the following [official documentation from Google](https://developers.google.com/fonts/docs/css2).
 
-### Check out the [CardForm story for this to see it in action](?path=/docs/components-cardform--styled).
+### Check out the [CardForm story for this to see it in action](?path=/docs/payment-facilitation-payments-card-form--example).
 
 Usage examples:
 


### PR DESCRIPTION
**Description**

* This fixes some component links across documentation
* This fix "note" style on intro-docs

**Before:** 
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/211466ad-0f67-4b1f-b881-348b46325366">

**After**
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/a42cf13b-6fd6-496f-a4b6-1fe16ba40999">


Links
-----

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------

[ ] - All internal links to components on the docs should be working fine.
[ ] - The "Note" right after the "See full list of CSS variables available" should look like a note block not overloading the screen container
