### PR TITLE
Add missing CSS variables

### DIFF
--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -90,7 +90,15 @@ justifi-checkout {
   --jfi-radio-button-group-background-color: transparent;
   --jfi-radio-button-group-background-color-hover: rgba(255, 120, 90, 0.25);
 
+  --jfi-radio-button-background-color: transparent;
+  --jfi-radio-button-border-color: rgba(255, 255, 255, 0.7);
 
+  --jfi-radio-button-background-color-selected: rgba(255, 120, 90, .5);
+  --jfi-radio-button-border-color-selected: rgba(255, 120, 90, 1);
+
+  --jfi-radio-button-border-color-focus: rgb(164, 201, 245);
+  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
+  
   /* submit button */
   --jfi-submit-button-width: 100%;
   --jfi-submit-button-padding: 5px 15px;

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -96,6 +96,15 @@ justifi-season-interruption-insurance {
   --jfi-radio-button-group-background-color: transparent;
   --jfi-radio-button-group-background-color-hover: rgba(0, 0, 0, .025);
 
+  --jfi-radio-button-background-color: transparent;
+  --jfi-radio-button-border-color: #333;
+
+  --jfi-radio-button-background-color-selected: #333;
+  --jfi-radio-button-border-color-selected: #333;
+
+  --jfi-radio-button-border-color-focus: #333;
+  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(0, 0, 0, .25);
+
   /* submit button */
   --jfi-submit-button-width: 100%;
   --jfi-submit-button-padding: 6px 18px;

--- a/apps/docs/stories/utils/css-variables.tsx
+++ b/apps/docs/stories/utils/css-variables.tsx
@@ -76,10 +76,12 @@ export const CSSVars = () => (
 
   /* Below only used in justifi-checkout */
   /* form radio input */
-  --jfi-radio-input-box-shadow-focus
-  --jfi-radio-input-background-color-selected
-  --jfi-radio-input-border-color
-  --jfi-radio-input-border-color-selected
+  --jfi-radio-button-background-color
+  --jfi-radio-button-border-color
+  --jfi-radio-button-background-color-selected
+  --jfi-radio-button-border-color-selected
+  --jfi-radio-button-border-color-focus
+  --jfi-radio-button-box-shadow-focus
 
   /* submit button */
   --jfi-submit-button-color


### PR DESCRIPTION
**Description**

This PR adds some the missing CSS variables for styling the radio buttons on the light and dark theme.

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA

Developer QA steps
--------------------

[ ] - Radio button on light theme should look like:
<img width="436" alt="image" src="https://github.com/user-attachments/assets/d9f8780e-4f13-41a7-b3cf-918bdc58d85d">
[ ] - And on dark theme should look like:
<img width="439" alt="image" src="https://github.com/user-attachments/assets/13235575-1a1a-4945-bb75-ea99e558f350">

