### PR TITLE
Checkout: Method to fill billing information

### DIFF
--- a/.changeset/chatty-trainers-repeat.md
+++ b/.changeset/chatty-trainers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": minor
+---
+
+Add fillBillingAddress method to Checkout component

--- a/apps/docs/stories/components/Checkout/index.stories.tsx
+++ b/apps/docs/stories/components/Checkout/index.stories.tsx
@@ -80,6 +80,13 @@ const meta: Meta = {
         defaultValue: { summary: "undefined" },
       },
     },
+    fillBillingForm: {
+      description:
+        "`fillBillingForm(fields: BillingFormFields) => Promise<void>`",
+      table: {
+        category: "methods",
+      },
+    },
     submitted: {
       description:
         "Emitted when the server response is received after submitting.  Will not be raised if form vailidation fails.",

--- a/packages/webcomponents/src/components/billing-form/billing-form.tsx
+++ b/packages/webcomponents/src/components/billing-form/billing-form.tsx
@@ -50,11 +50,11 @@ export class BillingForm {
 
   @Method()
   async fill(fields: BillingFormFields) {
-    this.formController.setValues(fields);
+    this.formController.setInitialValues(fields);
   }
 
   @Method()
-  async validate(): Promise<{ isValid: boolean }>{
+  async validate(): Promise<{ isValid: boolean }> {
     let isValid: boolean = await this.formController.validate();
     return { isValid: isValid };
   }

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -1,10 +1,11 @@
-import { Component, h, Prop, State, Event, EventEmitter, Host } from '@stencil/core';
+import { Component, h, Prop, State, Event, EventEmitter, Host, Method } from '@stencil/core';
 import { formatCurrency } from '../../utils/utils';
 import { config } from '../../../config';
 import { PaymentMethodPayload } from './payment-method-payload';
 import { Checkout, ICheckout, ICheckoutCompleteResponse } from '../../api/Checkout';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
 import { insuranceValues, insuranceValuesOn, validateInsuranceValues } from '../insurance/insurance-state';
+import { BillingFormFields } from '../billing-form/billing-form-schema';
 
 
 @Component({
@@ -38,6 +39,10 @@ export class CheckoutCore {
 
   private paymentMethodOptionsRef?: HTMLJustifiPaymentMethodOptionsElement;
 
+  @Method()
+  async fillBillingForm(fields: BillingFormFields) {
+    this.paymentMethodOptionsRef.fillBillingForm(fields);
+  }
 
   componentWillLoad() {
     if (this.getCheckout) {

--- a/packages/webcomponents/src/components/checkout/checkout.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout.tsx
@@ -1,8 +1,9 @@
-import { Component, Prop, h, State, Watch, Event, EventEmitter } from '@stencil/core';
+import { Component, Prop, h, State, Watch, Event, EventEmitter, Method } from '@stencil/core';
 import { makeGetCheckout, makeCheckoutComplete } from './checkout-actions';
 import { CheckoutService } from '../../api/services/checkout.service';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
 import JustifiAnalytics from '../../api/Analytics';
+import { BillingFormFields } from '../billing-form/billing-form-schema';
 
 @Component({
   tag: 'justifi-checkout',
@@ -21,6 +22,8 @@ export class Checkout {
   @State() errorMessage: string = '';
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
+
+  private checkoutCoreRef?: HTMLJustifiCheckoutCoreElement;
 
   analytics: JustifiAnalytics;
 
@@ -60,6 +63,11 @@ export class Checkout {
     this.initializeGetCheckout();
   }
 
+  @Method()
+  async fillBillingForm(fields: BillingFormFields) {
+    this.checkoutCoreRef.fillBillingForm(fields);
+  }
+
   render() {
     return (
       <justifi-checkout-core
@@ -68,7 +76,12 @@ export class Checkout {
         disableCreditCard={this.disableCreditCard}
         disableBankAccount={this.disableBankAccount}
         disableBnpl={this.disableBnpl}
-        disablePaymentMethodGroup={this.disablePaymentMethodGroup}>
+        disablePaymentMethodGroup={this.disablePaymentMethodGroup}
+        ref={el => {
+          if (el) {
+            this.checkoutCoreRef = el;
+          }
+        }}>
         <div slot="insurance">
           <slot name="insurance"></slot>
         </div>

--- a/packages/webcomponents/src/components/checkout/new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/new-payment-method.tsx
@@ -2,6 +2,7 @@ import { Component, h, Prop, Method, Event, EventEmitter } from '@stencil/core';
 import { config } from '../../../config';
 import { PaymentMethodOption } from './payment-method-option-utils';
 import { PaymentMethodPayload } from './payment-method-payload';
+import { BillingFormFields } from '../billing-form/billing-form-schema';
 
 const PaymentMethodTypeLabels = {
   bankAccount: 'New bank account',
@@ -23,6 +24,11 @@ export class NewPaymentMethod {
 
   private billingFormRef?: HTMLJustifiBillingFormElement;
   private paymentMethodFormRef?: HTMLJustifiPaymentMethodFormElement;
+
+  @Method()
+  async fillBillingForm(fields: BillingFormFields) {
+    this.billingFormRef.fill(fields);
+  }
 
   @Method()
   async resolvePaymentMethod(): Promise<PaymentMethodPayload> {

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -4,6 +4,7 @@ import { PaymentMethodTypes } from '../../api/Payment';
 import { PaymentMethodOption } from './payment-method-option-utils';
 import { PaymentMethodPayload } from './payment-method-payload';
 import { IBnpl } from '../../api';
+import { BillingFormFields } from '../billing-form/billing-form-schema';
 
 @Component({
   tag: 'justifi-payment-method-options',
@@ -28,6 +29,13 @@ export class PaymentMethodOptions {
   @Event({ bubbles: true }) toggleCreatingNewPaymentMethod: EventEmitter;
 
   private selectedPaymentMethodOptionRef?: HTMLJustifiNewPaymentMethodElement | HTMLJustifiSavedPaymentMethodElement | HTMLJustifiSezzlePaymentMethodElement;
+
+  @Method()
+  async fillBillingForm(fields: BillingFormFields) {
+    if (this.selectedPaymentMethodOptionRef instanceof HTMLJustifiNewPaymentMethodElement) {
+      this.selectedPaymentMethodOptionRef.fillBillingForm(fields);
+    }
+  }
 
   connectedCallback() {
     this.paymentMethodsChanged();

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -32,8 +32,9 @@ export class PaymentMethodOptions {
 
   @Method()
   async fillBillingForm(fields: BillingFormFields) {
-    if (this.selectedPaymentMethodOptionRef instanceof HTMLJustifiNewPaymentMethodElement) {
-      this.selectedPaymentMethodOptionRef.fillBillingForm(fields);
+    const newPaymentMethodElement = (this.selectedPaymentMethodOptionRef as HTMLJustifiNewPaymentMethodElement);
+    if (newPaymentMethodElement.fillBillingForm) {
+      newPaymentMethodElement.fillBillingForm(fields);
     }
   }
 


### PR DESCRIPTION
Just like we've done for `PaymentForm`, we need to expose a method that can be used to pre-fill the billing form: https://github.com/justifi-tech/web-component-library/blob/main/packages/webcomponents/src/components/payment-form/payment-form.tsx#L57

Customers use this when they already have the end-user's billing information on file or when it was collected in a previous step before checking out

Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
- Check out the `fill-billing-form-test` branch of https://github.com/justifi-tech/checkout-demo
- Run the checkout demo using `npm run start` and open the browser to `localhost:3000`
- [x] With network tab open, click the "Fill Billing Address" button, and the form should fill. Fill in the rest of the form so that a payment can be submitted. Check the request payload to see that the address is correct in the payload
- [x] Repeat the last step, but before submitting change the values in the billing form and check the request payload to see that the address is correct
