### PR TITLE
Move insurance slot and disable BNPL if insurance accepted

### DIFF
--- a/.changeset/tricky-drinks-leave.md
+++ b/.changeset/tricky-drinks-leave.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Moved `insurance` option above payment methods in `Checkout` component
+- Disable BNPL payment method in `Checkout` component if insurance is accepted by user. 

--- a/apps/docs/stories/components/Checkout/index.stories.tsx
+++ b/apps/docs/stories/components/Checkout/index.stories.tsx
@@ -114,7 +114,7 @@ const meta: Meta = {
       handles: ["submitted"],
     },
     chromatic: {
-      delay: 1000,
+      delay: 2000,
     },
   },
   render: ({ label, ...args }) => {

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -33,6 +33,7 @@ export class CheckoutCore {
   @State() serverError: string;
   @State() renderState: 'loading' | 'error' | 'success' = 'loading';
   @State() creatingNewPaymentMethod: boolean = false;
+  @State() insuranceToggled: boolean = false;
 
   @Event({ eventName: 'submitted' }) submitted: EventEmitter<ICheckoutCompleteResponse>;
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
@@ -52,6 +53,7 @@ export class CheckoutCore {
       insuranceValuesOn('set', (key) => {
         const value = insuranceValues[key];
         if (value !== undefined) {
+          this.insuranceToggled = value;
           this.fetchData();
         }
       });
@@ -64,6 +66,7 @@ export class CheckoutCore {
       onSuccess: ({ checkout }) => {
         this.checkout = new Checkout(checkout);
         this.renderState = 'success';
+
       },
       onError: ({ error, code, severity }) => {
         this.serverError = error;
@@ -158,6 +161,7 @@ export class CheckoutCore {
             account-id={this.checkout?.account_id}
             savedPaymentMethods={this.checkout?.payment_methods || []}
             paymentAmount={this.checkout?.payment_amount}
+            insuranceToggled={this.insuranceToggled}
           />
         </div>
       </section>
@@ -193,19 +197,18 @@ export class CheckoutCore {
         <div class="row gy-3 jfi-checkout-core">
           <div class="col-12 mb-4">
             {/* componentize this */}
-            <h2 class="fs-5 fw-bold pb-3 jfi-header">Summary</h2>
+            <h2 class="fs-5 fw-bold pb-3 jfi-header">AAAAAA</h2>
             {this.summary}
-          </div >
-
+          </div>
+          <div class="col-12">
+            <slot name="insurance"></slot>
+          </div>
           <div class="col-12">
             <h2 class="fs-5 fw-bold pb-3 jfi-header">Payment</h2>
             <h3 class="fs-6 fw-bold lh-lg">Select payment type</h3>
             <div class="d-flex flex-column">
               {this.paymentType}
             </div>
-          </div>
-          <div class="col-12">
-            <slot name="insurance"></slot>
           </div>
           <div class="col-12">
             <div class="d-flex justify-content-end">

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -197,7 +197,7 @@ export class CheckoutCore {
         <div class="row gy-3 jfi-checkout-core">
           <div class="col-12 mb-4">
             {/* componentize this */}
-            <h2 class="fs-5 fw-bold pb-3 jfi-header">AAAAAA</h2>
+            <h2 class="fs-5 fw-bold pb-3 jfi-header">Summary</h2>
             {this.summary}
           </div>
           <div class="col-12">

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -17,6 +17,7 @@ export class PaymentMethodOptions {
   @Prop() showBnpl: boolean;
   @Prop() showSavedPaymentMethods: boolean;
   @Prop() bnpl: IBnpl;
+  @Prop() insuranceToggled: boolean;
   @Prop() clientId: string;
   @Prop() accountId: string;
   @Prop({ mutable: true }) iframeOrigin?: string = config.iframeOrigin;
@@ -52,7 +53,7 @@ export class PaymentMethodOptions {
     if (this.showAch) {
       this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.bankAccount }));
     }
-    if (this.showBnpl && this.bnpl?.provider === 'sezzle') {
+    if (this.showBnpl && this.bnpl?.provider === 'sezzle' && !this.insuranceToggled) {
       this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.sezzle }));
     }
   }

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
@@ -28,6 +28,9 @@ exports[`justifi-checkout-core should display loading state correctly 1`] = `
         </section>
       </div>
       <div class="col-12">
+        <slot name="insurance"></slot>
+      </div>
+      <div class="col-12">
         <h2 class="fs-5 fw-bold jfi-header pb-3">
           Payment
         </h2>
@@ -44,9 +47,6 @@ exports[`justifi-checkout-core should display loading state correctly 1`] = `
             </div>
           </section>
         </div>
-      </div>
-      <div class="col-12">
-        <slot name="insurance"></slot>
       </div>
       <div class="col-12">
         <div class="d-flex justify-content-end">
@@ -92,6 +92,9 @@ exports[`justifi-checkout-core should set checkout correctly to state 1`] = `
         </section>
       </div>
       <div class="col-12">
+        <slot name="insurance"></slot>
+      </div>
+      <div class="col-12">
         <h2 class="fs-5 fw-bold jfi-header pb-3">
           Payment
         </h2>
@@ -108,9 +111,6 @@ exports[`justifi-checkout-core should set checkout correctly to state 1`] = `
             </div>
           </section>
         </div>
-      </div>
-      <div class="col-12">
-        <slot name="insurance"></slot>
       </div>
       <div class="col-12">
         <div class="d-flex justify-content-end">

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
@@ -28,6 +28,9 @@ exports[`justifi-checkout renders loading 1`] = `
           </section>
         </div>
         <div class="col-12">
+          <slot name="insurance"></slot>
+        </div>
+        <div class="col-12">
           <h2 class="fs-5 fw-bold jfi-header pb-3">
             Payment
           </h2>
@@ -44,9 +47,6 @@ exports[`justifi-checkout renders loading 1`] = `
               </div>
             </section>
           </div>
-        </div>
-        <div class="col-12">
-          <slot name="insurance"></slot>
         </div>
         <div class="col-12">
           <div class="d-flex justify-content-end">


### PR DESCRIPTION
### Move insurance slot above payment methods, and disable BNPL if insurance option is accepted / true



Links
-----

Closes #627 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------

- [x] Tests and snapshots pass
- [x] Insurance option should now be rendered above the payment methods
- [x] Accepting insurance disables BNPL
- [x] Declining insurance that has been accepted should re-enable BNPL

