### PR TITLE
Checkout save new payment methods

### DIFF
--- a/.changeset/angry-bobcats-yawn.md
+++ b/.changeset/angry-bobcats-yawn.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Added new feature to `Checkout` component that allows users to save new payment methods. If the checkout session has an associated `payment_method_group_id` then users will see a checkbox allowing them to save a new Credit Card or Bank Account payment method for future use.

--- a/packages/webcomponents/src/components/checkout/_jfi-checkbox.scss
+++ b/packages/webcomponents/src/components/checkout/_jfi-checkbox.scss
@@ -1,0 +1,7 @@
+input[type="checkbox"] {
+  cursor: pointer;
+}
+
+.checkbox-label {
+  cursor: auto;
+}

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -156,7 +156,7 @@ export class CheckoutCore {
             paymentMethodGroupId={this.checkout?.payment_method_group_id}
             show-saved-payment-methods={!this.disablePaymentMethodGroup}
             bnpl={this.checkout?.bnpl}
-            client-id={this.checkout?.payment_client_id}
+            authToken={this.authToken}
             account-id={this.checkout?.account_id}
             savedPaymentMethods={this.checkout?.payment_methods || []}
             paymentAmount={this.checkout?.payment_amount}

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -33,6 +33,7 @@ export class CheckoutCore {
   @State() serverError: string;
   @State() renderState: 'loading' | 'error' | 'success' = 'loading';
   @State() creatingNewPaymentMethod: boolean = false;
+  @State() paymentMethodGroupId: string;
 
   @Event({ eventName: 'submitted' }) submitted: EventEmitter<ICheckoutCompleteResponse>;
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
@@ -64,6 +65,7 @@ export class CheckoutCore {
       onSuccess: ({ checkout }) => {
         this.checkout = new Checkout(checkout);
         this.renderState = 'success';
+        this.paymentMethodGroupId = this.checkout?.payment_method_group_id;
       },
       onError: ({ error, code, severity }) => {
         this.serverError = error;
@@ -152,6 +154,7 @@ export class CheckoutCore {
             show-card={!this.disableCreditCard}
             show-ach={!this.disableBankAccount}
             show-bnpl={!this.disableBnpl}
+            paymentMethodGroupId={this.paymentMethodGroupId}
             show-saved-payment-methods={!this.disablePaymentMethodGroup}
             bnpl={this.checkout?.bnpl}
             client-id={this.checkout?.payment_client_id}

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -32,7 +32,6 @@ export class CheckoutCore {
   @State() serverError: string;
   @State() renderState: 'loading' | 'error' | 'success' = 'loading';
   @State() creatingNewPaymentMethod: boolean = false;
-  @State() paymentMethodGroupId: string;
   @State() insuranceToggled: boolean = false;
   
   @Event({ eventName: 'submitted' }) submitted: EventEmitter<ICheckoutCompleteResponse>;
@@ -66,7 +65,6 @@ export class CheckoutCore {
       onSuccess: ({ checkout }) => {
         this.checkout = new Checkout(checkout);
         this.renderState = 'success';
-        this.paymentMethodGroupId = this.checkout?.payment_method_group_id;
       },
       onError: ({ error, code, severity }) => {
         this.serverError = error;
@@ -155,7 +153,7 @@ export class CheckoutCore {
             show-card={!this.disableCreditCard}
             show-ach={!this.disableBankAccount}
             show-bnpl={!this.disableBnpl}
-            paymentMethodGroupId={this.paymentMethodGroupId}
+            paymentMethodGroupId={this.checkout?.payment_method_group_id}
             show-saved-payment-methods={!this.disablePaymentMethodGroup}
             bnpl={this.checkout?.bnpl}
             client-id={this.checkout?.payment_client_id}

--- a/packages/webcomponents/src/components/checkout/checkout.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout.tsx
@@ -72,6 +72,7 @@ export class Checkout {
     return (
       <justifi-checkout-core
         getCheckout={this.getCheckout}
+        authToken={this.authToken}
         complete={this.complete}
         disableCreditCard={this.disableCreditCard}
         disableBankAccount={this.disableBankAccount}

--- a/packages/webcomponents/src/components/checkout/new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/new-payment-method.tsx
@@ -15,7 +15,7 @@ const PaymentMethodTypeLabels = {
 })
 export class NewPaymentMethod {
   @Prop({ mutable: true }) iframeOrigin?: string = config.iframeOrigin;
-  @Prop() clientId: string;
+  @Prop() authToken: string;
   @Prop() accountId: string;
   @Prop() paymentMethodOption: PaymentMethodOption;
   @Prop() paymentMethodGroupId?: string;
@@ -68,7 +68,7 @@ export class NewPaymentMethod {
       } else {
         paymentMethodData = { ...billingFormFieldValues };
       }
-      const clientId = this.clientId;
+      const clientId = this.authToken;
       const tokenizeResponse = await this.paymentMethodFormRef.tokenize(clientId, paymentMethodData, this.accountId);
       return tokenizeResponse;
     } catch (error) {

--- a/packages/webcomponents/src/components/checkout/new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/new-payment-method.tsx
@@ -68,7 +68,6 @@ export class NewPaymentMethod {
       } else {
         paymentMethodData = { ...billingFormFieldValues };
       }
-      console.log('paymentMethodData', paymentMethodData);
       const clientId = this.clientId;
       const tokenizeResponse = await this.paymentMethodFormRef.tokenize(clientId, paymentMethodData, this.accountId);
       return tokenizeResponse;

--- a/packages/webcomponents/src/components/checkout/payment-method-options.scss
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.scss
@@ -2,6 +2,7 @@
 @import 'buttons';
 @import 'bootstrap-utilities';
 @import './jfi-radio-button';
+@import './jfi-checkbox';
 
 :host {
   @include host-base-styles;

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -16,6 +16,7 @@ export class PaymentMethodOptions {
   @Prop() showAch: boolean;
   @Prop() showBnpl: boolean;
   @Prop() showSavedPaymentMethods: boolean;
+  @Prop() paymentMethodGroupId?: string;
   @Prop() bnpl: IBnpl;
   @Prop() clientId: string;
   @Prop() accountId: string;
@@ -82,6 +83,7 @@ export class PaymentMethodOptions {
                 client-id={this.clientId}
                 account-id={this.accountId}
                 is-selected={isSelected}
+                paymentMethodGroupId={this.paymentMethodGroupId}
                 ref={(el) => {
                   if (isSelected) {
                     this.selectedPaymentMethodOptionRef = el;

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -19,7 +19,7 @@ export class PaymentMethodOptions {
   @Prop() paymentMethodGroupId?: string;
   @Prop() bnpl: IBnpl;
   @Prop() insuranceToggled: boolean;
-  @Prop() clientId: string;
+  @Prop() authToken: string;
   @Prop() accountId: string;
   @Prop({ mutable: true }) iframeOrigin?: string = config.iframeOrigin;
   @Prop() savedPaymentMethods: any[] = [];
@@ -81,7 +81,7 @@ export class PaymentMethodOptions {
             return (
               <justifi-new-payment-method
                 paymentMethodOption={paymentMethodOption}
-                client-id={this.clientId}
+                authToken={this.authToken}
                 account-id={this.accountId}
                 is-selected={isSelected}
                 paymentMethodGroupId={this.paymentMethodGroupId}

--- a/packages/webcomponents/src/components/checkout/readme.md
+++ b/packages/webcomponents/src/components/checkout/readme.md
@@ -57,7 +57,7 @@
 
 ## Methods
 
-### `resolvePaymentMethod(insuranceValidation?: any) => Promise<PaymentMethodPayload>`
+### `resolvePaymentMethod(insuranceValidation: any) => Promise<PaymentMethodPayload>`
 
 
 

--- a/packages/webcomponents/src/components/checkout/save-new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/save-new-payment-method.tsx
@@ -1,0 +1,31 @@
+import { Component, h, State, Event, EventEmitter } from '@stencil/core';
+
+@Component({
+  tag: 'justifi-save-new-payment-method',
+})
+export class SaveNewPaymentMethod {
+  @State() isChecked: boolean = false;
+  @Event({ bubbles: true }) checkboxChanged: EventEmitter<boolean>;
+
+  handleCheckboxChange(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.isChecked = target.checked;
+    this.checkboxChanged.emit(this.isChecked);
+  }
+
+  render() {
+    return (
+      <div class="mt-3 d-flex align-items-center">
+        <input
+          type="checkbox"
+          checked={this.isChecked}
+          onChange={(event) => this.handleCheckboxChange(event)}
+          class="me-2"
+        />
+        <label class='checkbox-label'>
+          Save new payment method
+        </label>
+      </div>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/checkout/save-new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/save-new-payment-method.tsx
@@ -15,7 +15,7 @@ export class SaveNewPaymentMethod {
 
   render() {
     return (
-      <div class="mt-3 d-flex align-items-center">
+      <div class="mt-4 d-flex align-items-center">
         <input
           type="checkbox"
           checked={this.isChecked}

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
@@ -107,7 +107,7 @@ exports[`justifi-checkout-core should set checkout correctly to state 1`] = `
               <justifi-skeleton height="300px" variant="rounded"></justifi-skeleton>
             </div>
             <div>
-              <justifi-payment-method-options account-id="acc_4Et9iXrAARKSZ4KSoiQGTYr" client-id="test_ef88f04afebc3c018de30fd3652d7cee" paymentamount="8592" show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
+              <justifi-payment-method-options account-id="acc_4Et9iXrAARKSZ4KSoiQGTYr" client-id="test_ef88f04afebc3c018de30fd3652d7cee" paymentamount="8592" paymentmethodgroupid="pmg_23YT1LVnpsrdXExZYxIjav" show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
             </div>
           </section>
         </div>

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
@@ -107,7 +107,7 @@ exports[`justifi-checkout-core should set checkout correctly to state 1`] = `
               <justifi-skeleton height="300px" variant="rounded"></justifi-skeleton>
             </div>
             <div>
-              <justifi-payment-method-options account-id="acc_4Et9iXrAARKSZ4KSoiQGTYr" client-id="test_ef88f04afebc3c018de30fd3652d7cee" paymentamount="8592" paymentmethodgroupid="pmg_23YT1LVnpsrdXExZYxIjav" show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
+              <justifi-payment-method-options account-id="acc_4Et9iXrAARKSZ4KSoiQGTYr" paymentamount="8592" paymentmethodgroupid="pmg_23YT1LVnpsrdXExZYxIjav" show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
             </div>
           </section>
         </div>


### PR DESCRIPTION
### Add logic to save new payment methods

NOTE: this PR will need to be coordinated with the following PR for payments-js:
[Payments-js 136](https://github.com/justifi-tech/payments-js/pull/136
)
This PR commits the following changes:

- Adds a checkbox below the new payment method billing form that will only render IF the checkout has an associated `payment_method_group_id`
- When checked / true, the checkout will submit the payment_method_group_id along with payment's metadata


Links
-----

Closes #629 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------
- Make sure that payment_method_group_id is being sent
- Rendering a new checkout shows the saved payment method