### PR TITLE
Ensure insuranceValidation is called before resolvePaymentMethod

### DIFF
--- a/.changeset/stupid-parents-shave.md
+++ b/.changeset/stupid-parents-shave.md
@@ -2,4 +2,4 @@
 "@justifi/webcomponents": patch
 ---
 
-- Fixed bug in `Checkout` component where BNPL 
+- Fixed bug in `Checkout` component with insurance where checkout session could be "completed" without making an insurance selection. It is now required to accept or decline insurance before completing a checkout with insurance.

--- a/.changeset/stupid-parents-shave.md
+++ b/.changeset/stupid-parents-shave.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Fixed bug in `Checkout` component where BNPL 

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -85,15 +85,12 @@ export class CheckoutCore {
     this.renderState = 'loading';
 
     const insuranceValidation = validateInsuranceValues();
+    const payload: PaymentMethodPayload = await this.paymentMethodOptionsRef.resolvePaymentMethod(insuranceValidation);
 
-    if (!insuranceValidation.isValid) {
+    if (payload.validationError) {
       this.renderState = 'error';
-      return;
     }
-
-    const payload: PaymentMethodPayload = await this.paymentMethodOptionsRef.resolvePaymentMethod();
-
-    if (payload.error) {
+    else if (payload.error) {
       this.renderState = 'error';
       this.serverError = payload.error.message;
       this.onError({

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -85,12 +85,15 @@ export class CheckoutCore {
     this.renderState = 'loading';
 
     const insuranceValidation = validateInsuranceValues();
-    const payload: PaymentMethodPayload = await this.paymentMethodOptionsRef.resolvePaymentMethod();
 
     if (!insuranceValidation.isValid) {
       this.renderState = 'error';
+      return;
     }
-    else if (payload.error) {
+
+    const payload: PaymentMethodPayload = await this.paymentMethodOptionsRef.resolvePaymentMethod();
+
+    if (payload.error) {
       this.renderState = 'error';
       this.serverError = payload.error.message;
       this.onError({

--- a/packages/webcomponents/src/components/checkout/new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/new-payment-method.tsx
@@ -31,7 +31,7 @@ export class NewPaymentMethod {
   }
 
   @Method()
-  async resolvePaymentMethod(insuranceValidation?: any): Promise<PaymentMethodPayload> {
+  async resolvePaymentMethod(insuranceValidation: any): Promise<PaymentMethodPayload> {
     if (!this.paymentMethodFormRef || !this.billingFormRef) return;
 
     const isValid = await this.validate();

--- a/packages/webcomponents/src/components/checkout/new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/new-payment-method.tsx
@@ -31,13 +31,14 @@ export class NewPaymentMethod {
   }
 
   @Method()
-  async resolvePaymentMethod(): Promise<PaymentMethodPayload> {
+  async resolvePaymentMethod(insuranceValidation?: any): Promise<PaymentMethodPayload> {
     if (!this.paymentMethodFormRef || !this.billingFormRef) return;
 
-    const billingFormValidation = await this.billingFormRef.validate();
-    const paymentMethodFormValidation = await this.paymentMethodFormRef.validate();
+    const isValid = await this.validate();
 
-    if (!billingFormValidation.isValid || !paymentMethodFormValidation.isValid) return;
+    if (!isValid || !insuranceValidation.isValid) {
+      return { validationError: true };
+    }
 
     const tokenizeResponse = await this.tokenize();
 
@@ -47,6 +48,13 @@ export class NewPaymentMethod {
       const tokenizeRessponseData = tokenizeResponse.data;
       return { token: tokenizeRessponseData.card?.token || tokenizeRessponseData.bank_account?.token };
     }
+  }
+
+  async validate(): Promise<boolean> {
+    const billingFormValidation = await this.billingFormRef.validate();
+    const paymentMethodFormValidation = await this.paymentMethodFormRef.validate();
+
+    return billingFormValidation.isValid && paymentMethodFormValidation.isValid;
   }
 
   async tokenize() {

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -64,8 +64,8 @@ export class PaymentMethodOptions {
   }
 
   @Method()
-  async resolvePaymentMethod(): Promise<PaymentMethodPayload> {
-    return await this.selectedPaymentMethodOptionRef?.resolvePaymentMethod();
+  async resolvePaymentMethod(insuranceValidation: any): Promise<PaymentMethodPayload> {
+    return await this.selectedPaymentMethodOptionRef?.resolvePaymentMethod(insuranceValidation);
   }
 
   render() {

--- a/packages/webcomponents/src/components/checkout/payment-method-payload.ts
+++ b/packages/webcomponents/src/components/checkout/payment-method-payload.ts
@@ -10,5 +10,6 @@ export interface PaymentMethodPayload {
     code: string;
     message: string;
     decline_code: string;
-  };
+  },
+  validationError?: boolean;
 }

--- a/packages/webcomponents/src/components/checkout/readme.md
+++ b/packages/webcomponents/src/components/checkout/readme.md
@@ -57,9 +57,15 @@
 
 ## Methods
 
-### `resolvePaymentMethod() => Promise<PaymentMethodPayload>`
+### `resolvePaymentMethod(insuranceValidation?: any) => Promise<PaymentMethodPayload>`
 
 
+
+#### Parameters
+
+| Name                  | Type  | Description |
+| --------------------- | ----- | ----------- |
+| `insuranceValidation` | `any` |             |
 
 #### Returns
 

--- a/packages/webcomponents/src/components/checkout/saved-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/saved-payment-method.tsx
@@ -15,7 +15,10 @@ export class SavedPaymentMethod {
   @Event({ bubbles: true }) paymentMethodOptionSelected: EventEmitter;
 
   @Method()
-  async resolvePaymentMethod(): Promise<PaymentMethodPayload> {
+  async resolvePaymentMethod(insuranceValidation?: any): Promise<PaymentMethodPayload> {
+    if (insuranceValidation && !insuranceValidation.isValid) {
+      return { validationError: true };
+    }
     return { token: this.paymentMethodOption?.id };
   };
 

--- a/packages/webcomponents/src/components/checkout/saved-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/saved-payment-method.tsx
@@ -15,8 +15,8 @@ export class SavedPaymentMethod {
   @Event({ bubbles: true }) paymentMethodOptionSelected: EventEmitter;
 
   @Method()
-  async resolvePaymentMethod(insuranceValidation?: any): Promise<PaymentMethodPayload> {
-    if (insuranceValidation && !insuranceValidation.isValid) {
+  async resolvePaymentMethod(insuranceValidation: any): Promise<PaymentMethodPayload> {
+    if (!insuranceValidation.isValid) {
       return { validationError: true };
     }
     return { token: this.paymentMethodOption?.id };

--- a/packages/webcomponents/src/components/checkout/sezzle-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/sezzle-payment-method.tsx
@@ -48,7 +48,10 @@ export class SezzlePaymentMethod {
   }
 
   @Method()
-  async resolvePaymentMethod(): Promise<PaymentMethodPayload> {
+  async resolvePaymentMethod(insuranceValidation?: any): Promise<PaymentMethodPayload> {
+    if (insuranceValidation && !insuranceValidation.isValid) { 
+      return { validationError: true }; 
+    }
     this.sezzleButtonRef.click();
     return this.sezzlePromise;
   }

--- a/packages/webcomponents/src/components/checkout/sezzle-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/sezzle-payment-method.tsx
@@ -48,8 +48,8 @@ export class SezzlePaymentMethod {
   }
 
   @Method()
-  async resolvePaymentMethod(insuranceValidation?: any): Promise<PaymentMethodPayload> {
-    if (insuranceValidation && !insuranceValidation.isValid) { 
+  async resolvePaymentMethod(insuranceValidation: any): Promise<PaymentMethodPayload> {
+    if (!insuranceValidation.isValid) { 
       return { validationError: true }; 
     }
     this.sezzleButtonRef.click();


### PR DESCRIPTION
### Ensure insuranceValidation is called before resolvePaymentMethod

This PR commits the following change:

- Passes `insuranceValidation` into the `resolvePaymentMethod` method so that each of the payment-method components check for an insurance selection. 
- In the case of `new-payment-method.tsx` - the insurance validation is checked along with the payment and billing form validations
- In the case of `sezzle-payment-method.tsx` - it simply checks for an insurance selection before opening the sezzle window
- in the case of `saved-payment-method.tsx` - it simply checks for an insurance selection before posting the checkout completion.


Links
-----

Closes #634 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [x] Perform dev QA


Developer QA steps
--------------------

It would be best to test the checkout component with AND without insurance included just to be safe. 

- [x] New Payment Method - Verify insurance validation fires along payment form / billing form validation. Tokenize call shouldn't happen until all fields are valid. 
- [x] Saved Payment Method - verify insurance validation fires.
- [x] Sezzle Payment Method - verify insurance validation fires before the sezzle window can open



