### PR TITLE
Adjustments to SSN and Tax ID fields in PaymentProvisioning component

### DIFF
--- a/.changeset/tricky-rocks-relate.md
+++ b/.changeset/tricky-rocks-relate.md
@@ -1,0 +1,7 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Updated field labels in `PaymentProvisioning` component.
+  - `Tax ID` field label has been updated to `Tax ID (EIN or SSN)`
+  - `SSN` field label no longer changes to `Update SSN (optional)` if submitting this form step again after the first time. 

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -39,10 +39,6 @@ export class BusinessOwnerForm {
     return this.ownerId ? `entities/identity/${this.ownerId}` : 'entities/identity';
   }
 
-  get identificationNumberLabel() {
-    return this.owner.ssn_last4 ? 'Update SSN (optional)' : 'SSN';
-  }
-
   get formTitle() {
     return this.ownerId ? 'Edit Business Owner' : 'Add Business Owner';
   }
@@ -227,79 +223,79 @@ export class BusinessOwnerForm {
       this.formController.getInitialValues();
 
     return (
-      <Host exportparts="label,input,input-invalid">
+      <Host exportparts='label,input,input-invalid'>
         <form onSubmit={this.validateAndSubmit}>
           <fieldset>
             <legend class='fw-semibold fs-5'>{this.formTitle}</legend>
             <br />
             <div class='row gy-3'>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-text
-                  name="name"
-                  label="Full Name"
+                  name='name'
+                  label='Full Name'
                   defaultValue={ownerDefaultValue?.name}
                   errorText={this.errors.name}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-4">
+              <div class='col-12 col-md-4'>
                 <form-control-text
-                  name="title"
-                  label="Title"
+                  name='title'
+                  label='Title'
                   defaultValue={ownerDefaultValue?.title}
                   errorText={this.errors.title}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-text
-                  name="email"
-                  label="Email Address"
+                  name='email'
+                  label='Email Address'
                   defaultValue={ownerDefaultValue?.email}
                   errorText={this.errors.email}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-number-masked
-                  name="phone"
-                  label="Phone Number"
+                  name='phone'
+                  label='Phone Number'
                   defaultValue={ownerDefaultValue?.phone}
                   errorText={this.errors.phone}
                   inputHandler={this.inputHandler}
                   mask={PHONE_MASKS.US}
                 />
               </div>
-              <div class="col-12 col-md-4">
+              <div class='col-12 col-md-4'>
                 <form-control-date
-                  name="dob_full"
-                  label="Birth Date"
+                  name='dob_full'
+                  label='Birth Date'
                   defaultValue={ownerDefaultValue?.dob_full}
                   errorText={this.errors.dob_full}
                   inputHandler={this.inputHandler}
                   onFormControlInput={this.onDateOfBirthUpdate}
                 />
               </div>
-              <div class="col-12 col-md-8">
+              <div class='col-12 col-md-8'>
                 <form-control-number-masked
-                  name="identification_number"
-                  label={this.identificationNumberLabel}
+                  name='identification_number'
+                  label='SSN'
                   defaultValue={ownerDefaultValue?.identification_number}
                   errorText={this.errors.identification_number}
                   inputHandler={this.inputHandler}
                   mask={SSN_MASK}
                 />
               </div>
-              <div class="col-12">
+              <div class='col-12'>
                 <justifi-identity-address-form
                   errors={this.errors.address}
                   defaultValues={ownerDefaultValue?.address}
                   handleFormUpdate={this.onAddressFormUpdate}
                 />
               </div>
-              <div class="container d-flex gap-2">
+              <div class='container d-flex gap-2'>
                 <button
-                  type="submit"
+                  type='submit'
                   class={`btn btn-primary jfi-submit-button${this.isLoading ? ' jfi-submit-button-loading' : ''}`}
                   onClick={() => this.handleAddOwner()}
                   disabled={this.isLoading}>
@@ -307,8 +303,8 @@ export class BusinessOwnerForm {
                 </button>
                 {this.showRemoveButton &&
                   <button
-                    type="button"
-                    class="btn btn-danger"
+                    type='button'
+                    class='btn btn-danger'
                     onClick={() => this.handleRemoveOwner()}>
                     Remove owner
                   </button>}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
+import { PHONE_MASKS } from '../../../../utils/form-input-masks';
 import { CoreBusinessInfo, IBusiness, ICoreBusinessInfo } from '../../../../api/Business';
 import { Api, IApiResponse } from '../../../../api';
 import { businessCoreInfoSchema } from '../../schemas/business-core-info-schema';
@@ -10,6 +10,7 @@ import { flattenNestedObject } from '../../../../utils/utils';
 import { BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { businessClassificationOptions } from '../../utils/business-form-options';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
+import { numberOnlyHandler } from '../../../form/utils';
 
 /**
  *
@@ -126,90 +127,90 @@ export class BusinessCoreInfoFormStep {
     const coreInfoDefaultValue = this.formController.getInitialValues();
 
     return (
-      <Host exportparts="label,input,input-invalid">
+      <Host exportparts='label,input,input-invalid'>
         <form>
           <fieldset>
             <legend>General Info</legend>
             <hr />
-            <div class="row gy-3">
-              <div class="col-12">
+            <div class='row gy-3'>
+              <div class='col-12'>
                 <form-control-text
-                  name="legal_name"
-                  label="Legal Name"
+                  name='legal_name'
+                  label='Legal Name'
                   defaultValue={coreInfoDefaultValue.legal_name}
                   errorText={this.errors.legal_name}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12">
+              <div class='col-12'>
                 <form-control-text
-                  name="doing_business_as"
-                  label="Doing Business As (DBA)"
+                  name='doing_business_as'
+                  label='Doing Business As (DBA)'
                   defaultValue={coreInfoDefaultValue.doing_business_as}
                   errorText={this.errors.doing_business_as}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-8">
+              <div class='col-12 col-md-8'>
                 <form-control-select
-                  name="classification"
-                  label="Business Classification"
+                  name='classification'
+                  label='Business Classification'
                   options={businessClassificationOptions}
                   defaultValue={coreInfoDefaultValue.classification}
                   errorText={this.errors.classification}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-4">
+              <div class='col-12 col-md-4'>
                 <form-control-date
-                  name="date_of_incorporation"
-                  label="Date of Incorporation"
+                  name='date_of_incorporation'
+                  label='Date of Incorporation'
                   defaultValue={coreInfoDefaultValue.date_of_incorporation}
                   errorText={this.errors.date_of_incorporation}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-text
-                  name="industry"
-                  label="Industry"
+                  name='industry'
+                  label='Industry'
                   defaultValue={coreInfoDefaultValue.industry}
                   errorText={this.errors.industry}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
-                <form-control-number-masked
-                  name="tax_id"
-                  label="Tax ID"
+              <div class='col-12 col-md-6'>
+                <form-control-text
+                  name='tax_id'
+                  label='Tax ID (EIN or SSN)'
                   defaultValue={coreInfoDefaultValue.tax_id}
                   errorText={this.errors.tax_id}
                   inputHandler={this.inputHandler}
-                  mask={TAX_ID_MASKS.US}
+                  keyDownHandler={numberOnlyHandler}
                 />
               </div>
-              <div class="col-12">
+              <div class='col-12'>
                 <form-control-text
-                  name="website_url"
-                  label="Website URL"
+                  name='website_url'
+                  label='Website URL'
                   defaultValue={coreInfoDefaultValue.website_url}
                   errorText={this.errors.website_url}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-text
-                  name="email"
-                  label="Email Address"
+                  name='email'
+                  label='Email Address'
                   defaultValue={coreInfoDefaultValue.email}
                   errorText={this.errors.email}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-number-masked
-                  name="phone"
-                  label="Phone Number"
+                  name='phone'
+                  label='Phone Number'
                   defaultValue={coreInfoDefaultValue.phone}
                   errorText={this.errors.phone}
                   inputHandler={this.inputHandler}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -187,6 +187,7 @@ export class BusinessCoreInfoFormStep {
                   errorText={this.errors.tax_id}
                   inputHandler={this.inputHandler}
                   keyDownHandler={numberOnlyHandler}
+                  maxLength={9}
                 />
               </div>
               <div class='col-12'>

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -34,10 +34,6 @@ export class BusinessRepresentativeFormStep {
     return `entities/business/${this.businessId}`
   }
 
-  get identificationNumberLabel() {
-    return this.representative.ssn_last4 ? 'Update SSN (optional)' : 'SSN';
-  }
-
   private fetchData = async () => {
     this.formLoading.emit(true);
     try {
@@ -151,70 +147,70 @@ export class BusinessRepresentativeFormStep {
       this.formController.getInitialValues();
 
     return (
-      <Host exportparts="label,input,input-invalid">
+      <Host exportparts='label,input,input-invalid'>
         <form>
           <fieldset>
             <legend>Representative</legend>
             <hr />
-            <div class="row gy-3">
-              <div class="col-12 col-md-8">
+            <div class='row gy-3'>
+              <div class='col-12 col-md-8'>
                 <form-control-text
-                  name="name"
-                  label="Full Name"
+                  name='name'
+                  label='Full Name'
                   defaultValue={representativeDefaultValue?.name}
                   errorText={this.errors.name}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-4">
+              <div class='col-12 col-md-4'>
                 <form-control-text
-                  name="title"
-                  label="Title"
+                  name='title'
+                  label='Title'
                   defaultValue={representativeDefaultValue?.title}
                   errorText={this.errors.title}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-text
-                  name="email"
-                  label="Email Address"
+                  name='email'
+                  label='Email Address'
                   defaultValue={representativeDefaultValue?.email}
                   errorText={this.errors.email}
                   inputHandler={this.inputHandler}
                 />
               </div>
-              <div class="col-12 col-md-6">
+              <div class='col-12 col-md-6'>
                 <form-control-number-masked
-                  name="phone"
-                  label="Phone Number"
+                  name='phone'
+                  label='Phone Number'
                   defaultValue={representativeDefaultValue?.phone}
                   errorText={this.errors.phone}
                   inputHandler={this.inputHandler}
                   mask={PHONE_MASKS.US}
                 />
               </div>
-              <div class="col-12 col-md-4">
+              <div class='col-12 col-md-4'>
                 <form-control-date
-                  name="dob_full"
-                  label="Birth Date"
+                  name='dob_full'
+                  label='Birth Date'
                   defaultValue={representativeDefaultValue?.dob_full}
                   errorText={this.errors.dob_full}
                   inputHandler={this.inputHandler}
                   onFormControlInput={this.onDateOfBirthUpdate}
                 />
               </div>
-              <div class="col-12 col-md-8">
+              <div class='col-12 col-md-8'>
                 <form-control-number-masked
-                  name="identification_number"
-                  label={this.identificationNumberLabel}
+                  name='identification_number'
+                  label='SSN'
                   defaultValue={representativeDefaultValue?.identification_number}
                   errorText={this.errors.identification_number}
                   inputHandler={this.inputHandler}
                   mask={SSN_MASK}
                 />
               </div>
-              <div class="col-12">
+              <div class='col-12'>
                 <justifi-identity-address-form
                   errors={this.errors.address}
                   defaultValues={representativeDefaultValue?.address}

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -20,7 +20,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     doing_business_as: doingBusinessAsValidation.required('Enter doing business as'),
     classification: businessClassificationValidation.required('Select business classification'),
     industry: industryValidation.required('Enter a business industry'),
-    tax_id: taxIdValidation.required('Enter tax id'),
+    tax_id: taxIdValidation.required('Enter tax id, SSN, or EIN'),
     date_of_incorporation: dateOfIncorporationValidation.required('Enter date of incorporation'),
   });
 

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-helpers.ts
@@ -23,8 +23,6 @@ export const phoneRegex = /^\d{10}$/;
 
 export const urlRegex = /^(?:http(s)?:\/\/)?(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/;
 
-export const taxIdRegex = /^\d{9}$/;
-
 export const stringLettersOnlyRegex = /^(?!^\s+$)[a-zA-Z\s]*$/;
 
 export const numbersOnlyRegex = /^\d+$/;

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -1,26 +1,25 @@
-import { mixed, string } from "yup";
-import StateOptions from "../../../utils/state-options";
-import { 
-  businessServiceReceivedOptions, 
-  recurringPaymentsOptions, 
-  seasonalBusinessOptions, 
+import { mixed, string } from 'yup';
+import StateOptions from '../../../utils/state-options';
+import {
+  businessServiceReceivedOptions,
+  recurringPaymentsOptions,
+  seasonalBusinessOptions,
   bankAccountTypeOptions,
   businessClassificationOptions
-} from "../utils/business-form-options";
-import { 
-  businessNameRegex, 
-  numbersOnlyRegex, 
-  phoneRegex, 
-  poBoxRegex, 
-  ssnRegex, 
-  streetAddressRegex, 
-  stringLettersOnlyRegex, 
-  taxIdRegex, 
-  transformEmptyString, 
-  urlRegex, 
+} from '../utils/business-form-options';
+import {
+  businessNameRegex,
+  numbersOnlyRegex,
+  phoneRegex,
+  poBoxRegex,
+  ssnRegex,
+  streetAddressRegex,
+  stringLettersOnlyRegex,
+  transformEmptyString,
+  urlRegex,
   validateRoutingNumber
-} from "./schema-helpers";
-import { EntityDocumentType } from "../../../api/Document";
+} from './schema-helpers';
+import { EntityDocumentType } from '../../../api/Document';
 
 // Common Validations
 
@@ -61,11 +60,10 @@ export const industryValidation = string()
   .transform(transformEmptyString);
 
 export const taxIdValidation = string()
-  .matches(taxIdRegex, 'Enter valid tax id')
-  .test('not-repeat', 'Enter valid tax id', (value) => {
+  .test('not-repeat', 'Enter valid tax id, SSN, or EIN', (value) => {
     return !/^(\d)\1+$/.test(value);
   })
-  .test('not-seq', 'Enter valid tax id', (value) => {
+  .test('not-seq', 'Enter valid tax id, SSN, or EIN', (value) => {
     return value !== '123456789';
   })
   .transform(transformEmptyString);

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -60,6 +60,7 @@ export const industryValidation = string()
   .transform(transformEmptyString);
 
 export const taxIdValidation = string()
+  .matches(numbersOnlyRegex, 'Enter valid tax id, SSN, or EIN')
   .test('not-repeat', 'Enter valid tax id, SSN, or EIN', (value) => {
     return !/^(\d)\1+$/.test(value);
   })

--- a/packages/webcomponents/src/components/form/form-control-text.tsx
+++ b/packages/webcomponents/src/components/form/form-control-text.tsx
@@ -63,7 +63,8 @@ export class TextInput {
             name={this.name}
             onBlur={this.formControlBlur.emit}
             onInput={this.handleFormControlInput}
-            onKeyDown={(event: any) => this.keyDownHandler && this.keyDownHandler(event)}
+            onKeyDown={this.keyDownHandler}
+            onPaste={this.keyDownHandler}
             maxLength={this.maxLength}
             part={`input ${this.errorText ? 'input-invalid ' : ''}${this.disabled ? ' input-disabled' : ''}`}
             class={this.errorText ? 'form-control is-invalid' : 'form-control'}

--- a/packages/webcomponents/src/components/form/utils.tsx
+++ b/packages/webcomponents/src/components/form/utils.tsx
@@ -6,25 +6,32 @@ export const LoadingSpinner = () => (
   </div>
 );
 
-export const numberOnlyHandler = (e: KeyboardEvent) => {
+export const numberOnlyHandler = (e: KeyboardEvent | ClipboardEvent) => {
   const specialKeys = ['Backspace', 'Tab', 'Enter', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Delete'];
 
-
   // Check if the key is a special key
-  if (specialKeys.includes(e.key)) {
+  if (e instanceof KeyboardEvent && specialKeys.includes(e.key)) {
     return;
   }
 
   // Allow Ctrl+V / Command+V for pasting
-  const isPaste =
-    (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'v';
+  const isPaste = e instanceof KeyboardEvent && (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'v';
 
   if (isPaste) {
     return;
   }
 
+  // Handle paste event
+  if (e instanceof ClipboardEvent) {
+    const clipboardData = e.clipboardData?.getData('text');
+    if (clipboardData && !/^\d+$/.test(clipboardData)) {
+      e.preventDefault();
+    }
+    return;
+  }
+
   // Prevent default action if the key is not a digit
-  if (!/^\d$/.test(e.key)) {
+  if (e instanceof KeyboardEvent && !/^\d$/.test(e.key)) {
     e.preventDefault();
   }
 };


### PR DESCRIPTION
### Adjustments to SSN and Tax ID fields in PaymentProvisioning component

This PR makes the following changes:

- Tax ID Field (Core Info / First form step)
  - label changed from `Tax ID` => `Tax ID (EIN or SSN)`
  - removed mask that was created for Tax ID specificly
  - adds keyDownHandler to prevent alphabet / special character input. Input allows numbers only. 
  - Validation is largely the same, but it no longer checks for the taxIDRegex. 

- SSN Field (Representative and Owner Form Steps)
  - removed logic that changed label for SSN field if ssn_last4 returns a value. Label always shows `SSN`
  - original validation is still in place, so the previous logic still holds true. If ssn_last4 is returned in fetch request, then this field will not be required for this business. 

These are really the only changes worth mentioning - but I did update the files I was working on so that they used single quotes instead of double quotes for strings, etc. 

Links
-----

Closes #623 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA


Developer QA steps
--------------------

The form should pretty much be the same. 

- [x] Label for Tax ID on first form step now says `Tax ID (EIN or SSN)`
- [x] error validation message for Tax ID field should also reflect new label changes - error text says `Enter valid tax id, SSN, or EIN`
- [ ] Tax ID field should largely follow the same validation rules as before. Mask should be removed, but it should still only allow raw number input. Long strings of just a single digit are invalid, as is `123456789`
- [ ] Field does not allow pasting alphabet characters or special characters into the field

- [x] SSN Field on Representative and Owner forms should only show `SSN` as label, no longer shows `Update SSN (optional)` if this form step has already been submitted with an ssn / identification_number
- [x] Validation and logic for this field remains the same. Even though the label is updated, the field should function exactly as befoee

