### PR TITLE
Hide saved disabled payment methods

### DIFF
--- a/.changeset/purple-dogs-compare.md
+++ b/.changeset/purple-dogs-compare.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Hides saved credit card/bank account payment methods when disable-credit-card or disable-bank-account props are true

--- a/packages/webcomponents/src/components/checkout/payment-method-option-utils.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-option-utils.tsx
@@ -1,12 +1,16 @@
+import { snakeToCamel } from "../../utils/utils";
+
 export class PaymentMethodOption {
   id: string;
   brand?: string;
   acct_last_four?: string;
+  type: string;
 
   constructor(paymentMethod: any) {
     this.id = paymentMethod.id;
     this.brand = paymentMethod.brand;
     this.acct_last_four = paymentMethod.acct_last_four;
+    this.type = snakeToCamel(paymentMethod.type);
   }
 };
 

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -47,7 +47,15 @@ export class PaymentMethodOptions {
 
   @Watch('savedPaymentMethods')
   paymentMethodsChanged() {
-    this.paymentMethodOptions = this.savedPaymentMethods.map((paymentMethod) => new PaymentMethodOption(paymentMethod));
+    this.paymentMethodOptions = this.savedPaymentMethods
+      .map((paymentMethod) => new PaymentMethodOption(paymentMethod))
+      .filter((paymentMethod) => {
+        // Don't saved card or bank account if they are disabled
+        return (
+          (this.showCard || paymentMethod.type !== PaymentMethodTypes.card) &&
+          (this.showAch || paymentMethod.type !== PaymentMethodTypes.bankAccount)
+        );
+      });
     if (this.showBnpl && this.bnpl?.provider === 'sezzle' && !this.insuranceToggled) {
       this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.sezzle }));
     }

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -42,7 +42,7 @@ export class PaymentMethodOptions {
 
   connectedCallback() {
     this.paymentMethodsChanged();
-    this.selectedPaymentMethodId = this.paymentMethodOptions[0].id;
+    this.selectedPaymentMethodId = this.paymentMethodOptions[0]?.id;
   }
 
   @Watch('savedPaymentMethods')

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -42,7 +42,6 @@ export class PaymentMethodOptions {
 
   connectedCallback() {
     this.paymentMethodsChanged();
-    this.selectedPaymentMethodId = this.paymentMethodOptions[0]?.id;
   }
 
   @Watch('savedPaymentMethods')
@@ -64,6 +63,9 @@ export class PaymentMethodOptions {
     }
     if (this.showAch) {
       this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.bankAccount }));
+    }
+    if (!this.selectedPaymentMethodId) {
+      this.selectedPaymentMethodId = this.paymentMethodOptions[0]?.id;
     }
   }
 

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -46,14 +46,14 @@ export class PaymentMethodOptions {
   @Watch('savedPaymentMethods')
   paymentMethodsChanged() {
     this.paymentMethodOptions = this.savedPaymentMethods.map((paymentMethod) => new PaymentMethodOption(paymentMethod));
+    if (this.showBnpl && this.bnpl?.provider === 'sezzle') {
+      this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.sezzle }));
+    }
     if (this.showCard) {
       this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.card }));
     }
     if (this.showAch) {
       this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.bankAccount }));
-    }
-    if (this.showBnpl && this.bnpl?.provider === 'sezzle') {
-      this.paymentMethodOptions.push(new PaymentMethodOption({ id: PaymentMethodTypes.sezzle }));
     }
   }
 

--- a/packages/webcomponents/src/utils/utils.ts
+++ b/packages/webcomponents/src/utils/utils.ts
@@ -183,6 +183,13 @@ export function camelToKebab(str: string): string {
   return str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
 }
 
+export function snakeToCamel(str: string): string {
+  if (!str) return '';
+  return str.replace(/([-_][a-z])/g, (group) =>
+    group.toUpperCase().replace('-', '').replace('_', '')
+  );
+}
+
 export function flattenNestedObject(obj) {
   const result = {};
 


### PR DESCRIPTION
**Description**

* This PR makes BNPL the default option after saved payment methods by pushing it before any other payment method in the array. (Jake's PR)
* This also add a new `type` property to the payment method options and filters out the saved payment methods accordingly with `disabled-bank-account` and `disabled-credit-card` props.


Links
-----
#625 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
This can be tested either in the demo-app or in Storybook, just need a checkout with saved credit cards or bank account payment methods
[ ] - passing `disable-credit-card=true` should hide saved credit card payment methods
[ ] - passing `disable-bank-account=true` should hide saved bank account payment methods 

