### PR TITLE
handle expired and completed checkout statuses

### DIFF
--- a/apps/docs/stories/components/Checkout/index.stories.tsx
+++ b/apps/docs/stories/components/Checkout/index.stories.tsx
@@ -102,6 +102,14 @@ const meta: Meta = {
       },
       action: true,
     },
+    "loaded": {
+      description:
+        "Return the checkout status once checkout is loaded. It can be `'created' | 'completed' | 'attempted' | 'expired'`",
+      table: {
+        category: "events",
+      },
+      action: true,
+    },
     loadFontsOnParent: {
       description: "`loadFontsOnParent() => Promise<any>`",
       table: {
@@ -111,7 +119,7 @@ const meta: Meta = {
   },
   parameters: {
     actions: {
-      handles: ["submitted"],
+      handles: ["submitted", 'loaded', 'error-event'],
     },
     chromatic: {
       delay: 2000,

--- a/mockData/mockGetCheckoutSuccess.json
+++ b/mockData/mockGetCheckoutSuccess.json
@@ -1,9 +1,9 @@
 {
-  "id": "cho_3PoxcZqCXWOGm69e1XcGrW",
+  "id": "cho_qkHk4NXnSV0PVulNY4M8J",
   "type": "checkout",
   "page_info": null,
   "data": {
-    "id": "cho_3PoxcZqCXWOGm69e1XcGrW",
+    "id": "cho_qkHk4NXnSV0PVulNY4M8J",
     "payment_intent_id": null,
     "account_id": "acc_5Et9iXrSSAZR2KSouQGAWi",
     "platform_account_id": "acc_3reNb4aNYy2iWDZQVczmx4",
@@ -12,7 +12,39 @@
     "payment_description": "One Chocolate Donut",
     "payment_methods": [
       {
+        "id": "pm_CVVljvGQiFrvZOCluxRtz",
+        "type": "bank_account",
+        "status": "valid",
+        "invalid_reason": null,
+        "account_owner_name": "Tiago Saft Fuelber",
+        "account_type": "checking",
+        "bank_name": null,
+        "acct_last_four": "6789"
+      },
+      {
+        "id": "pm_44kqDu0ac5f8TLu9vdSTQ",
+        "type": "card",
+        "status": "valid",
+        "invalid_reason": null,
+        "name": "Leslie Knope",
+        "brand": "visa",
+        "acct_last_four": "4242",
+        "month": "11",
+        "year": "25",
+        "address_line1_check": "pass",
+        "address_postal_code_check": "pass",
+        "bin_details": {
+          "type": "Debit",
+          "card_brand": "Visa",
+          "card_class": "Consumer",
+          "country": "United States of America",
+          "issuer": "Visa - Issuer Bank Not Available",
+          "funding_source": "Debit"
+        }
+      },
+      {
         "id": "pm_7PA97VwNELPkBhKf24kVE0",
+        "type": "card",
         "status": "valid",
         "invalid_reason": null,
         "name": "Julia Garnett",
@@ -26,7 +58,7 @@
       }
     ],
     "payment_method_group_id": "pmg_12TH1LBNpsrdEXxWyxFjQv",
-    "status": "created",
+    "status": "expired",
     "mode": "test",
     "payment_settings": {
       "ach_payments": true,
@@ -34,8 +66,10 @@
       "credit_card_payments": true
     },
     "successful_payment_id": null,
-    "created_at": "2024-08-15T13:54:01.558Z",
-    "updated_at": "2024-08-15T13:54:01.558Z",
+    "statement_descriptor": null,
+    "application_fees": null,
+    "created_at": "2024-08-08T15:47:45.376Z",
+    "updated_at": "2024-08-27T14:31:35.549Z",
     "total_amount": 1799,
     "insurance_amount": 0,
     "payment_client_id": "test_e94e298293426cacb29c953b2047d6e8",
@@ -44,13 +78,13 @@
       "provider": "sezzle",
       "provider_client_id": "sz_pub_Kfhyb9x0hdTb2JtUYejTTP3Kb2RTi1xV",
       "provider_mode": "sandbox",
-      "provider_checkout_url": "https://sandbox.checkout.sezzle.com?id=8162a420-953e-4cdc-8a0d-10ba4ada4eee",
-      "provider_order_id": "939d82be-d319-4d6e-adb6-97b03336c281",
+      "provider_checkout_url": "https://sandbox.checkout.sezzle.com?id=b5f96653-9d56-45d9-a760-c97973b6efdd",
+      "provider_order_id": "f573e219-33f1-4696-9e33-7afa61808a21",
       "balance": 1799,
       "provider_api_version": "v2",
       "status": "created",
-      "created_at": "2024-08-15T13:54:02.083Z",
-      "updated_at": "2024-08-15T13:54:02.083Z"
+      "created_at": "2024-08-08T15:47:45.815Z",
+      "updated_at": "2024-08-08T15:47:45.815Z"
     }
   }
 }

--- a/mockData/mockPostCheckoutSuccess.json
+++ b/mockData/mockPostCheckoutSuccess.json
@@ -1,79 +1,90 @@
 {
-  "id": "chc_1sCz2z7ZngIgN8Mk71sud8",
-  "type": "checkout_completion",
+  "id": "cho_qkHk4NXnSV0PVulNY4M8J",
+  "type": "checkout",
   "page_info": null,
   "data": {
-    "payment_mode": "ecom",
-    "payment_token": "pm_6Pa97VwPLENKbhff32kbE1",
-    "payment_status": "succeeded",
-    "payment_response": {
-      "id": "pi_6blZYsKGktLASDIE82qrIrs",
-      "type": "payment_intent",
-      "data": {
-        "id": "pi_7BlZYGktsw3tRasdfC33qRaRs",
-        "account_id": "acc_4Et9iXrAARKSZ4KSoiQGTYr",
-        "amount": 8592,
-        "currency": "usd",
-        "description": "4x Cases of Celsius Energy Drink",
-        "last_error": null,
-        "metadata": null,
-        "status": "succeeded",
-        "payment_method": {
-          "signature": "4hi2fPwi38xdLzoIaG5eKn",
-          "customer_id": "cust_0mJiaT87evxe0udTFxRnbU",
-          "account_id": "acc_4Et9iXrAARKSZ4KSoiQGTYr",
-          "status": "valid",
-          "invalid_reason": null,
-          "card": {
-            "id": "pm_6Pa97VwPLENKbhff32kbE1",
-            "name": "Julia Garnett",
-            "acct_last_four": "1111",
-            "brand": "visa",
-            "token": "pm_6Pa97VwPLENKbhff32kbE1",
-            "metadata": null,
-            "month": "10",
-            "year": "2042",
-            "address_line1_check": "pass",
-            "address_postal_code_check": "pass",
-            "bin_details": null
-          }
-        },
-        "successful_payment_id": "py_ZwxB243mPYpd83XYgZyhasdf",
-        "created_at": "2024-05-13T19:32:46.232Z",
-        "updated_at": "2024-05-13T19:39:28.419Z"
+    "id": "cho_qkHk4NXnSV0PVulNY4M8J",
+    "payment_intent_id": null,
+    "account_id": "acc_5Et9iXrSSAZR2KSouQGAWi",
+    "platform_account_id": "acc_3reNb4aNYy2iWDZQVczmx4",
+    "payment_amount": 1799,
+    "payment_currency": "USD",
+    "payment_description": "One Chocolate Donut",
+    "payment_methods": [
+      {
+        "id": "pm_CVVljvGQiFrvZOCluxRtz",
+        "type": "bank_account",
+        "status": "valid",
+        "invalid_reason": null,
+        "account_owner_name": "Tiago Saft Fuelber",
+        "account_type": "checking",
+        "bank_name": null,
+        "acct_last_four": "6789"
       },
-      "page_info": null
-    },
-    "checkout_id": "cho_SuaBaIa78dedf9934cf4vrbHVX",
-    "additional_transactions": [],
-    "checkout": {
-      "payment_intent_id": "pi_7BlZYsKGktASDFdchjgkz",
-      "account_id": "acc_4Et9iXrAARKSZ4KSoiQGTYr",
-      "platform_account_id": "acc_2erNb3aRBy2iWaYUOczmx4",
-      "payment_amount": "8592",
-      "payment_client_id": "test_ef88f04afebc3c018de30fd3652d7cee",
-      "payment_description": "4x Cases of Celsius Energy Drink",
-      "payment_methods": [
-        {
-          "id": "pm_7PA97VwNKZskBhKf24kRTY",
-          "status": "valid",
-          "invalid_reason": null,
-          "name": "Julia Garnett",
-          "brand": "visa",
-          "acct_last_four": "1111",
-          "month": "10",
-          "year": "2042",
-          "address_line1_check": "pass",
-          "address_postal_code_check": "pass",
-          "bin_details": null
+      {
+        "id": "pm_44kqDu0ac5f8TLu9vdSTQ",
+        "type": "card",
+        "status": "valid",
+        "invalid_reason": null,
+        "name": "Leslie Knope",
+        "brand": "visa",
+        "acct_last_four": "4242",
+        "month": "11",
+        "year": "25",
+        "address_line1_check": "pass",
+        "address_postal_code_check": "pass",
+        "bin_details": {
+          "type": "Debit",
+          "card_brand": "Visa",
+          "card_class": "Consumer",
+          "country": "United States of America",
+          "issuer": "Visa - Issuer Bank Not Available",
+          "funding_source": "Debit"
         }
-      ],
-      "payment_method_group_id": "pmg_23YT1LVnpsrdXExZYxIjav",
-      "payment_settings": {
-        "ach_payments": true,
-        "bnpl_payments": true,
-        "credit_card_payments": true
+      },
+      {
+        "id": "pm_7PA97VwNELPkBhKf24kVE0",
+        "type": "card",
+        "status": "valid",
+        "invalid_reason": null,
+        "name": "Julia Garnett",
+        "brand": "visa",
+        "acct_last_four": "1111",
+        "month": "10",
+        "year": "2042",
+        "address_line1_check": "pass",
+        "address_postal_code_check": "pass",
+        "bin_details": null
       }
+    ],
+    "payment_method_group_id": "pmg_12TH1LBNpsrdEXxWyxFjQv",
+    "status": "expired",
+    "mode": "test",
+    "payment_settings": {
+      "ach_payments": true,
+      "bnpl_payments": true,
+      "credit_card_payments": true
+    },
+    "successful_payment_id": null,
+    "statement_descriptor": null,
+    "application_fees": null,
+    "created_at": "2024-08-08T15:47:45.376Z",
+    "updated_at": "2024-08-27T14:31:35.549Z",
+    "total_amount": 1799,
+    "insurance_amount": 0,
+    "payment_client_id": "test_e94e298293426cacb29c953b2047d6e8",
+    "completions": [],
+    "bnpl": {
+      "provider": "sezzle",
+      "provider_client_id": "sz_pub_Kfhyb9x0hdTb2JtUYejTTP3Kb2RTi1xV",
+      "provider_mode": "sandbox",
+      "provider_checkout_url": "https://sandbox.checkout.sezzle.com?id=b5f96653-9d56-45d9-a760-c97973b6efdd",
+      "provider_order_id": "f573e219-33f1-4696-9e33-7afa61808a21",
+      "balance": 1799,
+      "provider_api_version": "v2",
+      "status": "created",
+      "created_at": "2024-08-08T15:47:45.815Z",
+      "updated_at": "2024-08-08T15:47:45.815Z"
     }
   }
 }

--- a/packages/webcomponents/src/api/Checkout.ts
+++ b/packages/webcomponents/src/api/Checkout.ts
@@ -38,7 +38,8 @@ export interface ICheckout {
   bnpl?: IBnpl;
   total_amount: number;
   insurance_amount: number;
-};
+  status?: string;
+}
 
 export class Checkout implements ICheckout {
   payment_intent_id: string;
@@ -69,6 +70,7 @@ export class Checkout implements ICheckout {
   bnpl?: IBnpl;
   total_amount: number;
   insurance_amount: number;
+  status?: string;
 
   constructor(data: ICheckout) {
     Object.assign(this, data);

--- a/packages/webcomponents/src/api/Checkout.ts
+++ b/packages/webcomponents/src/api/Checkout.ts
@@ -38,7 +38,7 @@ export interface ICheckout {
   bnpl?: IBnpl;
   total_amount: number;
   insurance_amount: number;
-  status?: string;
+  status: ICheckoutStatus;
 }
 
 export class Checkout implements ICheckout {
@@ -70,7 +70,7 @@ export class Checkout implements ICheckout {
   bnpl?: IBnpl;
   total_amount: number;
   insurance_amount: number;
-  status?: string;
+  status: ICheckoutStatus;
 
   constructor(data: ICheckout) {
     Object.assign(this, data);
@@ -86,3 +86,9 @@ export type ICheckoutCompleteResponse = IApiResponse<{
   additional_transactions: any[];
   checkout: ICheckout;
 }>;
+
+export type ICheckoutStatus = 'created' | 'completed' | 'attempted' | 'expired';
+
+export type ILoadedEventResponse = {
+  checkout_status: ICheckoutStatus;
+};

--- a/packages/webcomponents/src/api/ComponentError.ts
+++ b/packages/webcomponents/src/api/ComponentError.ts
@@ -8,8 +8,6 @@ export enum ComponentErrorCodes {
   NOT_AUTHENTICATED = 'not-authenticated',
   INVALID_PARAMETER = 'invalid-parameter',
   PROVISIONING_REQUESTED = 'provisioning-already-requested',
-  CHECKOUT_EXPIRED = 'checkout-expired',
-  CHECKOUT_COMPLETED = 'checkout-completed',
 }
 
 export enum ComponentErrorSeverity {

--- a/packages/webcomponents/src/api/ComponentError.ts
+++ b/packages/webcomponents/src/api/ComponentError.ts
@@ -8,6 +8,8 @@ export enum ComponentErrorCodes {
   NOT_AUTHENTICATED = 'not-authenticated',
   INVALID_PARAMETER = 'invalid-parameter',
   PROVISIONING_REQUESTED = 'provisioning-already-requested',
+  CHECKOUT_EXPIRED = 'checkout-expired',
+  CHECKOUT_COMPLETED = 'checkout-completed',
 }
 
 export enum ComponentErrorSeverity {

--- a/packages/webcomponents/src/components/checkout/checkout-actions.ts
+++ b/packages/webcomponents/src/components/checkout/checkout-actions.ts
@@ -1,7 +1,8 @@
 import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
-export const makeGetCheckout = ({ authToken, checkoutId, service }) =>
+export const makeGetCheckout =
+  ({ authToken, checkoutId, service }) =>
   async ({ onSuccess, onError }) => {
     try {
       const response = await service.fetchCheckout(authToken, checkoutId);
@@ -28,7 +29,8 @@ export const makeGetCheckout = ({ authToken, checkoutId, service }) =>
     }
   };
 
-export const makeCheckoutComplete = ({ authToken, checkoutId, service }) =>
+export const makeCheckoutComplete =
+  ({ authToken, checkoutId, service }) =>
   async ({ payment, onSuccess, onError }) => {
     try {
       const response = await service.complete(authToken, checkoutId, payment);

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -33,7 +33,7 @@ export class CheckoutCore {
   @State() renderState: 'loading' | 'error' | 'success' = 'loading';
   @State() creatingNewPaymentMethod: boolean = false;
   @State() insuranceToggled: boolean = false;
-  
+
   @Event({ eventName: 'submitted' }) submitted: EventEmitter<ICheckoutCompleteResponse>;
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 
@@ -64,6 +64,22 @@ export class CheckoutCore {
     this.getCheckout({
       onSuccess: ({ checkout }) => {
         this.checkout = new Checkout(checkout);
+        const { status } = this.checkout;
+        if (status === 'completed' || status === 'expired') {
+          const errorCode = status === 'completed'
+            ? ComponentErrorCodes.CHECKOUT_COMPLETED
+            : ComponentErrorCodes.CHECKOUT_EXPIRED;
+
+          const message = status === 'completed'
+            ? 'Checkout has already been completed'
+            : 'Checkout has expired';
+
+          this.errorEvent.emit({
+            errorCode,
+            message,
+            severity: ComponentErrorSeverity.ERROR,
+          });
+        }
         this.renderState = 'success';
       },
       onError: ({ error, code, severity }) => {

--- a/packages/webcomponents/src/components/checkout/checkout.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout.tsx
@@ -4,6 +4,7 @@ import { CheckoutService } from '../../api/services/checkout.service';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
 import JustifiAnalytics from '../../api/Analytics';
 import { BillingFormFields } from '../billing-form/billing-form-schema';
+import { ILoadedEventResponse } from '../../api';
 
 @Component({
   tag: 'justifi-checkout',
@@ -22,6 +23,9 @@ export class Checkout {
   @State() errorMessage: string = '';
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
+  // The original event is emitted from the core component, 
+  // but we want to expose it here so it's documented in the storybook
+  @Event({ eventName: 'loaded' }) loadedEvent: EventEmitter<ILoadedEventResponse>;
 
   private checkoutCoreRef?: HTMLJustifiCheckoutCoreElement;
 


### PR DESCRIPTION
**DESCRIPTION**
* This PR adds some logic to emit an error event when checkout status is expired or completed

Links
-----
#639 

Developer considerations
-------------


Developer QA steps
--------------------
While we don't have yet `completed` and `expired` statuses on our API yet, it's still possible to test this by overriding the request response on the browser:
* On the network tab, right click the checkout request, and click "Override content"
* Edit the response JSON changing the status to `completed` or `expired` and save.
* An error event should be emitted with error details for each case. 
