### PR TITLE
PaymentProvisioning - Refactor representative form step

### DIFF
--- a/packages/webcomponents/src/components/business-forms/owner-form/identity-address/readme.md
+++ b/packages/webcomponents/src/components/business-forms/owner-form/identity-address/readme.md
@@ -19,7 +19,7 @@
 ### Used by
 
  - [justifi-business-representative](../../business-form/business-representative)
- - [justifi-business-representative-form-step](../../payment-provisioning/business-representative)
+ - [justifi-business-representative-form-step-core](../../payment-provisioning/business-representative)
  - [justifi-owner-form](..)
 
 ### Depends on
@@ -37,7 +37,7 @@ graph TD;
   form-control-select --> form-control-help-text
   form-control-select --> form-control-error-text
   justifi-business-representative --> justifi-identity-address-form
-  justifi-business-representative-form-step --> justifi-identity-address-form
+  justifi-business-representative-form-step-core --> justifi-identity-address-form
   justifi-owner-form --> justifi-identity-address-form
   style justifi-identity-address-form fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
@@ -7,11 +7,13 @@
 
 ## Properties
 
-| Property              | Attribute               | Description | Type      | Default     |
-| --------------------- | ----------------------- | ----------- | --------- | ----------- |
-| `allowOptionalFields` | `allow-optional-fields` |             | `boolean` | `undefined` |
-| `authToken`           | `auth-token`            |             | `string`  | `undefined` |
-| `businessId`          | `business-id`           |             | `string`  | `undefined` |
+| Property              | Attribute               | Description | Type       | Default     |
+| --------------------- | ----------------------- | ----------- | ---------- | ----------- |
+| `allowOptionalFields` | `allow-optional-fields` |             | `boolean`  | `undefined` |
+| `authToken`           | `auth-token`            |             | `string`   | `undefined` |
+| `businessId`          | `business-id`           |             | `string`   | `undefined` |
+| `getBusiness`         | --                      |             | `Function` | `undefined` |
+| `patchBusiness`       | --                      |             | `Function` | `undefined` |
 
 
 ## Events
@@ -46,7 +48,7 @@ Type: `Promise<void>`
 
 ### Used by
 
- - [justifi-payment-provisioning-form-steps](..)
+ - [justifi-business-representative-form-step](.)
 
 ### Depends on
 
@@ -58,10 +60,10 @@ Type: `Promise<void>`
 ### Graph
 ```mermaid
 graph TD;
-  justifi-business-representative-form-step --> form-control-text
-  justifi-business-representative-form-step --> form-control-number-masked
-  justifi-business-representative-form-step --> form-control-date
-  justifi-business-representative-form-step --> justifi-identity-address-form
+  justifi-business-representative-form-step-core --> form-control-text
+  justifi-business-representative-form-step-core --> form-control-number-masked
+  justifi-business-representative-form-step-core --> form-control-date
+  justifi-business-representative-form-step-core --> justifi-identity-address-form
   form-control-text --> form-control-help-text
   form-control-text --> form-control-error-text
   form-control-number-masked --> form-control-help-text
@@ -72,8 +74,8 @@ graph TD;
   justifi-identity-address-form --> form-control-select
   form-control-select --> form-control-help-text
   form-control-select --> form-control-error-text
-  justifi-payment-provisioning-form-steps --> justifi-business-representative-form-step
-  style justifi-business-representative-form-step fill:#f9f,stroke:#333,stroke-width:4px
+  justifi-business-representative-form-step --> justifi-business-representative-form-step-core
+  style justifi-business-representative-form-step-core fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
 ----------------------------------------------

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-inputs.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-inputs.tsx
@@ -1,0 +1,101 @@
+import { Component, h, Prop } from '@stencil/core';
+import { FormController } from '../../../form/form';
+import { updateAddressFormValues, updateDateOfBirthFormValues, updateFormValues } from '../../utils/input-handlers';
+import { PHONE_MASKS, SSN_MASK } from '../../../../utils/form-input-masks';
+
+@Component({
+  tag: 'justifi-business-representative-form-inputs',
+})
+export class RepresentativeFormInputs {
+  @Prop() representativeDefaultValue: any;
+  @Prop() errors: any;
+  @Prop() formController: FormController;
+
+  inputHandler = (name: string, value: string) => {
+    updateFormValues(this.formController, { [name]: value });
+  }
+
+  onAddressFormUpdate = (values: any): void => {
+    updateAddressFormValues(this.formController, {
+      ...this.formController.values.getValue().address,
+      ...values,
+    });
+  }
+  
+  render() {
+    return (
+      <form>
+        <fieldset>
+          <legend>Representative</legend>
+          <hr />
+          <div class='row gy-3'>
+            <div class='col-12 col-md-8'>
+              <form-control-text
+                name='name'
+                label='Full Name'
+                defaultValue={this.representativeDefaultValue?.name}
+                errorText={this.errors.name}
+                inputHandler={this.inputHandler}
+              />
+            </div>
+            <div class='col-12 col-md-4'>
+              <form-control-text
+                name='title'
+                label='Title'
+                defaultValue={this.representativeDefaultValue?.title}
+                errorText={this.errors.title}
+                inputHandler={this.inputHandler}
+              />
+            </div>
+            <div class='col-12 col-md-6'>
+              <form-control-text
+                name='email'
+                label='Email Address'
+                defaultValue={this.representativeDefaultValue?.email}
+                errorText={this.errors.email}
+                inputHandler={this.inputHandler}
+              />
+            </div>
+            <div class='col-12 col-md-6'>
+              <form-control-number-masked
+                name='phone'
+                label='Phone Number'
+                defaultValue={this.representativeDefaultValue?.phone}
+                errorText={this.errors.phone}
+                inputHandler={this.inputHandler}
+                mask={PHONE_MASKS.US}
+              />
+            </div>
+            <div class='col-12 col-md-4'>
+              <form-control-date
+                name='dob_full'
+                label='Birth Date'
+                defaultValue={this.representativeDefaultValue?.dob_full}
+                errorText={this.errors.dob_full}
+                inputHandler={this.inputHandler}
+                onFormControlInput={(e) => updateDateOfBirthFormValues(e, this.formController)}
+              />
+            </div>
+            <div class='col-12 col-md-8'>
+              <form-control-number-masked
+                name='identification_number'
+                label='SSN'
+                defaultValue={this.representativeDefaultValue?.identification_number}
+                errorText={this.errors.identification_number}
+                inputHandler={this.inputHandler}
+                mask={SSN_MASK}
+              />
+            </div>
+            <div class='col-12'>
+              <justifi-identity-address-form
+                errors={this.errors.address}
+                defaultValues={this.representativeDefaultValue?.address}
+                handleFormUpdate={this.onAddressFormUpdate}
+              />
+            </div>
+          </div>
+        </fieldset>
+      </form>
+    );
+  }
+};

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
@@ -1,12 +1,10 @@
-import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
+import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { Identity, Representative } from '../../../../api/Identity';
 import { parseIdentityInfo } from '../../utils/payload-parsers';
 import { FormController } from '../../../form/form';
 import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import { identitySchema } from '../../schemas/business-identity-schema';
-import { PHONE_MASKS, SSN_MASK } from '../../../../utils/form-input-masks';
-import { updateAddressFormValues, updateDateOfBirthFormValues, updateFormValues } from '../../utils/input-handlers';
 
 @Component({
   tag: 'justifi-business-representative-form-step-core',
@@ -44,17 +42,6 @@ export class BusinessRepresentativeFormStepCore {
   componentDidLoad() {
     this.formController.errors.subscribe(errors => {
       this.errors = { ...errors };
-    });
-  }
-
-  inputHandler = (name: string, value: string) => {
-    updateFormValues(this.formController, { [name]: value });
-  }
-
-  onAddressFormUpdate = (values: any): void => {
-    updateAddressFormValues(this.formController, {
-      ...this.formController.values.getValue().address,
-      ...values,
     });
   }
 
@@ -101,84 +88,12 @@ export class BusinessRepresentativeFormStepCore {
   }
 
   render() {
-    const representativeDefaultValue =
-      this.formController.getInitialValues();
-
     return (
-      <Host exportparts='label,input,input-invalid'>
-        <form>
-          <fieldset>
-            <legend>Representative</legend>
-            <hr />
-            <div class='row gy-3'>
-              <div class='col-12 col-md-8'>
-                <form-control-text
-                  name='name'
-                  label='Full Name'
-                  defaultValue={representativeDefaultValue?.name}
-                  errorText={this.errors.name}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class='col-12 col-md-4'>
-                <form-control-text
-                  name='title'
-                  label='Title'
-                  defaultValue={representativeDefaultValue?.title}
-                  errorText={this.errors.title}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class='col-12 col-md-6'>
-                <form-control-text
-                  name='email'
-                  label='Email Address'
-                  defaultValue={representativeDefaultValue?.email}
-                  errorText={this.errors.email}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class='col-12 col-md-6'>
-                <form-control-number-masked
-                  name='phone'
-                  label='Phone Number'
-                  defaultValue={representativeDefaultValue?.phone}
-                  errorText={this.errors.phone}
-                  inputHandler={this.inputHandler}
-                  mask={PHONE_MASKS.US}
-                />
-              </div>
-              <div class='col-12 col-md-4'>
-                <form-control-date
-                  name='dob_full'
-                  label='Birth Date'
-                  defaultValue={representativeDefaultValue?.dob_full}
-                  errorText={this.errors.dob_full}
-                  inputHandler={this.inputHandler}
-                  onFormControlInput={(e) => updateDateOfBirthFormValues(e, this.formController)}
-                />
-              </div>
-              <div class='col-12 col-md-8'>
-                <form-control-number-masked
-                  name='identification_number'
-                  label='SSN'
-                  defaultValue={representativeDefaultValue?.identification_number}
-                  errorText={this.errors.identification_number}
-                  inputHandler={this.inputHandler}
-                  mask={SSN_MASK}
-                />
-              </div>
-              <div class='col-12'>
-                <justifi-identity-address-form
-                  errors={this.errors.address}
-                  defaultValues={representativeDefaultValue?.address}
-                  handleFormUpdate={this.onAddressFormUpdate}
-                />
-              </div>
-            </div>
-          </fieldset>
-        </form>
-      </Host>
+      <justifi-business-representative-form-inputs
+        representativeDefaultValue={this.formController.getInitialValues()}
+        errors={this.errors}
+        formController={this.formController}
+      />
     );
   }
 };

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
@@ -6,10 +6,10 @@ import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import { identitySchema } from '../../schemas/business-identity-schema';
 import { PHONE_MASKS, SSN_MASK } from '../../../../utils/form-input-masks';
-import { deconstructDate } from '../../utils/helpers';
+import { updateAddressFormValues, updateDateOfBirthFormValues, updateFormValues } from '../../utils/input-handlers';
 
 @Component({
-  tag: "justifi-business-representative-form-step-core",
+  tag: 'justifi-business-representative-form-step-core',
 })
 export class BusinessRepresentativeFormStepCore {
   @State() formController: FormController;
@@ -24,7 +24,7 @@ export class BusinessRepresentativeFormStepCore {
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
-  @Event({ eventName: "error-event", bubbles: true }) errorEvent: EventEmitter<ComponentError>;
+  @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
   @Method()
   async validateAndSubmit({ onSuccess }) {
@@ -47,33 +47,15 @@ export class BusinessRepresentativeFormStepCore {
     });
   }
 
-  onAddressFormUpdate = (values: any): void => {
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      address: {
-        ...this.formController.values.getValue().address,
-        ...values,
-      }
-    });
+  inputHandler = (name: string, value: string) => {
+    updateFormValues(this.formController, { [name]: value });
   }
 
-  onDateOfBirthUpdate = (event): void => {
-    if (event.detail === '') {
-      this.formController.setValues({
-        ...this.formController.values.getValue(),
-        dob_day: null,
-        dob_month: null,
-        dob_year: null,
-      });
-    } else {
-      const dob_values = deconstructDate(event.detail);
-      this.formController.setValues({
-        ...this.formController.values.getValue(),
-        dob_day: dob_values.dob_day,
-        dob_month: dob_values.dob_month,
-        dob_year: dob_values.dob_year,
-      });
-    }
+  onAddressFormUpdate = (values: any): void => {
+    updateAddressFormValues(this.formController, {
+      ...this.formController.values.getValue().address,
+      ...values,
+    });
   }
 
   private getData = () => {
@@ -115,13 +97,6 @@ export class BusinessRepresentativeFormStepCore {
         this.submitted.emit({ data: { submittedData } });
         this.formLoading.emit(false)
       }
-    });
-  }
-
-  inputHandler = (name: string, value: string) => {
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      [name]: value,
     });
   }
 
@@ -180,7 +155,7 @@ export class BusinessRepresentativeFormStepCore {
                   defaultValue={representativeDefaultValue?.dob_full}
                   errorText={this.errors.dob_full}
                   inputHandler={this.inputHandler}
-                  onFormControlInput={this.onDateOfBirthUpdate}
+                  onFormControlInput={(e) => updateDateOfBirthFormValues(e, this.formController)}
                 />
               </div>
               <div class='col-12 col-md-8'>
@@ -206,4 +181,4 @@ export class BusinessRepresentativeFormStepCore {
       </Host>
     );
   }
-}
+};

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
@@ -14,8 +14,6 @@ export class BusinessRepresentativeFormStepCore {
   @State() errors: any = {};
   @State() representative: Identity = {};
 
-  @Prop() authToken: string;
-  @Prop() businessId: string;
   @Prop() getBusiness: Function;
   @Prop() patchBusiness: Function;
   @Prop() allowOptionalFields?: boolean;

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
@@ -1,0 +1,209 @@
+import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
+import { Identity, Representative } from '../../../../api/Identity';
+import { parseIdentityInfo } from '../../utils/payload-parsers';
+import { FormController } from '../../../form/form';
+import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { ComponentError } from '../../../../api/ComponentError';
+import { identitySchema } from '../../schemas/business-identity-schema';
+import { PHONE_MASKS, SSN_MASK } from '../../../../utils/form-input-masks';
+import { deconstructDate } from '../../utils/helpers';
+
+@Component({
+  tag: "justifi-business-representative-form-step-core",
+})
+export class BusinessRepresentativeFormStepCore {
+  @State() formController: FormController;
+  @State() errors: any = {};
+  @State() representative: Identity = {};
+
+  @Prop() authToken: string;
+  @Prop() businessId: string;
+  @Prop() getBusiness: Function;
+  @Prop() patchBusiness: Function;
+  @Prop() allowOptionalFields?: boolean;
+
+  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
+  @Event({ eventName: "error-event", bubbles: true }) errorEvent: EventEmitter<ComponentError>;
+
+  @Method()
+  async validateAndSubmit({ onSuccess }) {
+    this.formController.validateAndSubmit(() => this.sendData(onSuccess));
+  }
+
+  get patchPayload() {
+    let formValues = parseIdentityInfo(this.formController.values.getValue());
+    return JSON.stringify({ representative: formValues });
+  }
+
+  componentWillLoad() {
+    this.getBusiness && this.getData();
+    this.formController = new FormController(identitySchema('representative', this.allowOptionalFields));
+  }
+
+  componentDidLoad() {
+    this.formController.errors.subscribe(errors => {
+      this.errors = { ...errors };
+    });
+  }
+
+  onAddressFormUpdate = (values: any): void => {
+    this.formController.setValues({
+      ...this.formController.values.getValue(),
+      address: {
+        ...this.formController.values.getValue().address,
+        ...values,
+      }
+    });
+  }
+
+  onDateOfBirthUpdate = (event): void => {
+    if (event.detail === '') {
+      this.formController.setValues({
+        ...this.formController.values.getValue(),
+        dob_day: null,
+        dob_month: null,
+        dob_year: null,
+      });
+    } else {
+      const dob_values = deconstructDate(event.detail);
+      this.formController.setValues({
+        ...this.formController.values.getValue(),
+        dob_day: dob_values.dob_day,
+        dob_month: dob_values.dob_month,
+        dob_year: dob_values.dob_year,
+      });
+    }
+  }
+
+  private getData = () => {
+    this.formLoading.emit(true);
+    this.getBusiness({
+      onSuccess: (response) => {
+        this.representative = new Representative(response.data.representative || {});
+        this.formController.setInitialValues({ ...this.representative });
+      },
+      onError: ({ error, code, severity }) => {
+        this.errorEvent.emit({
+          message: error,
+          errorCode: code,
+          severity: severity
+        });
+      },
+      final: () => this.formLoading.emit(false)
+    });
+  }
+
+  private sendData = (onSuccess: () => void) => {
+    let submittedData;
+    this.formLoading.emit(true);
+    this.patchBusiness({
+      payload: this.patchPayload,
+      onSuccess: (response) => {
+        submittedData = response;
+        onSuccess();
+      },
+      onError: ({ error, code, severity }) => {
+        submittedData = error;
+        this.errorEvent.emit({
+          message: error,
+          errorCode: code,
+          severity: severity
+        });
+      },
+      final: () => {
+        this.submitted.emit({ data: { submittedData } });
+        this.formLoading.emit(false)
+      }
+    });
+  }
+
+  inputHandler = (name: string, value: string) => {
+    this.formController.setValues({
+      ...this.formController.values.getValue(),
+      [name]: value,
+    });
+  }
+
+  render() {
+    const representativeDefaultValue =
+      this.formController.getInitialValues();
+
+    return (
+      <Host exportparts='label,input,input-invalid'>
+        <form>
+          <fieldset>
+            <legend>Representative</legend>
+            <hr />
+            <div class='row gy-3'>
+              <div class='col-12 col-md-8'>
+                <form-control-text
+                  name='name'
+                  label='Full Name'
+                  defaultValue={representativeDefaultValue?.name}
+                  errorText={this.errors.name}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class='col-12 col-md-4'>
+                <form-control-text
+                  name='title'
+                  label='Title'
+                  defaultValue={representativeDefaultValue?.title}
+                  errorText={this.errors.title}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class='col-12 col-md-6'>
+                <form-control-text
+                  name='email'
+                  label='Email Address'
+                  defaultValue={representativeDefaultValue?.email}
+                  errorText={this.errors.email}
+                  inputHandler={this.inputHandler}
+                />
+              </div>
+              <div class='col-12 col-md-6'>
+                <form-control-number-masked
+                  name='phone'
+                  label='Phone Number'
+                  defaultValue={representativeDefaultValue?.phone}
+                  errorText={this.errors.phone}
+                  inputHandler={this.inputHandler}
+                  mask={PHONE_MASKS.US}
+                />
+              </div>
+              <div class='col-12 col-md-4'>
+                <form-control-date
+                  name='dob_full'
+                  label='Birth Date'
+                  defaultValue={representativeDefaultValue?.dob_full}
+                  errorText={this.errors.dob_full}
+                  inputHandler={this.inputHandler}
+                  onFormControlInput={this.onDateOfBirthUpdate}
+                />
+              </div>
+              <div class='col-12 col-md-8'>
+                <form-control-number-masked
+                  name='identification_number'
+                  label='SSN'
+                  defaultValue={representativeDefaultValue?.identification_number}
+                  errorText={this.errors.identification_number}
+                  inputHandler={this.inputHandler}
+                  mask={SSN_MASK}
+                />
+              </div>
+              <div class='col-12'>
+                <justifi-identity-address-form
+                  errors={this.errors.address}
+                  defaultValues={representativeDefaultValue?.address}
+                  handleFormUpdate={this.onAddressFormUpdate}
+                />
+              </div>
+            </div>
+          </fieldset>
+        </form>
+      </Host>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -58,8 +58,6 @@ export class BusinessRepresentativeFormStep {
     return (
       <Host exportparts='label,input,input-invalid'>
         <justifi-business-representative-form-step-core 
-          authToken={this.authToken}
-          businessId={this.businessId}
           getBusiness={this.getBusiness}
           patchBusiness={this.patchBusiness}
           allowOptionalFields={this.allowOptionalFields}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -1,226 +1,69 @@
-import { Component, Host, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
-import { FormController } from '../../../form/form';
-import { PHONE_MASKS, SSN_MASK } from '../../../../utils/form-input-masks';
-import Api, { IApiResponse } from '../../../../api/Api';
-import { IBusiness } from '../../../../api/Business';
-import { parseIdentityInfo } from '../../utils/payload-parsers';
-import { identitySchema } from '../../schemas/business-identity-schema';
-import { config } from '../../../../../config';
-import { BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
-import { Representative } from '../../../../api/Identity';
-import { deconstructDate } from '../../utils/helpers';
+import { Component, h, Prop, State, Method, Event, EventEmitter, Watch } from '@stencil/core';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
-
+import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
+import { BusinessService } from '../../../../api/services/business.service';
 
 @Component({
   tag: 'justifi-business-representative-form-step'
 })
 export class BusinessRepresentativeFormStep {
-  @State() formController: FormController;
-  @State() errors: any = {};
-  @State() representative: Representative = {};
-  
+  coreComponent: HTMLJustifiBusinessRepresentativeFormStepCoreElement;
+
+  @State() getBusiness: Function;
+  @State() patchBusiness: Function;
+
   @Prop() authToken: string;
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean;
+
+  @Watch('authToken')
+  @Watch('businessId')
+  propChanged() {
+    this.initializeApi();
+  }
   
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
-
-  private api: any;
-
-  get businessEndpoint() {
-    return `entities/business/${this.businessId}`
-  }
-
-  private fetchData = async () => {
-    this.formLoading.emit(true);
-    try {
-      const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
-      this.representative = new Representative(response.data.representative || {});
-      this.formController.setInitialValues({ ...this.representative });
-    } catch (error) {
-      this.errorEvent.emit({
-        errorCode: ComponentErrorCodes.FETCH_ERROR,
-        message: error.message,
-        severity: ComponentErrorSeverity.ERROR,
-        data: error,
-      })
-    } finally {
-      this.formLoading.emit(false);
-    }
-  }
-
-  private sendData = async (onSuccess?: () => void) => {
-    this.formLoading.emit(true);
-    try {
-      const payload = parseIdentityInfo(this.formController.values.getValue());
-      const response = await this.api.patch(this.businessEndpoint, JSON.stringify({ representative: payload }));
-      this.handleResponse(response, onSuccess);
-    } catch (error) {
-      this.errorEvent.emit({
-        errorCode: ComponentErrorCodes.PATCH_ERROR,
-        message: error.message,
-        severity: ComponentErrorSeverity.ERROR,
-        data: error,
-      })
-    } finally {
-      this.formLoading.emit(false);
-    }
-  }
-
-  handleResponse(response, onSuccess) {
-    if (response.error) {
-      this.errorEvent.emit({
-        errorCode: ComponentErrorCodes.PATCH_ERROR,
-        message: response.error.message,
-        severity: ComponentErrorSeverity.ERROR,
-        data: response.error,
-      })
-    } else {
-      onSuccess();
-    }
-    this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.representative } });
-  }
 
   @Method()
   async validateAndSubmit({ onSuccess }) {
-    this.formController.validateAndSubmit(() => this.sendData(onSuccess));
-  };
+    this.coreComponent.validateAndSubmit({ onSuccess });
+  }
 
   componentWillLoad() {
-    this.formController = new FormController(identitySchema('representative', this.allowOptionalFields));
-    this.api = Api({ authToken: this.authToken, apiOrigin: config.proxyApiOrigin });
-    if (this.businessId && this.authToken) {
-      this.fetchData();
-    }
+    this.initializeApi();
   }
 
-  componentDidLoad() {
-    this.formController.errors.subscribe(
-      errors => (this.errors = { ...errors }),
-    );
-    this.formController.values.subscribe(
-      values => (this.representative = { ...values }),
-    );
-  }
-
-  inputHandler = (name: string, value: string) => {
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      [name]: value,
-    });
-  }
-
-  onAddressFormUpdate = (values: any): void => {
-    this.formController.setValues({
-      ...this.formController.values.getValue(),
-      address: {
-        ...this.formController.values.getValue().address,
-        ...values,
-      }
-    });
-  }
-
-  onDateOfBirthUpdate = (event): void => {
-    if (event.detail === '') {
-      this.formController.setValues({
-        ...this.formController.values.getValue(),
-        dob_day: null,
-        dob_month: null,
-        dob_year: null,
+  private initializeApi() {
+    if (this.authToken && this.businessId) {
+      this.getBusiness = makeGetBusiness({
+        authToken: this.authToken,
+        businessId: this.businessId,
+        service: new BusinessService()
+      });
+      this.patchBusiness = makePatchBusiness({
+        authToken: this.authToken,
+        businessId: this.businessId,
+        service: new BusinessService()
       });
     } else {
-      const dob_values = deconstructDate(event.detail);
-      this.formController.setValues({
-        ...this.formController.values.getValue(),
-        dob_day: dob_values.dob_day,
-        dob_month: dob_values.dob_month,
-        dob_year: dob_values.dob_year,
+      this.errorEvent.emit({
+        message: 'Missing required props',
+        errorCode: ComponentErrorCodes.MISSING_PROPS,
+        severity: ComponentErrorSeverity.ERROR,
       });
     }
   }
 
   render() {
-    const representativeDefaultValue =
-      this.formController.getInitialValues();
-
     return (
-      <Host exportparts='label,input,input-invalid'>
-        <form>
-          <fieldset>
-            <legend>Representative</legend>
-            <hr />
-            <div class='row gy-3'>
-              <div class='col-12 col-md-8'>
-                <form-control-text
-                  name='name'
-                  label='Full Name'
-                  defaultValue={representativeDefaultValue?.name}
-                  errorText={this.errors.name}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class='col-12 col-md-4'>
-                <form-control-text
-                  name='title'
-                  label='Title'
-                  defaultValue={representativeDefaultValue?.title}
-                  errorText={this.errors.title}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class='col-12 col-md-6'>
-                <form-control-text
-                  name='email'
-                  label='Email Address'
-                  defaultValue={representativeDefaultValue?.email}
-                  errorText={this.errors.email}
-                  inputHandler={this.inputHandler}
-                />
-              </div>
-              <div class='col-12 col-md-6'>
-                <form-control-number-masked
-                  name='phone'
-                  label='Phone Number'
-                  defaultValue={representativeDefaultValue?.phone}
-                  errorText={this.errors.phone}
-                  inputHandler={this.inputHandler}
-                  mask={PHONE_MASKS.US}
-                />
-              </div>
-              <div class='col-12 col-md-4'>
-                <form-control-date
-                  name='dob_full'
-                  label='Birth Date'
-                  defaultValue={representativeDefaultValue?.dob_full}
-                  errorText={this.errors.dob_full}
-                  inputHandler={this.inputHandler}
-                  onFormControlInput={this.onDateOfBirthUpdate}
-                />
-              </div>
-              <div class='col-12 col-md-8'>
-                <form-control-number-masked
-                  name='identification_number'
-                  label='SSN'
-                  defaultValue={representativeDefaultValue?.identification_number}
-                  errorText={this.errors.identification_number}
-                  inputHandler={this.inputHandler}
-                  mask={SSN_MASK}
-                />
-              </div>
-              <div class='col-12'>
-                <justifi-identity-address-form
-                  errors={this.errors.address}
-                  defaultValues={representativeDefaultValue?.address}
-                  handleFormUpdate={this.onAddressFormUpdate}
-                />
-              </div>
-            </div>
-          </fieldset>
-        </form>
-      </Host>
+      <justifi-business-representative-form-step-core 
+        authToken={this.authToken}
+        businessId={this.businessId}
+        getBusiness={this.getBusiness}
+        patchBusiness={this.patchBusiness}
+        allowOptionalFields={this.allowOptionalFields}
+        ref={el => this.coreComponent = el}
+      />
     );
   }
-}
+};

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, State, Method, Event, EventEmitter, Watch } from '@stencil/core';
+import { Component, Host, h, Prop, State, Method, Event, EventEmitter, Watch } from '@stencil/core';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
 import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
 import { BusinessService } from '../../../../api/services/business.service';
@@ -56,14 +56,16 @@ export class BusinessRepresentativeFormStep {
 
   render() {
     return (
-      <justifi-business-representative-form-step-core 
-        authToken={this.authToken}
-        businessId={this.businessId}
-        getBusiness={this.getBusiness}
-        patchBusiness={this.patchBusiness}
-        allowOptionalFields={this.allowOptionalFields}
-        ref={el => this.coreComponent = el}
-      />
+      <Host exportparts='label,input,input-invalid'>
+        <justifi-business-representative-form-step-core 
+          authToken={this.authToken}
+          businessId={this.businessId}
+          getBusiness={this.getBusiness}
+          patchBusiness={this.patchBusiness}
+          allowOptionalFields={this.allowOptionalFields}
+          ref={el => this.coreComponent = el}
+        />
+      </Host>
     );
   }
 };

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
@@ -40,7 +40,6 @@ export class PaymentProvisioningFormSteps {
       businessId={this.businessId}
       authToken={this.authToken}
       ref={(el) => this.refs[3] = el}
-      onFormLoading={this.handleFormLoading}
       allowOptionalFields={this.allowOptionalFields}
     />,
     4: () => <justifi-business-owners-form-step

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
@@ -72,10 +72,11 @@ graph TD;
   justifi-additional-questions-form-step-core --> form-control-text
   form-control-monetary --> form-control-help-text
   form-control-monetary --> form-control-error-text
-  justifi-business-representative-form-step --> form-control-text
-  justifi-business-representative-form-step --> form-control-number-masked
-  justifi-business-representative-form-step --> form-control-date
-  justifi-business-representative-form-step --> justifi-identity-address-form
+  justifi-business-representative-form-step --> justifi-business-representative-form-step-core
+  justifi-business-representative-form-step-core --> form-control-text
+  justifi-business-representative-form-step-core --> form-control-number-masked
+  justifi-business-representative-form-step-core --> form-control-date
+  justifi-business-representative-form-step-core --> justifi-identity-address-form
   justifi-identity-address-form --> form-control-text
   justifi-identity-address-form --> form-control-select
   justifi-business-owners-form-step --> justifi-owner-form

--- a/packages/webcomponents/src/components/form/readme.md
+++ b/packages/webcomponents/src/components/form/readme.md
@@ -46,7 +46,7 @@
  - [justifi-business-core-info](../business-forms/business-form/business-core-info)
  - [justifi-business-core-info-form-step-core](../business-forms/payment-provisioning/business-core-info)
  - [justifi-business-representative](../business-forms/business-form/business-representative)
- - [justifi-business-representative-form-step](../business-forms/payment-provisioning/business-representative)
+ - [justifi-business-representative-form-step-core](../business-forms/payment-provisioning/business-representative)
  - [justifi-identity-address-form](../business-forms/owner-form/identity-address)
  - [justifi-legal-address-form](../business-forms/business-form/legal-address-form)
  - [justifi-legal-address-form-step-core](../business-forms/payment-provisioning/legal-address-form)
@@ -70,7 +70,7 @@ graph TD;
   justifi-business-core-info --> form-control-text
   justifi-business-core-info-form-step-core --> form-control-text
   justifi-business-representative --> form-control-text
-  justifi-business-representative-form-step --> form-control-text
+  justifi-business-representative-form-step-core --> form-control-text
   justifi-identity-address-form --> form-control-text
   justifi-legal-address-form --> form-control-text
   justifi-legal-address-form-step-core --> form-control-text


### PR DESCRIPTION
### Refactor representative form step

This PR commits the following changes:

- Refactor Representative form step of PaymentProvisioning component to use core component structure
- Abstract form inputs to their own component file for additional tidiness and organization

Links
-----

Closes #616 

Developer considerations
--------------

- On any task
  - [x] Previous unit and e2e tests are passing
  - [x] Perform dev QA


Developer QA steps
--------------------

Ideally everything should function as it did before. This PR only changes the fourth form step, the Representative form, so you only need to test the fourth step for this PR. 

- [x] Unit tests are passing
- [x] Verify that data loads and fills properly for business with existing data
- [x] Verify that form validation is firing correctly if attempting to submit without completing required fields
- [x] Verify that data submits and patches business properly when required data is filled and user clicks `Next` button. 

