### PR TITLE
add analytics to insurance component

### DIFF
--- a/.changeset/many-hairs-grab.md
+++ b/.changeset/many-hairs-grab.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Sends data to analytics from season-interrption-insurance component

--- a/packages/webcomponents/src/components/insurance/season-interruption/season-interruption-insurance.tsx
+++ b/packages/webcomponents/src/components/insurance/season-interruption/season-interruption-insurance.tsx
@@ -2,6 +2,7 @@ import { Component, Event, EventEmitter, Method, Prop, State, h } from '@stencil
 import { InsuranceService } from '../../../api/services/insurance.service';
 import { makeGetQuote, makeToggleCoverage } from '../insurance-actions';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../../api/ComponentError';
+import JustifiAnalytics from '../../../api/Analytics';
 
 @Component({
   tag: 'justifi-season-interruption-insurance',
@@ -30,13 +31,20 @@ export class SeasonInterruptionInsurance {
 
   private seasonInterruptionCoreRef?: HTMLJustifiSeasonInterruptionInsuranceCoreElement;
 
+  analytics: JustifiAnalytics;
+
   @Method()
   async validate(): Promise<{ isValid: boolean }> {
     return this.seasonInterruptionCoreRef.validate();
   }
 
   componentWillLoad() {
+    this.analytics = new JustifiAnalytics(this);
     this.initializeServiceMethods();
+  }
+
+  disconnectedCallback() {
+    this.analytics.cleanup();
   }
 
   private initializeServiceMethods() {


### PR DESCRIPTION
This PR adds Analytics service on the Season Interruption Component

*. All other components are actually connected with Analytics and sending along the component name as expected.

Links
-----
#657 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [x]  Open the Season [Interruption Insurance component](http://localhost:6006/?path=/story/insurance-season-interruption-insurance--basic) and on the network tab should display the analytics request
- [x] The request should have the field `component_name` correctly sent in the payload

