### PR TITLE
fix style bug on Safari

### DIFF
--- a/.changeset/fluffy-spies-enjoy.md
+++ b/.changeset/fluffy-spies-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix Safari style bug on payment-method-form

--- a/packages/webcomponents/src/components/payment-method-form/payment-method-form.tsx
+++ b/packages/webcomponents/src/components/payment-method-form/payment-method-form.tsx
@@ -89,6 +89,7 @@ export class PaymentMethodForm {
 
     if (eventType === eventTypeMessage.ready) {
       this.paymentMethodFormReady.emit(data);
+      this.sendStyleOverrides();
     } else if (eventType === eventTypeMessage.tokenize) {
       this.paymentMethodFormTokenized.emit(data);
     } else if (eventType === eventTypeMessage.validate) {
@@ -132,7 +133,6 @@ export class PaymentMethodForm {
             iFrameResize({
               scrollbars: false,
             }, this.iframeElement);
-            this.sendStyleOverrides();
           }}
         ></iframe>
       </Host>

--- a/packages/webcomponents/src/components/payment-method-form/test/payment-method-form.spec.tsx
+++ b/packages/webcomponents/src/components/payment-method-form/test/payment-method-form.spec.tsx
@@ -157,6 +157,8 @@ describe('justifi-payment-method-form', () => {
         ),
       });
 
+      page.rootInstance.sendStyleOverrides = jest.fn();
+
       await page.waitForChanges();
 
       const eventSpy = jest.fn();


### PR DESCRIPTION
* In Safari, the `card-form` and `bank-account-form` components were attaching the `eventListener` too late to capture the `StyleOverrides` event. To fix this, the `sendStyleOverrides` call in the `payment-method-form` web component has been moved from the iframe's `onLoad` event to the `ready` event, which occurs later.

<img width="495" alt="image" src="https://github.com/user-attachments/assets/53d34f0a-c29e-4cac-97ec-536411a6e73b">


Links
-----
#678 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
[ ] - The card-form/bank-account-form should have the same styles as the billing-form and other inputs in the checkout on all browsers (in special Safari)

