### PR TITLE
Add New Payment ID Filter / optional api Origin prop for payments-list

### DIFF
--- a/.changeset/four-suns-search.md
+++ b/.changeset/four-suns-search.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Added `payment_id` search filter to table filter menu in `payments-list` component. Users may now filter the list down to a specific payment based on a provided `payment_id`. 

--- a/apps/docs/stories/utils/mockAllServices.ts
+++ b/apps/docs/stories/utils/mockAllServices.ts
@@ -136,6 +136,10 @@ export const mockAllServices = (config: MockAllServicesConfig = {}): void => {
 
       this.put(API_PATHS.BUSINESS_DOCUMENT_UPLOAD, () => null);
 
+      // URL Prefix for NPM Package Check
+      this.namespace = ''; // Reset the namespace to avoid prefixing with the primary URL prefix
+      this.urlPrefix = 'https://registry.npmjs.org';
+
       // Ensure all other requests not handled by Mirage are sent to the real network
       this.passthrough(...bypass);
 

--- a/packages/webcomponents/src/api/Payment.ts
+++ b/packages/webcomponents/src/api/Payment.ts
@@ -274,6 +274,7 @@ export interface IApplicationFee {
 }
 
 export interface PaymentsParams {
+  payment_id?: string;
   terminal_id?: string;
   payment_status?: PaymentStatuses;
   created_after?: string;

--- a/packages/webcomponents/src/api/services/payment.service.ts
+++ b/packages/webcomponents/src/api/services/payment.service.ts
@@ -5,7 +5,8 @@ export interface IPaymentService {
   fetchPayments(
     accountId: string,
     authToken: string,
-    params: any
+    params: any,
+    apiOrigin?: string
   ): Promise<IApiResponseCollection<IPayment[]>>;
   fetchPayment(
     paymentId: string,
@@ -17,9 +18,15 @@ export class PaymentService implements IPaymentService {
   async fetchPayments(
     accountId: string,
     authToken: string,
-    params: any
+    params: any,
+    apiOrigin?: string
   ): Promise<IApiResponseCollection<IPayment[]>> {
-    const api = Api({ authToken, apiOrigin: config.proxyApiOrigin });
+    
+    if (!apiOrigin) {
+      apiOrigin = config.proxyApiOrigin;
+    }
+
+    const api = Api({ authToken, apiOrigin: apiOrigin });
     const endpoint = `account/${accountId}/payments`;
     return api.get(endpoint, params);
   }

--- a/packages/webcomponents/src/components/payments-list/get-payments.ts
+++ b/packages/webcomponents/src/components/payments-list/get-payments.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayments =
-  ({ id, authToken, service }) =>
+  ({ id, authToken, service, apiOrigin }) =>
   async ({ params, onSuccess, onError }) => {
     try {
-      const response = await service.fetchPayments(id, authToken, params);
+      const response = await service.fetchPayments(id, authToken, params, apiOrigin);
 
       if (!response.error) {
         const pagingInfo = {

--- a/packages/webcomponents/src/components/payments-list/payments-list-filters.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-filters.tsx
@@ -33,6 +33,14 @@ export class PaymentsListFilters {
     return (
       <table-filters-menu params={this.params} clearParams={this.clearParams}>
         <div class="grid-cols-2 gap-3 p-1">
+        <div class="p-2">
+            <form-control-text 
+              name="payment_id"
+              label="Payment ID"
+              inputHandler={this.debouncedSetParamsOnChange}
+              defaultValue={this.params.payment_id}
+            />
+          </div>
           <div class="p-2">
             <form-control-text 
               name="terminal_id"

--- a/packages/webcomponents/src/components/payments-list/payments-list.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list.tsx
@@ -5,6 +5,7 @@ import { ErrorState } from '../details/utils';
 import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
 import JustifiAnalytics from '../../api/Analytics';
 import { checkPkgVersion } from '../../utils/check-pkg-version';
+import { config } from '../../../config';
 
 /**
   * @exportedPart label: Label for inputs
@@ -34,12 +35,13 @@ import { checkPkgVersion } from '../../utils/check-pkg-version';
 })
 
 export class PaymentsList {
-  @Prop() accountId: string;
-  @Prop() authToken: string;
-
   @State() getPayments: Function;
   @State() errorMessage: string = null;
-
+  
+  @Prop() accountId: string;
+  @Prop() authToken: string;
+  @Prop() apiOrigin?: string = config.proxyApiOrigin;
+  
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 
   analytics: JustifiAnalytics;
@@ -66,6 +68,7 @@ export class PaymentsList {
         id: this.accountId,
         authToken: this.authToken,
         service: new PaymentService(),
+        apiOrigin: this.apiOrigin,
       });
     } else {
       this.errorMessage = 'Account ID and Auth Token are required';

--- a/packages/webcomponents/src/components/payments-list/test/get-payments.spec.ts
+++ b/packages/webcomponents/src/components/payments-list/test/get-payments.spec.ts
@@ -10,6 +10,7 @@ describe('makeGetPayments', () => {
   const mockId = '123';
   const mockAuthToken = 'token';
   const mockParams = { limit: 10, page: 1 };
+  const mockApiOrigin = 'http://localhost:3000';
 
   let mockServiceInstance: jest.Mocked<PaymentService>;
 
@@ -36,6 +37,7 @@ describe('makeGetPayments', () => {
       id: mockId,
       authToken: mockAuthToken,
       service: mockServiceInstance,
+      apiOrigin: mockApiOrigin
     });
     await getPayments({ params: mockParams, onSuccess, onError });
 
@@ -61,6 +63,7 @@ describe('makeGetPayments', () => {
       id: mockId,
       authToken: mockAuthToken,
       service: mockServiceInstance,
+      apiOrigin: mockApiOrigin
     });
     await getPayments({ params: mockParams, onSuccess, onError });
 
@@ -84,6 +87,7 @@ describe('makeGetPayments', () => {
       id: mockId,
       authToken: mockAuthToken,
       service: mockServiceInstance,
+      apiOrigin: mockApiOrigin
     });
     await getPayments({ params: mockParams, onSuccess, onError });
 

--- a/packages/webcomponents/src/components/payments-list/test/payments-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/payments-list/test/payments-list-core.spec.tsx
@@ -23,7 +23,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService
+      service: mockPaymentsService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const page = await newSpecPage({
@@ -48,7 +49,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService
+      service: mockService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const page = await newSpecPage({
@@ -70,7 +72,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService
+      service: mockPaymentsService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const page = await newSpecPage({
@@ -98,7 +101,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService
+      service: mockPaymentsService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const page = await newSpecPage({
@@ -126,7 +130,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService
+      service: mockPaymentsService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const page = await newSpecPage({
@@ -169,7 +174,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService
+      service: mockPaymentsService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const page = await newSpecPage({
@@ -217,7 +223,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService
+      service: mockPaymentsService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const page = await newSpecPage({
@@ -245,7 +252,8 @@ describe('payments-list-core', () => {
     const getPayments = makeGetPayments({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService
+      service: mockService,
+      apiOrigin: 'http://localhost:3000'
     });
 
     const errorEvent = jest.fn();


### PR DESCRIPTION
### Add New Payment ID Filter / optional api Origin prop for payments-list

This PR commits the following changes:

- Add `payment_id` text search filter for payments-list-filters
- Add passthrough logic for package version check request to NPM when using mock data
- Add optional apiOrigin prop for payments-list component and associated requests

Links
-----

Closes #727 
Closes #728 



Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [x] `payments-list` component should work exactly the same if you don't pass an apiOrigin prop
- [x] `payments-list` component should use alternate apiOrigin if prop is passed
- [x] `payment_id` filter should return single payment to list that matches the id provided
- [x] building the app locally with mock data should no longer return a console error when NPM package version check request runs. should allow the request to pass through normally

