### PR TITLE
Remove CSS variables

### DIFF
--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -1,4 +1,54 @@
 const dark = `
+:root {
+  /* new vars */
+  --jfi-body-color: rgb(182, 190, 201);
+
+  /* general */
+  --jfi-load-google-font: 'Open Sans', sans-serif;
+
+  /* layout */
+  --jfi-layout-font-family: Arial, sans-serif;
+  --jfi-layout-padding: 20px;
+  --jfi-layout-form-control-spacing-x: 10px;
+  --jfi-layout-form-control-spacing-y: 10px;
+
+  /* form control */
+  --jfi-form-control-background-color: transparent;
+  --jfi-form-control-border-color: rgba(255, 255, 255, 0.7);
+  --jfi-form-control-border-color-focus: rgb(164, 201, 245);
+  --jfi-form-control-border-color-error: #FF785A;
+  --jfi-form-control-border-width: 1px;
+  --jfi-form-control-border-bottom-width: 1px;
+  --jfi-form-control-border-left-width: 1px;
+  --jfi-form-control-border-right-width: 1px;
+  --jfi-form-control-border-top-width: 1px;
+  --jfi-form-control-border-radius: 4px;
+  --jfi-form-control-border-style: solid;
+  --jfi-form-control-box-shadow: none;
+  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(255, 120, 90, 0.25);
+  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(255, 120, 90, 0.5);
+  --jfi-form-control-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
+  --jfi-form-control-color: rgba(255, 255, 255, 1);
+  --jfi-form-control-color-focus: rgba(255, 255, 255, 1);
+  --jfi-form-control-font-size: 1rem;
+  --jfi-form-control-font-weight: normal;
+  --jfi-form-control-line-height: 1.5;
+  --jfi-form-control-margin: 0;
+  --jfi-form-control-padding: 0.375rem 0.75rem;
+
+  /* form label */
+  --jfi-form-label-color: var(--jfi-body-color);
+  --jfi-form-label-font-family: Arial, sans-serif;
+  --jfi-form-label-font-size: 16px;
+  --jfi-form-label-font-weight: normal;
+  --jfi-form-label-margin: 0 0 0.5rem 0;
+
+  /* validation messages */
+  --jfi-error-message-color: #FF785A;
+  --jfi-error-message-margin: 5px;
+  --jfi-error-message-font-size: 12px;
+}
+
 body {
   background-color: #161616;
 }
@@ -333,63 +383,6 @@ justifi-payment-details {
 ::part(page-link):hover {
   cursor: pointer;
   text-decoration: underline;
-}
-
-:root {
-  /* new vars */
-  --jfi-body-color: rgb(182, 190, 201);
-  --jfi-header-color: #fff;
-  --jfi-header-border: 1px solid #fff;
-
-  /* general */
-  --jfi-load-google-font: 'Open Sans', sans-serif;
-
-  /* layout */
-  --jfi-layout-font-family: Arial, sans-serif;
-  --jfi-layout-padding: 20px;
-  --jfi-layout-form-control-spacing-x: 10px;
-  --jfi-layout-form-control-spacing-y: 10px;
-
-  /* form control */
-  --jfi-form-control-background-color: transparent;
-  --jfi-form-control-border-color: rgba(255, 255, 255, 0.7);
-  --jfi-form-control-border-color-focus: rgb(164, 201, 245);
-  --jfi-form-control-border-color-error: #FF785A;
-  --jfi-form-control-border-width: 1px;
-  --jfi-form-control-border-bottom-width: 1px;
-  --jfi-form-control-border-left-width: 1px;
-  --jfi-form-control-border-right-width: 1px;
-  --jfi-form-control-border-top-width: 1px;
-  --jfi-form-control-border-radius: 4px;
-  --jfi-form-control-border-style: solid;
-  --jfi-form-control-box-shadow: none;
-  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(255, 120, 90, 0.25);
-  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(255, 120, 90, 0.5);
-  --jfi-form-control-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
-  --jfi-form-control-color: rgba(255, 255, 255, 1);
-  --jfi-form-control-color-focus: rgba(255, 255, 255, 1);
-  --jfi-form-control-font-size: 1rem;
-  --jfi-form-control-font-weight: normal;
-  --jfi-form-control-line-height: 1.5;
-  --jfi-form-control-margin: 0;
-  --jfi-form-control-padding: 0.375rem 0.75rem;
-  --jfi-form-control-disabled-background-color: transparent;
-  --jfi-form-control-disabled-color: rgba(255, 255, 255, 0.5);
-
-  /* form label */
-  --jfi-form-label-color: var(--jfi-body-color);
-  --jfi-form-label-font-family: Arial, sans-serif;
-  --jfi-form-label-font-size: 16px;
-  --jfi-form-label-font-weight: normal;
-  --jfi-form-label-margin: 0 0 0.5rem 0;
-
-  /* validation messages */
-  --jfi-error-message-color: #FF785A;
-  --jfi-error-message-margin: 5px;
-  --jfi-error-message-font-size: 12px;
-
-  /* Skeleton */
-  --jfi-skeleton-wave-animation-bg: rgba(255, 255, 255, 0.1);
 }
 `;
 

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -1,4 +1,54 @@
 const light = `
+:root {
+  /* new vars */
+  --jfi-body-color: black;
+
+  /* general */
+  --jfi-load-google-font: 'Open Sans', sans-serif;
+
+  /* layout */
+  --jfi-layout-font-family: Arial, sans-serif;
+  --jfi-layout-padding: 20px;
+  --jfi-layout-form-control-spacing-x: 10px;
+  --jfi-layout-form-control-spacing-y: 10px;
+
+  /* form control */
+  --jfi-form-control-background-color: transparent;
+  --jfi-form-control-border-color: #555;
+  --jfi-form-control-border-color-focus: #333;
+  --jfi-form-control-border-color-error: rgb(138, 42, 35);
+  --jfi-form-control-border-width: 1px;
+  --jfi-form-control-border-bottom-width: 1px;
+  --jfi-form-control-border-left-width: 1px;  
+  --jfi-form-control-border-right-width: 1px;
+  --jfi-form-control-border-top-width: 1px;
+  --jfi-form-control-border-radius: 0;
+  --jfi-form-control-border-style: solid;
+  --jfi-form-control-box-shadow: none;
+  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
+  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(244, 67, 54, 0.4);
+  --jfi-form-control-box-shadow-focus: 0 0 0 0.25rem rgba(0, 0, 0, .25);
+  --jfi-form-control-color: var(--jfi-body-color);
+  --jfi-form-control-color-focus: var(--jfi-body-color);
+  --jfi-form-control-font-size: 1rem;
+  --jfi-form-control-font-weight: normal;
+  --jfi-form-control-line-height: 1.5;
+  --jfi-form-control-margin: 0;
+  --jfi-form-control-padding: 0.375rem 0.75rem;
+
+  /* form label */
+  --jfi-form-label-color: var(--jfi-body-color);
+  --jfi-form-label-font-family: Arial, sans-serif;
+  --jfi-form-label-font-size: 16px;
+  --jfi-form-label-font-weight: normal;
+  --jfi-form-label-margin: 0 0 0.5rem 0;
+
+  /* validation messages */
+  --jfi-error-message-color: rgb(138, 42, 35);
+  --jfi-error-message-margin: 8px 0 0 0;
+  --jfi-error-message-font-size: 12px;
+}
+
 body {
   background-color: #efefef;
 }
@@ -351,63 +401,6 @@ justifi-payouts-list::part(input-invalid) {
 ::part(page-link):hover {
   cursor: pointer;
   text-decoration: underline;
-}
-
-:root {
-  /* new vars */
-  --jfi-body-color: #333;
-  --jfi-header-color: #222;
-  --jfi-header-border: 1px solid #222;
-
-  /* general */
-  --jfi-load-google-font: 'Open Sans', sans-serif;
-
-  /* layout */
-  --jfi-layout-font-family: Arial, sans-serif;
-  --jfi-layout-padding: 20px;
-  --jfi-layout-form-control-spacing-x: 10px;
-  --jfi-layout-form-control-spacing-y: 10px;
-
-  /* form control */
-  --jfi-form-control-background-color: transparent;
-  --jfi-form-control-border-color: #555;
-  --jfi-form-control-border-color-focus: #333;
-  --jfi-form-control-border-color-error: rgb(138, 42, 35);
-  --jfi-form-control-border-width: 1px;
-  --jfi-form-control-border-bottom-width: 1px;
-  --jfi-form-control-border-left-width: 1px;  
-  --jfi-form-control-border-right-width: 1px;
-  --jfi-form-control-border-top-width: 1px;
-  --jfi-form-control-border-radius: 0;
-  --jfi-form-control-border-style: solid;
-  --jfi-form-control-box-shadow: none;
-  --jfi-form-control-box-shadow-error: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
-  --jfi-form-control-box-shadow-error-focus: 0 0 0 0.25rem rgba(244, 67, 54, 0.4);
-  --jfi-form-control-box-shadow-focus: 0 0 0 0.25rem rgba(0, 0, 0, .25);
-  --jfi-form-control-color: var(--jfi-body-color);
-  --jfi-form-control-color-focus: var(--jfi-body-color);
-  --jfi-form-control-font-size: 1rem;
-  --jfi-form-control-font-weight: normal;
-  --jfi-form-control-line-height: 1.5;
-  --jfi-form-control-margin: 0;
-  --jfi-form-control-padding: 0.375rem 0.75rem;
-  --jfi-form-control-disabled-background-color: transparent;
-  --jfi-form-control-disabled-color: rgba(255, 255, 255, 0.5);
-
-  /* form label */
-  --jfi-form-label-color: var(--jfi-body-color);
-  --jfi-form-label-font-family: Arial, sans-serif;
-  --jfi-form-label-font-size: 16px;
-  --jfi-form-label-font-weight: normal;
-  --jfi-form-label-margin: 0 0 0.5rem 0;
-
-  /* validation messages */
-  --jfi-error-message-color: rgb(138, 42, 35);
-  --jfi-error-message-margin: 8px 0 0 0;
-  --jfi-error-message-font-size: 12px;
-
-  /* Skeleton */
-  --jfi-skeleton-wave-animation-bg: rgba(200, 200, 200, 1);
 }
 `;
 

--- a/apps/docs/stories/utils/css-variables.tsx
+++ b/apps/docs/stories/utils/css-variables.tsx
@@ -15,9 +15,6 @@ export const CSSVars = () => (
   --jfi-layout-form-control-spacing-x
   --jfi-layout-form-control-spacing-y
 
-  /* colors */
-  --jfi-primary-color
-
   /* form control */
   --jfi-form-control-background-color
   --jfi-form-control-border-color
@@ -41,8 +38,6 @@ export const CSSVars = () => (
   --jfi-form-control-line-height
   --jfi-form-control-margin
   --jfi-form-control-padding
-  --jfi-form-control-disabled-background-color
-  --jfi-form-control-disabled-color
 
   /* form label */
   --jfi-form-label-color
@@ -56,54 +51,6 @@ export const CSSVars = () => (
   --jfi-error-message-margin
   --jfi-error-message-font-size
 
-  /* Below only used in justifi-payment-form */
-  /* form radio group */
-  --jfi-radio-button-color
-  --jfi-radio-button-background-color
-  --jfi-radio-button-color-selected
-  --jfi-radio-button-background-color-selected
-  --jfi-radio-button-border-color
-  --jfi-radio-button-border-color-selected
-  --jfi-radio-button-padding
-  --jfi-radio-button-font-size
-  --jfi-radio-button-color-hover
-  --jfi-radio-button-color-selected-hover
-  --jfi-radio-button-background-color-hover
-  --jfi-radio-button-background-color-selected-hover
-  --jfi-radio-button-border-color-selected-hover
-  --jfi-radio-button-border-color-hover
-  --jfi-radio-button-group-width
-
-  /* Below only used in justifi-checkout */
-  /* form radio input */
-  --jfi-radio-button-background-color
-  --jfi-radio-button-border-color
-  --jfi-radio-button-background-color-selected
-  --jfi-radio-button-border-color-selected
-  --jfi-radio-button-border-color-focus
-  --jfi-radio-button-box-shadow-focus
-
-  /* submit button */
-  --jfi-submit-button-color
-  --jfi-submit-button-background-color
-  --jfi-submit-button-border-color
-  --jfi-submit-button-padding
-  --jfi-submit-button-font-size
-  --jfi-submit-button-border-radius
-  --jfi-submit-button-color-hover
-  --jfi-submit-button-background-color-hover
-  --jfi-submit-button-border-color-hover
-  --jfi-submit-button-color-focus
-  --jfi-submit-button-background-color-focus
-  --jfi-submit-button-border-color-focus
-  --jfi-submit-button-color-active
-  --jfi-submit-button-background-color-active
-  --jfi-submit-button-border-color-active
-  --jfi-submit-button-width
-  --jfi-submit-button-box-shadow
-  --jfi-submit-button-color-loading
-  --jfi-submit-button-background-color-loading
-  --jfi-submit-button-border-color-loading
   `}
   />
 );
@@ -143,38 +90,4 @@ export const CSSVarsExample = `
   --jfi-error-message-color: #C12727;
   --jfi-error-message-margin: .25rem 0 0 0;
   --jfi-error-message-font-size: .875rem;
-
-  --jfi-submit-button-color: white;
-  --jfi-submit-button-background-color: #3F3F47;
-  --jfi-submit-button-border-color: var(--jfi-primary-color);
-  --jfi-submit-button-padding: 0.375rem 0.75rem;
-  --jfi-submit-button-font-size: 1rem;
-  --jfi-submit-button-border-radius: 1px;
-  --jfi-submit-button-color-hover: white;
-  --jfi-submit-button-background-color-hover: var(--jfi-primary-color);
-  --jfi-submit-button-border-color-hover: var(--jfi-primary-color);
-  --jfi-submit-button-color-focus: white;
-  --jfi-submit-button-background-color-focus: var(--jfi-primary-color);
-  --jfi-submit-button-border-color-focus: var(--jfi-primary-color);
-  --jfi-submit-button-color-active: white;
-  --jfi-submit-button-background-color-active: var(--jfi-primary-color);
-  --jfi-submit-button-border-color-active: var(--jfi-primary-color);
-  --jfi-submit-button-width: 100%;
-  --jfi-submit-button-box-shadow: rgba(0, 0, 0, 0.2) 0px 3px 1px -2px, rgba(0, 0, 0, 0.14) 0px 2px 2px 0px, rgba(0, 0, 0, 0.12) 0px 1px 5px 0px;
-
-  --jfi-radio-button-color: var(--jfi-primary-color);
-  --jfi-radio-button-background-color: transparent;
-  --jfi-radio-button-color-selected: white;
-  --jfi-radio-button-background-color-selected: var(--jfi-primary-color);
-  --jfi-radio-button-border-color: var(--jfi-primary-color);
-  --jfi-radio-button-border-color-selected: var(--jfi-primary-color);
-  --jfi-radio-button-padding: 0.375rem 0.75rem;
-  --jfi-radio-button-font-size: 1rem;
-  --jfi-radio-button-color-hover: var(--jfi-primary-color);
-  --jfi-radio-button-color-selected-hover: white;
-  --jfi-radio-button-background-color-hover: transparent;
-  --jfi-radio-button-background-color-selected-hover: var(--jfi-primary-color);
-  --jfi-radio-button-border-color-selected-hover: var(--jfi-primary-color);
-  --jfi-radio-button-border-color-hover: var(--jfi-primary-color);
-  --jfi-radio-button-group-width: 100%;
 `;

--- a/packages/webcomponents/src/components/checkout/payment-method-options.css
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.css
@@ -4,12 +4,12 @@
 
 .radio-list-item {
   cursor: pointer;
-  color: var(--jfi-radio-button-group-color);
-  background-color: var(--jfi-radio-button-group-background-color);
-  border-bottom: var(--jfi-radio-button-group-divider);
+  color: var(--bs-body-color);
+  background-color: transparent;
+  border-bottom: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
 }
 
 .radio-list-item:hover {
-  color: var(--jfi-radio-button-group-color-hover);
-  background-color: var(--jfi-radio-button-group-background-color-hover);
+  color: var(--bs-body-color);
+  background-color: var(--bs-gray-100);
 }

--- a/packages/webcomponents/src/components/checkout/readme.md
+++ b/packages/webcomponents/src/components/checkout/readme.md
@@ -79,10 +79,10 @@ Type: `Promise<PaymentMethodPayload>`
 
 ## Shadow Parts
 
-| Part                      | Description |
-| ------------------------- | ----------- |
-| `"payment-method-header"` |             |
-| `"radio-input-label"`     |             |
+| Part                  | Description |
+| --------------------- | ----------- |
+| `"radio-input-label"` |             |
+| `"radio-list-item"`   |             |
 
 
 ## Dependencies

--- a/packages/webcomponents/src/components/payments-list/test/__snapshots__/payments-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payments-list/test/__snapshots__/payments-list-core.spec.tsx.snap
@@ -11,8 +11,8 @@ exports[`payments-list-core displays an error state on failed data fetch 1`] = `
       <form-control-date label="End Date" name="created_before"></form-control-date>
     </div>
   </div>
-  <div class="table-wrapper">
-    <table class="table table-hover">
+  <div class="table-wrapper" part="table-wrapper">
+    <table class="table table-hover" part="table">
       <thead class="sticky-top table-head" part="table-head">
         <tr class="table-light text-nowrap" part="table-head-row">
           <th part="table-head-cell" scope="col" title="The date and time each payment was made">
@@ -93,8 +93,8 @@ exports[`payments-list-core renders properly with fetched data 1`] = `
       <form-control-date label="End Date" name="created_before"></form-control-date>
     </div>
   </div>
-  <div class="table-wrapper">
-    <table class="table table-hover">
+  <div class="table-wrapper" part="table-wrapper">
+    <table class="table table-hover" part="table">
       <thead class="sticky-top table-head" part="table-head">
         <tr class="table-light text-nowrap" part="table-head-row">
           <th part="table-head-cell" scope="col" title="The date and time each payment was made">

--- a/packages/webcomponents/src/components/payouts-list/test/__snapshots__/payouts-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payouts-list/test/__snapshots__/payouts-list-core.spec.tsx.snap
@@ -15,8 +15,8 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
       <form-control-date label="Date to:" name="created_before"></form-control-date>
     </div>
   </div>
-  <div class="table-wrapper">
-    <table class="table table-hover">
+  <div class="table-wrapper" part="table-wrapper">
+    <table class="table table-hover" part="table">
       <thead class="sticky-top table-head" part="table-head">
         <tr class="table-light text-nowrap" part="table-head-row">
           <th part="table-head-cell" scope="col" title="The date each transaction occurred">
@@ -113,8 +113,8 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
       <form-control-date label="Date to:" name="created_before"></form-control-date>
     </div>
   </div>
-  <div class="table-wrapper">
-    <table class="table table-hover">
+  <div class="table-wrapper" part="table-wrapper">
+    <table class="table table-hover" part="table">
       <thead class="sticky-top table-head" part="table-head">
         <tr class="table-light text-nowrap" part="table-head-row">
           <th part="table-head-cell" scope="col" title="The date each transaction occurred">

--- a/packages/webcomponents/src/styles/root.css
+++ b/packages/webcomponents/src/styles/root.css
@@ -125,14 +125,10 @@
 }
 
 :root {
-  --jfi-body-color: var(--bs-body-color);
-  --jfi-header-color: var(--bs-body-color);
-  --jfi-header-border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
   --jfi-layout-font-family: var(--bs-font-sans-serif);
   --jfi-layout-padding: 4px;
   --jfi-layout-form-control-spacing-x: 0.5rem;
   --jfi-layout-form-control-spacing-y: 1rem;
-  --jfi-primary-color: #0d6efd;
   --jfi-form-control-background-color: var(--bs-body-bg);
   --jfi-form-control-border-color: var(--bs-border-color);
   --jfi-form-control-border-color-focus: #86b7fe;
@@ -155,54 +151,6 @@
   --jfi-form-control-line-height: 1.5;
   --jfi-form-control-margin: 0;
   --jfi-form-control-padding: 0.375rem 0.75rem;
-  --jfi-radio-button-color: var(--jfi-primary-color);
-  --jfi-radio-button-background-color: transparent;
-  --jfi-radio-button-color-selected: white;
-  --jfi-radio-button-background-color-selected: var(--jfi-primary-color);
-  --jfi-radio-button-border-color: var(--jfi-form-control-border-color);
-  --jfi-radio-button-border-color-selected: var(--jfi-primary-color);
-  --jfi-radio-button-padding: 0.375rem 0.75rem;
-  --jfi-radio-button-font-size: 1rem;
-  --jfi-radio-button-color-hover: var(--jfi-primary-color);
-  --jfi-radio-button-color-selected-hover: white;
-  --jfi-radio-button-background-color-hover: transparent;
-  --jfi-radio-button-background-color-selected-hover: var(--jfi-primary-color);
-  --jfi-radio-button-border-color-selected-hover: var(--jfi-primary-color);
-  --jfi-radio-button-border-color-hover: var(--jfi-primary-color);
-  --jfi-radio-button-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
-  --jfi-radio-button-border-color-focus: #86b7fe;
-  --jfi-radio-button-group-color: var(--jfi-body-color);
-  --jfi-radio-button-group-color-hover: var(--jfi-body-color);
-  --jfi-radio-button-group-divider: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
-  --jfi-radio-button-group-background-color: transparent;
-  --jfi-radio-button-group-background-color-hover: var(--bs-gray-100);
-  --jfi-radio-input-box-shadow-focus: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
-  --jfi-radio-input-background-color-selected: #212529;
-  --jfi-radio-input-border-color: #6c757d;
-  --jfi-radio-input-border-color-selected: #212529;
-  --jfi-skeleton-wave-animation-bg: rgba(100, 100, 100, 0.6);
-  --jfi-submit-button-color: white;
-  --jfi-submit-button-background-color: var(--jfi-primary-color);
-  --jfi-submit-button-border-color: var(--jfi-primary-color);
-  --jfi-submit-button-padding: 0.375rem 0.75rem;
-  --jfi-submit-button-font-size: 1rem;
-  --jfi-submit-button-border-radius: 0.375rem;
-  --jfi-submit-button-color-hover: white;
-  --jfi-submit-button-background-color-hover: var(--jfi-primary-color);
-  --jfi-submit-button-border-color-hover: var(--jfi-primary-color);
-  --jfi-submit-button-color-focus: white;
-  --jfi-submit-button-background-color-focus: var(--jfi-primary-color);
-  --jfi-submit-button-border-color-focus: var(--jfi-primary-color);
-  --jfi-submit-button-color-active: white;
-  --jfi-submit-button-background-color-active: var(--jfi-primary-color);
-  --jfi-submit-button-border-color-active: var(--jfi-primary-color);
-  --jfi-submit-button-width: auto;
-  --jfi-submit-button-box-shadow: none;
-  --jfi-submit-button-color-loading: white;
-  --jfi-submit-button-background-color-loading: var(--jfi-primary-color);
-  --jfi-submit-button-border-color-loading: var(--jfi-primary-color);
-  --jfi-submit-button-line-height: 1.5;
-  --jfi-submit-button-text-transform: initial;
   --jfi-form-label-color: #212529;
   --jfi-form-label-font-family: var(--bs-font-sans-serif);
   --jfi-form-label-font-size: 1rem;
@@ -218,7 +166,7 @@
 /* Use CSS variables in CSS parts */
 
 ::part(skeleton) {
-  background-color: var(--jfi-skeleton-wave-animation-bg, #f5f5f5);
+  background-color: rgba(100, 100, 100, 0.6);
   animation: pulseAnimation 2s ease-in-out 0.5s infinite;
 }
 
@@ -314,49 +262,49 @@
 }
 
 ::part(button) {
-  border-radius: var(--jfi-submit-button-border-radius);
+  border-radius: 0.375rem;
 }
 
 ::part(button-primary) {
   font-family: var(--jfi-layout-font-family);
-  color: var(--jfi-submit-button-color);
-  background-color: var(--jfi-submit-button-background-color);
-  border-color: var(--jfi-submit-button-border-color);
-  padding: var(--jfi-submit-button-padding);
-  font-size: var(--jfi-submit-button-font-size);
-  border-radius: var(--jfi-submit-button-border-radius);
-  box-shadow: var(--jfi-submit-button-box-shadow);
+  color: white;
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  border-radius: 0.375rem;
+  box-shadow: none;
 }
 
 ::part(button-primary):hover {
-  color: var(--jfi-submit-button-color-hover);
-  background-color: var(--jfi-submit-button-background-color-hover);
-  border-color: var(--jfi-submit-button-border-color-hover);
+  color: white;
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
 }
 
 ::part(button-primary):focus {
-  color: var(--jfi-submit-button-color-focus);
-  background-color: var(--jfi-submit-button-background-color-focus);
-  border-color: var(--jfi-submit-button-border-color-focus);
+  color: white;
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
 }
 
 ::part(button-primary):active {
-  color: var(--jfi-submit-button-color-active);
-  background-color: var(--jfi-submit-button-background-color-active);
-  border-color: var(--jfi-submit-button-border-color-active);
+  color: white;
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
 }
 
 ::part(button-loading) {
   min-width: 75px;
-  color: var(--jfi-submit-button-color-loading);
-  background-color: var(--jfi-submit-button-background-color-loading);
-  border-color: var(--jfi-submit-button-border-color-loading);
+  color: white;
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
 }
 
 ::part(button-spinner) {
-  border-top-color: var(--jfi-submit-button-color-loading);
-  border-bottom-color: var(--jfi-submit-button-color-loading);
-  border-left-color: var(--jfi-submit-button-color-loading);
+  border-top-color: white;
+  border-bottom-color: var(--bs-primary);
+  border-left-color: var(--bs-primary);
 }
 
 .table-wrapper {


### PR DESCRIPTION
This PR commits the following changes: 

- Remove all CSS variables that are not used by the iframe-components.


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

