### PR TITLE
PaymentProvisioning - Add Tooltips and Refactor Labels

### DIFF
--- a/.changeset/cold-nails-judge.md
+++ b/.changeset/cold-nails-judge.md
@@ -1,0 +1,7 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Refactored several form input labels in `payment-provisioning` component
+- Optional fields now include `(optional)` in their form input labels
+- Added tooltips to several fields in the `payment-provisioning` component. Tooltips render as a bootstrap SVG icon that will display help text when hovered with a mouse.

--- a/packages/webcomponents/src/components/billing-form/readme.md
+++ b/packages/webcomponents/src/components/billing-form/readme.md
@@ -71,7 +71,7 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   justifi-new-payment-method --> justifi-billing-form
   justifi-payment-form --> justifi-billing-form

--- a/packages/webcomponents/src/components/business-forms/business-form/additional-questions/readme.md
+++ b/packages/webcomponents/src/components/business-forms/business-form/additional-questions/readme.md
@@ -32,11 +32,11 @@ graph TD;
   justifi-additional-questions --> form-control-text
   form-control-monetary --> form-control-help-text
   form-control-monetary --> form-control-error-text
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
+  form-control-tooltip --> custom-popper
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
-  form-control-tooltip --> custom-popper
   justifi-business-form --> justifi-additional-questions
   style justifi-additional-questions fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/webcomponents/src/components/business-forms/business-form/business-core-info/readme.md
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-core-info/readme.md
@@ -41,11 +41,11 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
-  form-control-number-masked --> form-control-help-text
+  form-control-number-masked --> form-control-tooltip
   form-control-number-masked --> form-control-error-text
   justifi-business-form --> justifi-business-core-info
   style justifi-business-core-info fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/business-form/business-representative/README.md
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-representative/README.md
@@ -35,13 +35,13 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-number-masked --> form-control-help-text
+  form-control-number-masked --> form-control-tooltip
   form-control-number-masked --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
   justifi-identity-address-form --> form-control-text
   justifi-identity-address-form --> form-control-select
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   justifi-business-form --> justifi-business-representative
   style justifi-business-representative fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/business-form/legal-address-form/readme.md
+++ b/packages/webcomponents/src/components/business-forms/business-form/legal-address-form/readme.md
@@ -31,7 +31,7 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   justifi-business-form --> justifi-legal-address-form
   style justifi-legal-address-form fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/business-form/readme.md
+++ b/packages/webcomponents/src/components/business-forms/business-form/readme.md
@@ -50,11 +50,11 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
-  form-control-number-masked --> form-control-help-text
+  form-control-number-masked --> form-control-tooltip
   form-control-number-masked --> form-control-error-text
   justifi-legal-address-form --> form-control-text
   justifi-legal-address-form --> form-control-select

--- a/packages/webcomponents/src/components/business-forms/owner-form/identity-address/identity-address-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/identity-address/identity-address-form.tsx
@@ -33,6 +33,7 @@ export class IdentityAddressForm {
               defaultValue={this.defaultValues?.line1}
               errorText={this.errors?.line1}
               inputHandler={this.inputHandler}
+              helpText="​​Enter your address exactly as stated on your driver's license. No PO Boxes."
             />
           </div>
           <div class="col-12 col-md-4">

--- a/packages/webcomponents/src/components/business-forms/owner-form/identity-address/readme.md
+++ b/packages/webcomponents/src/components/business-forms/owner-form/identity-address/readme.md
@@ -35,7 +35,7 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   justifi-business-representative --> justifi-identity-address-form
   justifi-business-representative-form-inputs --> justifi-identity-address-form

--- a/packages/webcomponents/src/components/business-forms/owner-form/identity-address/test/identity-address.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/identity-address/test/identity-address.spec.tsx
@@ -15,7 +15,7 @@ describe('identity-address', () => {
     <justifi-identity-address-form exportparts="label,input,input-invalid">
       <div class="row gy-3">
         <div class="col-12 col-md-8">
-          <form-control-text label="Street Address" name="line1"></form-control-text>
+          <form-control-text helptext="​​Enter your address exactly as stated on your driver's license. No PO Boxes." label="Street Address" name="line1"></form-control-text>
         </div>
 
         <div class="col-12 col-md-4">
@@ -63,7 +63,7 @@ describe('identity-address', () => {
     <justifi-identity-address-form exportparts="label,input,input-invalid">
       <div class="gy-3 row">
         <div class="col-12 col-md-8">
-          <form-control-text defaultValue="Street 1" label="Street Address" name="line1"></form-control-text>
+          <form-control-text defaultvalue="Street 1" helptext="​​Enter your address exactly as stated on your driver's license. No PO Boxes." label="Street Address" name="line1"></form-control-text>        
         </div>
         <div class="col-12 col-md-4">
           <form-control-text defaultValue="Apartment 1" label="Apartment, Suite, etc. (optional)" name="line2"></form-control-text>

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form-inputs.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form-inputs.tsx
@@ -24,65 +24,68 @@ export class BusinessOwnerFormInputs {
   
   render() {
     return (
-      <div class='row gy-3'>
-        <div class='col-12 col-md-6'>
+      <div class="row gy-3">
+        <div class="col-12 col-md-6">
           <form-control-text
-            name='name'
-            label='Full Name'
+            name="name"
+            label="Full Name"
             defaultValue={this.ownerDefaultValue.name}
             errorText={this.errors.name}
             inputHandler={this.inputHandler}
           />
         </div>
-        <div class='col-12 col-md-4'>
+        <div class="col-12 col-md-4">
           <form-control-text
-            name='title'
-            label='Title'
+            name="title"
+            label="Title"
             defaultValue={this.ownerDefaultValue.title}
             errorText={this.errors.title}
             inputHandler={this.inputHandler}
+            helpText="Role at your business, e.g. President, CEO, Treasurer."
           />
         </div>
-        <div class='col-12 col-md-6'>
+        <div class="col-12 col-md-6">
           <form-control-text
-            name='email'
-            label='Email Address'
+            name="email"
+            label="Email Address"
             defaultValue={this.ownerDefaultValue.email}
             errorText={this.errors.email}
             inputHandler={this.inputHandler}
           />
         </div>
-        <div class='col-12 col-md-6'>
+        <div class="col-12 col-md-6">
           <form-control-number-masked
-            name='phone'
-            label='Phone Number'
+            name="phone"
+            label="Phone Number"
             defaultValue={this.ownerDefaultValue.phone}
             errorText={this.errors.phone}
             inputHandler={this.inputHandler}
             mask={PHONE_MASKS.US}
           />
         </div>
-        <div class='col-12 col-md-4'>
+        <div class="col-12 col-md-4">
           <form-control-date
-            name='dob_full'
-            label='Birth Date'
+            name="dob_full"
+            label="Birth Date"
             defaultValue={this.ownerDefaultValue.dob_full}
             errorText={this.errors.dob_full}
             inputHandler={this.inputHandler}
             onFormControlInput={(e) => updateDateOfBirthFormValues(e, this.formController)}
+            helpText="Must be 18 or older."
           />
         </div>
-        <div class='col-12 col-md-8'>
+        <div class="col-12 col-md-8">
           <form-control-number-masked
-            name='identification_number'
-            label={'SSN'}
+            name="identification_number"
+            label={"SSN"}
             defaultValue={this.ownerDefaultValue.identification_number}
             errorText={this.errors.identification_number}
             inputHandler={this.inputHandler}
             mask={SSN_MASK}
+            helpText="Enter your full Social Security Number. It is required for Federal OFAC check."
           />
         </div>
-        <div class='col-12'>
+        <div class="col-12">
           <justifi-identity-address-form
             errors={this.errors.address}
             defaultValues={this.ownerDefaultValue.address}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
@@ -94,78 +94,81 @@ export class AdditionalQuestionsFormStepCore {
   }
 
   render() {
-    const additionalQuestionsDefaultValue =
-      this.formController.getInitialValues();
+    const additionalQuestionsDefaultValue = this.formController.getInitialValues();
 
     return (
       <form>
         <fieldset>
-          <legend>Additional Questions</legend>
-          <hr />
-          <div class='row gy-3'>
-            <div class='col-12 col-md-6'>
+          <div class="d-flex align-items-center gap-2">
+            <legend class="mb-0">Additional Questions</legend>
+            <form-control-tooltip helpText="This information helps us understand the business and identify and monitor trends to safeguard you and your customers." />
+          </div>
+          <hr class="mt-2" />
+          <div class="row gy-3">
+            <div class="col-12 col-md-6">
               <form-control-monetary
-                name='business_revenue'
-                label='What is the business’ estimated annual revenue from its primary business activities?'
+                name="business_revenue"
+                label="What is your business’ estimated annual revenue from its primary business activities?"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_revenue}
                 defaultValue={additionalQuestionsDefaultValue?.business_revenue}
                 maskOptions={CURRENCY_MASK.WHOLE}
               />
             </div>
-            <div class='col-12 col-md-6'>
+            <div class="col-12 col-md-6">
               <form-control-monetary
-                name='business_payment_volume'
-                label="What is the business' annual credit card & ACH volume anticipated to process?"
+                name="business_payment_volume"
+                label="What is your business' annual credit card & ACH volume anticipated to process?"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_payment_volume}
                 defaultValue={additionalQuestionsDefaultValue?.business_payment_volume}
                 maskOptions={CURRENCY_MASK.WHOLE}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-select
-                name='business_when_service_received'
-                label='On average, how long after paying will your customers typically receive their goods or services?'
+                name="business_when_service_received"
+                label="On average, how long after paying will your customers typically receive their goods or services?"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_when_service_received}
                 options={businessServiceReceivedOptions}
                 defaultValue={additionalQuestionsDefaultValue?.business_when_service_received}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-select
-                name='business_recurring_payments'
-                label='Does your business offer recurring payments?'
+                name="business_recurring_payments"
+                label="Does your business offer recurring payments?"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_recurring_payments}
                 options={recurringPaymentsOptions}
                 defaultValue={additionalQuestionsDefaultValue?.business_recurring_payments}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-text
-                name='business_recurring_payments_percentage'
-                label='What percent of revenue is generated from each recurring payment type offered?'
+                name="business_recurring_payments_percentage"
+                label="What percent of revenue is generated from each recurring payment type offered?"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_recurring_payments_percentage}
                 defaultValue={additionalQuestionsDefaultValue?.business_recurring_payments_percentage}
+                helpText="For example: 50% monthly, 50% annual."
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-select
-                name='business_seasonal'
-                label='Is this business seasonal?'
+                name="business_seasonal"
+                label="Is this business seasonal?"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_seasonal}
                 options={seasonalBusinessOptions}
                 defaultValue={additionalQuestionsDefaultValue?.business_seasonal}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-text
-                name='business_other_payment_details'
-                label='Is there anything else you would like us to know about how your customers pay the business?'
+                name="business_other_payment_details"
+                label="Is there anything else you would like us to know about how your customers pay the business?"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_other_payment_details}
                 defaultValue={additionalQuestionsDefaultValue?.business_other_payment_details}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
@@ -168,7 +168,7 @@ export class AdditionalQuestionsFormStepCore {
             <div class="col-12">
               <form-control-text
                 name="business_other_payment_details"
-                label="Is there anything else you would like us to know about how your customers pay the business?"
+                label="Is there anything else you would like us to know about how your customers pay the business? (optional)"
                 inputHandler={this.inputHandler}
                 errorText={this.errors?.business_other_payment_details}
                 defaultValue={additionalQuestionsDefaultValue?.business_other_payment_details}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/readme.md
@@ -50,6 +50,7 @@ Type: `Promise<void>`
 
 ### Depends on
 
+- [form-control-tooltip](../../../form/form-helpers/form-control-tooltip)
 - [form-control-monetary](../../../form)
 - [form-control-select](../../../form)
 - [form-control-text](../../../form)
@@ -57,16 +58,17 @@ Type: `Promise<void>`
 ### Graph
 ```mermaid
 graph TD;
+  justifi-additional-questions-form-step-core --> form-control-tooltip
   justifi-additional-questions-form-step-core --> form-control-monetary
   justifi-additional-questions-form-step-core --> form-control-select
   justifi-additional-questions-form-step-core --> form-control-text
+  form-control-tooltip --> custom-popper
   form-control-monetary --> form-control-help-text
   form-control-monetary --> form-control-error-text
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
-  form-control-tooltip --> custom-popper
   justifi-additional-questions-form-step --> justifi-additional-questions-form-step-core
   style justifi-additional-questions-form-step-core fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -141,8 +141,11 @@ export class BusinessBankAccountFormStep {
     return (
       <form>
         <fieldset>
-          <legend>Bank Account Info</legend>
-          <hr />
+          <div class="d-flex align-items-center gap-2">
+            <legend class="mb-0">Bank Account Info</legend>
+            <form-control-tooltip helpText="The Direct Deposit Account is the business bank account where your funds will be deposited. The name of this account must match the registered business name exactly. We are not able to accept personal accounts unless your business is a registered sole proprietorship." />
+          </div>
+          <hr class="mt-2" />
           <div class="row gy-3">
             <div class="col-12">
               <form-control-text
@@ -195,6 +198,7 @@ export class BusinessBankAccountFormStep {
                 inputHandler={this.inputHandler}
                 keyDownHandler={numberOnlyHandler}
                 disabled={this.formDisabled}
+                helpText="Please copy the account number as shown on your statement/check. Do not include spaces or dashes."
               />
             </div>
             <div class="col-12">
@@ -207,6 +211,7 @@ export class BusinessBankAccountFormStep {
                 inputHandler={this.inputHandler}
                 keyDownHandler={numberOnlyHandler}
                 disabled={this.formDisabled}
+                helpText="A valid routing number is nine digits. Please include any leading or trailing zeroes."
               />
             </div>
           </div>

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -170,7 +170,7 @@ export class BusinessCoreInfoFormStepCore {
             <div class="col-12">
               <form-control-text
                 name="website_url"
-                label="Website URL"
+                label="Business Website URL"
                 defaultValue={coreInfoDefaultValue.website_url}
                 errorText={this.errors.website_url}
                 inputHandler={this.inputHandler}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -101,88 +101,95 @@ export class BusinessCoreInfoFormStepCore {
     return (
       <form>
         <fieldset>
-          <legend>General Info</legend>
-          <hr />
-          <div class='row gy-3'>
-            <div class='col-12'>
+          <div class="d-flex align-items-center gap-2">
+            <legend class="mb-0">Business Information</legend>
+          </div>
+          <hr class="mt-2" />
+          <div class="row gy-3">
+            <div class="col-12">
               <form-control-text
-                name='legal_name'
-                label='Legal Name'
+                name="legal_name"
+                label="Business Name"
                 defaultValue={coreInfoDefaultValue.legal_name}
                 errorText={this.errors.legal_name}
                 inputHandler={this.inputHandler}
+                helpText="Enter this exactly as it appears on your tax records (don't use acronyms or abbreviations unless you registered that way)."
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-text
-                name='doing_business_as'
-                label='Doing Business As (DBA)'
+                name="doing_business_as"
+                label="Doing Business As (DBA)"
                 defaultValue={coreInfoDefaultValue.doing_business_as}
                 errorText={this.errors.doing_business_as}
                 inputHandler={this.inputHandler}
+                helpText="Enter this exactly as it appears on your tax records (leave blank if you don't have a registered DBA/trade name)"
               />
             </div>
-            <div class='col-12 col-md-8'>
+            <div class="col-12 col-md-8">
               <form-control-select
-                name='classification'
-                label='Business Classification'
+                name="classification"
+                label="Business Classification"
                 options={businessClassificationOptions}
                 defaultValue={coreInfoDefaultValue.classification}
                 errorText={this.errors.classification}
                 inputHandler={this.inputHandler}
               />
             </div>
-            <div class='col-12 col-md-4'>
+            <div class="col-12 col-md-4">
               <form-control-date
-                name='date_of_incorporation'
-                label='Date of Incorporation'
+                name="date_of_incorporation"
+                label="Date of Incorporation"
                 defaultValue={coreInfoDefaultValue.date_of_incorporation}
                 errorText={this.errors.date_of_incorporation}
                 inputHandler={this.inputHandler}
               />
             </div>
-            <div class='col-12 col-md-6'>
+            <div class="col-12 col-md-6">
               <form-control-text
-                name='industry'
-                label='Industry'
+                name="industry"
+                label="Industry"
                 defaultValue={coreInfoDefaultValue.industry}
                 errorText={this.errors.industry}
                 inputHandler={this.inputHandler}
+                helpText="Describe what you sell"
               />
             </div>
-            <div class='col-12 col-md-6'>
+            <div class="col-12 col-md-6">
               <form-control-text
-                name='tax_id'
-                label='Tax ID (EIN or SSN)'
+                name="tax_id"
+                label="Tax ID (EIN or SSN)"
                 defaultValue={coreInfoDefaultValue.tax_id}
                 errorText={this.errors.tax_id}
                 inputHandler={this.inputHandler}
                 keyDownHandler={numberOnlyHandler}
                 maxLength={9}
+                helpText="Employer Identification Numbers (EINs) are nine digits. The federal tax identification number/EIN issued to you by the IRS. It can be found on your tax returns."
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-text
-                name='website_url'
-                label='Website URL'
+                name="website_url"
+                label="Website URL"
                 defaultValue={coreInfoDefaultValue.website_url}
                 errorText={this.errors.website_url}
                 inputHandler={this.inputHandler}
+                helpText="Don't have a live website? You can use your social media business page, app store link, or staging site URL."
               />
             </div>
-            <div class='col-12 col-md-6'>
+            <div class="col-12 col-md-6">
               <form-control-text
-                name='email'
-                label='Email Address'
+                name="email"
+                label="Business Email Address"
                 defaultValue={coreInfoDefaultValue.email}
                 errorText={this.errors.email}
                 inputHandler={this.inputHandler}
               />
             </div>
-            <div class='col-12 col-md-6'>
+            <div class="col-12 col-md-6">
               <form-control-number-masked
-                name='phone'
-                label='Phone Number'
+                name="phone"
+                label="Business Phone Number"
                 defaultValue={coreInfoDefaultValue.phone}
                 errorText={this.errors.phone}
                 inputHandler={this.inputHandler}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
@@ -66,11 +66,11 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
-  form-control-number-masked --> form-control-help-text
+  form-control-number-masked --> form-control-tooltip
   form-control-number-masked --> form-control-error-text
   justifi-business-core-info-form-step --> justifi-business-core-info-form-step-core
   style justifi-business-core-info-form-step-core fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
@@ -139,8 +139,11 @@ export class BusinessOwnersFormStepCore {
   render() {
     return (
       <div>
-        <legend>Owners</legend>
-        <hr />
+        <div class="d-flex align-items-center gap-2">
+          <legend class="mb-0">Owners</legend>
+          <form-control-tooltip helpText="For partnerships, LLCs or privately held corporations, the business is required to apply with all individuals with 25% or more ownership to the application. For charities and registered non-profits, the business is required to apply with 1 individual with substantial control over the entity; a board member or director." />
+        </div>
+        <hr class="mt-2" />
         <div class='row gy-3'>
           {this.ownersPayload.map((owner) => {
             return (

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
@@ -141,7 +141,7 @@ export class BusinessOwnersFormStepCore {
       <div>
         <div class="d-flex align-items-center gap-2">
           <legend class="mb-0">Owners</legend>
-          <form-control-tooltip helpText="For partnerships, LLCs or privately held corporations, the business is required to apply with all individuals with 25% or more ownership to the application. For charities and registered non-profits, the business is required to apply with 1 individual with substantial control over the entity; a board member or director." />
+          <form-control-tooltip helpText="For partnerships, LLCs or privately held corporations, the business is required to apply with all individuals with 25% or more ownership to the application. For charities and registered non-profits, the business is required to apply with 1 individual with substantial control over the entity, such as a board member or director." />
         </div>
         <hr class="mt-2" />
         <div class='row gy-3'>

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/readme.md
@@ -53,12 +53,15 @@ Type: `Promise<void>`
 
 ### Depends on
 
+- [form-control-tooltip](../../../form/form-helpers/form-control-tooltip)
 - [justifi-owner-form](../../owner-form)
 
 ### Graph
 ```mermaid
 graph TD;
+  justifi-business-owners-form-step-core --> form-control-tooltip
   justifi-business-owners-form-step-core --> justifi-owner-form
+  form-control-tooltip --> custom-popper
   justifi-owner-form --> owner-form-core
   owner-form-core --> owner-form-inputs
   owner-form-inputs --> form-control-text
@@ -67,14 +70,13 @@ graph TD;
   owner-form-inputs --> justifi-identity-address-form
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
-  form-control-tooltip --> custom-popper
-  form-control-number-masked --> form-control-help-text
+  form-control-number-masked --> form-control-tooltip
   form-control-number-masked --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
   justifi-identity-address-form --> form-control-text
   justifi-identity-address-form --> form-control-select
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   justifi-business-owners-form-step --> justifi-business-owners-form-step-core
   style justifi-business-owners-form-step-core fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
@@ -56,20 +56,21 @@ Type: `Promise<void>`
 ```mermaid
 graph TD;
   justifi-business-representative-form-step-core --> justifi-business-representative-form-inputs
+  justifi-business-representative-form-inputs --> form-control-tooltip
   justifi-business-representative-form-inputs --> form-control-text
   justifi-business-representative-form-inputs --> form-control-number-masked
   justifi-business-representative-form-inputs --> form-control-date
   justifi-business-representative-form-inputs --> justifi-identity-address-form
+  form-control-tooltip --> custom-popper
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
-  form-control-tooltip --> custom-popper
-  form-control-number-masked --> form-control-help-text
+  form-control-number-masked --> form-control-tooltip
   form-control-number-masked --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
   justifi-identity-address-form --> form-control-text
   justifi-identity-address-form --> form-control-select
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   justifi-business-representative-form-step --> justifi-business-representative-form-step-core
   style justifi-business-representative-form-step-core fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-inputs.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-inputs.tsx
@@ -26,67 +26,73 @@ export class RepresentativeFormInputs {
     return (
       <form>
         <fieldset>
-          <legend>Representative</legend>
-          <hr />
-          <div class='row gy-3'>
-            <div class='col-12 col-md-8'>
+          <div class="d-flex align-items-center gap-2">
+            <legend class="mb-0">Representative</legend>
+            <form-control-tooltip helpText="The representative for your business needs to be someone who has significant control over managing your business’s finance. You will have an opportunity to add owners later in the form." />
+          </div>
+          <hr class="mt-2" />
+          <div class="row gy-3">
+            <div class="col-12 col-md-8">
               <form-control-text
-                name='name'
-                label='Full Name'
+                name="name"
+                label="Full Name"
                 defaultValue={this.representativeDefaultValue?.name}
                 errorText={this.errors.name}
                 inputHandler={this.inputHandler}
               />
             </div>
-            <div class='col-12 col-md-4'>
+            <div class="col-12 col-md-4">
               <form-control-text
-                name='title'
-                label='Title'
+                name="title"
+                label="Title"
                 defaultValue={this.representativeDefaultValue?.title}
                 errorText={this.errors.title}
                 inputHandler={this.inputHandler}
+                helpText="Role at your business, e.g. President, CEO, Treasurer."
               />
             </div>
-            <div class='col-12 col-md-6'>
+            <div class="col-12 col-md-6">
               <form-control-text
-                name='email'
-                label='Email Address'
+                name="email"
+                label="Email Address"
                 defaultValue={this.representativeDefaultValue?.email}
                 errorText={this.errors.email}
                 inputHandler={this.inputHandler}
               />
             </div>
-            <div class='col-12 col-md-6'>
+            <div class="col-12 col-md-6">
               <form-control-number-masked
-                name='phone'
-                label='Phone Number'
+                name="phone"
+                label="Phone Number"
                 defaultValue={this.representativeDefaultValue?.phone}
                 errorText={this.errors.phone}
                 inputHandler={this.inputHandler}
                 mask={PHONE_MASKS.US}
               />
             </div>
-            <div class='col-12 col-md-4'>
+            <div class="col-12 col-md-4">
               <form-control-date
-                name='dob_full'
-                label='Birth Date'
+                name="dob_full"
+                label="Birth Date"
                 defaultValue={this.representativeDefaultValue?.dob_full}
                 errorText={this.errors.dob_full}
                 inputHandler={this.inputHandler}
                 onFormControlInput={(e) => updateDateOfBirthFormValues(e, this.formController)}
+                helpText="Must be 18 or older."
               />
             </div>
-            <div class='col-12 col-md-8'>
+            <div class="col-12 col-md-8">
               <form-control-number-masked
-                name='identification_number'
-                label='SSN'
+                name="identification_number"
+                label="SSN"
                 defaultValue={this.representativeDefaultValue?.identification_number}
                 errorText={this.errors.identification_number}
                 inputHandler={this.inputHandler}
                 mask={SSN_MASK}
+                helpText="Enter your full Social Security Number. It is required for Federal OFAC check."
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <justifi-identity-address-form
                 errors={this.errors.address}
                 defaultValues={this.representativeDefaultValue?.address}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -218,9 +218,11 @@ export class BusinessDocumentFormStep {
     return (
       <form>
         <fieldset>
-          <legend>Document Uploads</legend>
-          <p>Various file formats such as PDF, DOC, DOCX, JPEG, and others are accepted. Multiple files can be uploaded for each document category.</p>
-          <hr />
+          <div class="d-flex align-items-center gap-2">
+            <legend class="mb-0">Document Uploads</legend>
+            <form-control-tooltip helpText="Various file formats such as PDF, DOC, DOCX, JPEG, and others are accepted. Multiple files can be uploaded for each document category." />
+          </div>
+          <hr class="mt-2" />
           {this.documentsOnFile}
           <div class="d-flex flex-column">
             {this.formInputs}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
@@ -1,52 +1,52 @@
 import { EntityDocumentType } from "../../../../api/Document";
 
 const voidedCheck = {
-  name: 'voided_check',
-  label: 'Upload Voided Check',
+  name: "voided_check",
+  label: "Upload Voided Check",
   documentType: EntityDocumentType.voidedCheck,
-  helpText: 'Please upload a voided check for the business.'
+  helpText: "Voided check or bank statement where the legal entity and account number are clearly visible. The check must match the legal entity registering for this merchant account."
 };
 
 const bankStatements = {
-  name: 'bank_statement',
-  label: 'Upload Bank Statements',
+  name: "bank_statement",
+  label: "Upload Bank Statements",
   documentType: EntityDocumentType.bankStatement,
-  helpText: 'Please upload 3 months of bank statements for the business.'
+  helpText: "The most recent 3 months of your business’ bank statements. The statements must match the legal entity registering for this merchant account."
 };
 
 const balanceSheet = {
-  name: 'balance_sheet',
-  label: 'Upload FYE Balance Sheet',
+  name: "balance_sheet",
+  label: "Upload FYE Balance Sheets",
   documentType: EntityDocumentType.balanceSheet,
-  helpText: 'Please upload the most recent 2 years of balance sheets.'
+  helpText: "Please provide the balance sheet that corresponds to the last day of your business' last two fiscal years. For example, 12/31/2022 & 12/31/2023 balance sheets."
 };
 
 const governmentId = {
-  name: 'government_id',
-  label: 'Upload Government ID',
+  name: "government_id",
+  label: "Upload Government ID",
   documentType: EntityDocumentType.governmentId,
-  helpText: 'Please upload a government issued ID for the business owner.'
+  helpText: "The ID must include a personal address."
 };
 
 const profitAndLossStatement = {
-  name: 'profit_and_loss_statement',
-  label: 'Upload Profit and Loss Statements',
+  name: "profit_and_loss_statement",
+  label: "Upload FYE Profit and Loss Statements",
   documentType: EntityDocumentType.profitAndLossStatement,
-  helpText: 'Please upload the most recent profit and loss statements.'
+  helpText: "Fiscal Year End Profit and Loss statements for your business’ last two fiscal years. For example, FYE 2022 and FYE 2023 profit and loss statements."
 };
 
 const ss4 = {
-  name: 'ss4',
-  label: 'Upload SS4 / Article of Incorporation',
+  name: "ss4",
+  label: "Upload SS4 / Article of Incorporation",
   documentType: EntityDocumentType.taxReturn,
   helpText: "Please upload the business's SS4 / Article of Incorporation."
 };
 
 const other = {
-  name: 'other',
-  label: 'Upload any other documents',
+  name: "other",
+  label: "Upload any other documents",
   documentType: EntityDocumentType.other,
-  helpText: 'Please upload any other documents that may be relevant to your business.'
+  helpText: "Please upload any other documents that may be relevant to your business."
 };
 
 export const inputConfigurations = {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
@@ -121,7 +121,6 @@ export class LegalAddressFormStepCore {
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.line2}
                 errorText={this.errors?.line2}
-    
               />
             </div>
             <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
@@ -94,57 +94,59 @@ export class LegalAddressFormStepCore {
   }
 
   render() {
-    const legalAddressDefaultValue =
-      this.formController.getInitialValues();
+    const legalAddressDefaultValue = this.formController.getInitialValues();
 
     return (
       <form>
         <fieldset>
-          <legend>Business Legal Address</legend>
-          <hr />
-          <div class='row gy-3'>
-            <div class='col-12'>
+          <div class="d-flex align-items-center gap-2">
+            <legend class="mb-0">Legal Address of your Business</legend>
+            <form-control-tooltip helpText="No PO Boxes." />
+          </div>
+          <hr class="mt-2" />
+          <div class="row gy-3">
+            <div class="col-12">
               <form-control-text
-                name='line1'
-                label='Legal Address'
+                name="line1"
+                label="Legal Address"
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.line1}
                 errorText={this.errors?.line1}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-text
-                name='line2'
-                label='Address Line 2'
+                name="line2"
+                label="Address Line 2 (optional)"
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.line2}
                 errorText={this.errors?.line2}
-
+    
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-text
-                name='city'
-                label='City'
+                name="city"
+                label="City"
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.city}
                 errorText={this.errors?.city}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-select
-                name='state'
-                label='State'
+                name="state"
+                label="State"
                 options={StateOptions}
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.state}
                 errorText={this.errors?.state}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-text
-                name='postal_code'
-                label='Postal Code'
+                name="postal_code"
+                label="Postal Code"
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.postal_code}
                 errorText={this.errors?.postal_code}
@@ -152,11 +154,11 @@ export class LegalAddressFormStepCore {
                 keyDownHandler={numberOnlyHandler}
               />
             </div>
-            <div class='col-12'>
+            <div class="col-12">
               <form-control-select
-                name='country'
-                label='Country'
-                options={[{ label: 'United States', value: 'USA' }]}
+                name="country"
+                label="Country"
+                options={[{ label: "United States", value: "USA" }]}
                 inputHandler={this.inputHandler}
                 defaultValue={legalAddressDefaultValue?.country}
                 errorText={this.errors?.country}
@@ -170,3 +172,4 @@ export class LegalAddressFormStepCore {
     );
   }
 }
+      

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/readme.md
@@ -50,18 +50,20 @@ Type: `Promise<void>`
 
 ### Depends on
 
+- [form-control-tooltip](../../../form/form-helpers/form-control-tooltip)
 - [form-control-text](../../../form)
 - [form-control-select](../../../form)
 
 ### Graph
 ```mermaid
 graph TD;
+  justifi-legal-address-form-step-core --> form-control-tooltip
   justifi-legal-address-form-step-core --> form-control-text
   justifi-legal-address-form-step-core --> form-control-select
+  form-control-tooltip --> custom-popper
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
-  form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
   justifi-legal-address-form-step --> justifi-legal-address-form-step-core
   style justifi-legal-address-form-step-core fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
@@ -58,16 +58,18 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
-  form-control-number-masked --> form-control-help-text
+  form-control-number-masked --> form-control-tooltip
   form-control-number-masked --> form-control-error-text
   justifi-legal-address-form-step --> justifi-legal-address-form-step-core
+  justifi-legal-address-form-step-core --> form-control-tooltip
   justifi-legal-address-form-step-core --> form-control-text
   justifi-legal-address-form-step-core --> form-control-select
   justifi-additional-questions-form-step --> justifi-additional-questions-form-step-core
+  justifi-additional-questions-form-step-core --> form-control-tooltip
   justifi-additional-questions-form-step-core --> form-control-monetary
   justifi-additional-questions-form-step-core --> form-control-select
   justifi-additional-questions-form-step-core --> form-control-text
@@ -75,6 +77,7 @@ graph TD;
   form-control-monetary --> form-control-error-text
   justifi-business-representative-form-step --> justifi-business-representative-form-step-core
   justifi-business-representative-form-step-core --> justifi-business-representative-form-inputs
+  justifi-business-representative-form-inputs --> form-control-tooltip
   justifi-business-representative-form-inputs --> form-control-text
   justifi-business-representative-form-inputs --> form-control-number-masked
   justifi-business-representative-form-inputs --> form-control-date
@@ -82,6 +85,7 @@ graph TD;
   justifi-identity-address-form --> form-control-text
   justifi-identity-address-form --> form-control-select
   justifi-business-owners-form-step --> justifi-business-owners-form-step-core
+  justifi-business-owners-form-step-core --> form-control-tooltip
   justifi-business-owners-form-step-core --> justifi-owner-form
   justifi-owner-form --> owner-form-core
   owner-form-core --> owner-form-inputs
@@ -89,10 +93,12 @@ graph TD;
   owner-form-inputs --> form-control-number-masked
   owner-form-inputs --> form-control-date
   owner-form-inputs --> justifi-identity-address-form
+  justifi-business-bank-account-form-step --> form-control-tooltip
   justifi-business-bank-account-form-step --> form-control-text
   justifi-business-bank-account-form-step --> form-control-select
   justifi-business-document-upload-form-step --> justifi-business-documents-on-file
   justifi-business-document-upload-form-step --> justifi-business-document-upload-input-group
+  justifi-business-document-upload-form-step --> form-control-tooltip
   justifi-business-document-upload-input-group --> form-control-file
   form-control-file --> form-control-tooltip
   form-control-file --> form-control-error-text

--- a/packages/webcomponents/src/components/form/form-control-date.tsx
+++ b/packages/webcomponents/src/components/form/form-control-date.tsx
@@ -48,22 +48,26 @@ export class DateInput {
   render() {
     return (
       <Host exportparts="label,input,input-invalid">
-        <label part="label" class="form-label" htmlFor={this.name}>
-          {this.label}
-        </label>
-        <input
-          type="date"
-          ref={el => (this.dateInput = el as HTMLInputElement)}
-          id={this.name}
-          name={this.name}
-          onBlur={this.formControlBlur.emit}
-          onInput={this.handleFormControlInput}
-          part={`input ${this.errorText && 'input-invalid'}`}
-          class={this.errorText ? 'form-control is-invalid' : 'form-control'}
-          disabled={this.disabled}
-        />
-        <form-control-help-text helpText={this.helpText} name={this.name} />
-        <form-control-error-text errorText={this.errorText} name={this.name} />     
+        <div class="form-group d-flex flex-column">
+          <div class="d-flex gap-2">
+            <label part="label" class="form-label" htmlFor={this.name}>
+              {this.label}
+            </label>
+            <form-control-tooltip helpText={this.helpText} />
+          </div>
+          <input
+            type="date"
+            ref={el => (this.dateInput = el as HTMLInputElement)}
+            id={this.name}
+            name={this.name}
+            onBlur={this.formControlBlur.emit}
+            onInput={this.handleFormControlInput}
+            part={`input ${this.errorText && 'input-invalid'}`}
+            class={this.errorText ? 'form-control is-invalid' : 'form-control'}
+            disabled={this.disabled}
+          />
+          <form-control-error-text errorText={this.errorText} name={this.name} />     
+        </div>
       </Host>
     );
   }

--- a/packages/webcomponents/src/components/form/form-control-file.tsx
+++ b/packages/webcomponents/src/components/form/form-control-file.tsx
@@ -58,7 +58,7 @@ export class FileInput {
     return (
       <Host exportparts="label,input,input-invalid">
         <div class="form-group d-flex flex-column">
-          <div class="d-flex gap-2">
+          <div class="d-flex align-items-start gap-2">
             <label part="label" class="form-label" htmlFor={this.name}>
               {this.label}
             </label>

--- a/packages/webcomponents/src/components/form/form-control-number-masked.tsx
+++ b/packages/webcomponents/src/components/form/form-control-number-masked.tsx
@@ -78,9 +78,12 @@ export class NumberInputMasked {
     return (
       <Host exportparts="label,input,input-invalid">
         <div class="form-group d-flex flex-column">
-          <label part="label" class="form-label" htmlFor={this.name}>
-            {this.label}
-          </label>
+          <div class="d-flex align-items-start gap-2">
+            <label part="label" class="form-label" htmlFor={this.name}>
+              {this.label}
+            </label>
+            <form-control-tooltip helpText={this.helpText} />
+          </div>
           <input
             ref={el => (this.textInput = el as HTMLInputElement)}
             id={this.name}
@@ -92,7 +95,6 @@ export class NumberInputMasked {
             type="text"
             disabled={this.disabled}
           />
-          <form-control-help-text helpText={this.helpText} name={this.name} />
           <form-control-error-text errorText={this.errorText} name={this.name} />
         </div>
       </Host>

--- a/packages/webcomponents/src/components/form/form-control-select.tsx
+++ b/packages/webcomponents/src/components/form/form-control-select.tsx
@@ -50,9 +50,12 @@ export class SelectInput {
     return (
       <Host exportparts="label,input,input-invalid">
         <div class="form-group d-flex flex-column">
-          <label part="label" class="form-label" htmlFor={this.name}>
-            {this.label}
-          </label>
+          <div class="d-flex align-items-start gap-2">
+            <label part="label" class="form-label" htmlFor={this.name}>
+              {this.label}
+            </label>
+            <form-control-tooltip helpText={this.helpText} />
+          </div>
           <select
             ref={el => (this.selectElement = el as HTMLSelectElement)}
             id={this.name}
@@ -67,7 +70,6 @@ export class SelectInput {
               <option value={option.value}>{option.label}</option>
             ))}
           </select>
-          <form-control-help-text helpText={this.helpText} name={this.name} />
           <form-control-error-text errorText={this.errorText} name={this.name} />
         </div>
       </Host>

--- a/packages/webcomponents/src/components/form/form-control-text.tsx
+++ b/packages/webcomponents/src/components/form/form-control-text.tsx
@@ -55,7 +55,7 @@ export class TextInput {
     return (
       <Host exportparts="label,input,input-invalid">
         <div class="form-group d-flex flex-column">
-          <div class="d-flex gap-2">
+          <div class="d-flex align-items-start gap-2">
             <label part="label" class="form-label" htmlFor={this.name}>
               {this.label}
             </label>

--- a/packages/webcomponents/src/components/form/form-helpers/form-control-tooltip/form-control-tooltip.tsx
+++ b/packages/webcomponents/src/components/form/form-helpers/form-control-tooltip/form-control-tooltip.tsx
@@ -31,7 +31,7 @@ export class TooltipComponent {
             width="16"
             height="16"
             fill="currentColor"
-            class="bi bi-question-square"
+            class="bi bi-question-square tooltip-icon"
             viewBox="0 0 16 16"
             ref={(el) => (this.anchorIcon = el)}
             part="tooltip-icon"

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-date.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-date.spec.tsx.snap
@@ -2,30 +2,48 @@
 
 exports[`form-control-date Renders with all props provided 1`] = `
 <form-control-date exportparts="label,input,input-invalid">
-  <label class="form-label" htmlfor="birthday" part="label">
-    Birthday
-  </label>
-  <input class="form-control is-invalid" disabled="" id="birthday" name="birthday" part="input input-invalid" type="date" value="1990-01-01">
-  <form-control-help-text>
-    <small class="form-text text-muted" id="form-help-text-birthday">
-      Enter your birthday
-    </small>
-  </form-control-help-text>
-  <form-control-error-text>
-    <small class="form-text text-danger" id="form-error-text-birthday">
-      Invalid date
-    </small>
-  </form-control-error-text>
+  <div class="d-flex flex-column form-group">
+    <div class="d-flex gap-2">
+      <label class="form-label" htmlfor="birthday" part="label">
+        Birthday
+      </label>
+      <form-control-tooltip>
+        <div class="tooltip-container">
+          <svg class="bi bi-question-square tooltip-icon" fill="currentColor" height="16" part="tooltip-icon" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
+            <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286m1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94"></path>
+          </svg>
+          <custom-popper placement="top" trigger="hover">
+            <div class="bs-tooltip-top tooltip" part="tooltip" role="tooltip">
+              <div class="tooltip-inner" part="tooltip-inner">
+                Enter your birthday
+              </div>
+            </div>
+          </custom-popper>
+        </div>
+      </form-control-tooltip>
+    </div>
+    <input class="form-control is-invalid" disabled="" id="birthday" name="birthday" part="input input-invalid" type="date" value="1990-01-01">
+    <form-control-error-text>
+      <small class="form-text text-danger" id="form-error-text-birthday">
+        Invalid date
+      </small>
+    </form-control-error-text>
+  </div>
 </form-control-date>
 `;
 
 exports[`form-control-date Renders with default props 1`] = `
 <form-control-date exportparts="label,input,input-invalid">
-  <label class="form-label" htmlfor="birthday" part="label">
-    Birthday
-  </label>
-  <input class="form-control" id="birthday" name="birthday" part="input undefined" type="date" value="undefined">
-  <form-control-help-text></form-control-help-text>
-  <form-control-error-text></form-control-error-text>
+  <div class="d-flex flex-column form-group">
+    <div class="d-flex gap-2">
+      <label class="form-label" htmlfor="birthday" part="label">
+        Birthday
+      </label>
+      <form-control-tooltip></form-control-tooltip>
+    </div>
+    <input class="form-control" id="birthday" name="birthday" part="input undefined" type="date" value="undefined">
+    <form-control-error-text></form-control-error-text>
+  </div>
 </form-control-date>
 `;

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-file.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-file.spec.tsx.snap
@@ -3,13 +3,13 @@
 exports[`form-control-file Renders with all props provided 1`] = `
 <form-control-file exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <div class="d-flex gap-2">
+    <div class="align-items-start d-flex gap-2">
       <label class="form-label" htmlfor="resume" part="label">
         Resume
       </label>
       <form-control-tooltip>
         <div class="tooltip-container">
-          <svg class="bi bi-question-square" fill="currentColor" height="16" part="tooltip-icon" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+          <svg class="bi bi-question-square tooltip-icon" fill="currentColor" height="16" part="tooltip-icon" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
             <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
             <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286m1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94"></path>
           </svg>
@@ -36,7 +36,7 @@ exports[`form-control-file Renders with all props provided 1`] = `
 exports[`form-control-file Renders with default props 1`] = `
 <form-control-file exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <div class="d-flex gap-2">
+    <div class="align-items-start d-flex gap-2">
       <label class="form-label" htmlfor="profilePicture" part="label">
         Profile Picture
       </label>

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-number-masked.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-number-masked.spec.tsx.snap
@@ -3,15 +3,27 @@
 exports[`form-control-number-masked Renders with all props provided 1`] = `
 <form-control-number-masked exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <label class="form-label" htmlfor="age" part="label">
-      Age
-    </label>
+    <div class="align-items-start d-flex gap-2">
+      <label class="form-label" htmlfor="age" part="label">
+        Age
+      </label>
+      <form-control-tooltip>
+        <div class="tooltip-container">
+          <svg class="bi bi-question-square tooltip-icon" fill="currentColor" height="16" part="tooltip-icon" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
+            <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286m1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94"></path>
+          </svg>
+          <custom-popper placement="top" trigger="hover">
+            <div class="bs-tooltip-top tooltip" part="tooltip" role="tooltip">
+              <div class="tooltip-inner" part="tooltip-inner">
+                Enter your age
+              </div>
+            </div>
+          </custom-popper>
+        </div>
+      </form-control-tooltip>
+    </div>
     <input class="form-control is-invalid" disabled="" id="age" name="age" part="input input-invalid" type="text" value="25">
-    <form-control-help-text>
-      <small class="form-text text-muted" id="form-help-text-age">
-        Enter your age
-      </small>
-    </form-control-help-text>
     <form-control-error-text>
       <small class="form-text text-danger" id="form-error-text-age">
         Invalid age
@@ -24,11 +36,13 @@ exports[`form-control-number-masked Renders with all props provided 1`] = `
 exports[`form-control-number-masked Renders with default props 1`] = `
 <form-control-number-masked exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <label class="form-label" htmlfor="age" part="label">
-      Age
-    </label>
+    <div class="align-items-start d-flex gap-2">
+      <label class="form-label" htmlfor="age" part="label">
+        Age
+      </label>
+      <form-control-tooltip></form-control-tooltip>
+    </div>
     <input class="form-control" id="age" name="age" part="input undefined" type="text">
-    <form-control-help-text></form-control-help-text>
     <form-control-error-text></form-control-error-text>
   </div>
 </form-control-number-masked>

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-select.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-select.spec.tsx.snap
@@ -3,9 +3,26 @@
 exports[`form-control-select Renders with all props provided 1`] = `
 <form-control-select exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <label class="form-label" htmlfor="delivery_method" part="label">
-      Select your delivery method
-    </label>
+    <div class="align-items-start d-flex gap-2">
+      <label class="form-label" htmlfor="delivery_method" part="label">
+        Select your delivery method
+      </label>
+      <form-control-tooltip>
+        <div class="tooltip-container">
+          <svg class="bi bi-question-square tooltip-icon" fill="currentColor" height="16" part="tooltip-icon" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+            <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
+            <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286m1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94"></path>
+          </svg>
+          <custom-popper placement="top" trigger="hover">
+            <div class="bs-tooltip-top tooltip" part="tooltip" role="tooltip">
+              <div class="tooltip-inner" part="tooltip-inner">
+                Select your preferred delivery method
+              </div>
+            </div>
+          </custom-popper>
+        </div>
+      </form-control-tooltip>
+    </div>
     <select class="form-select is-invalid" disabled="" id="delivery_method" name="delivery_method" part="input input-invalid">
       <option value="pickup">
         Pickup
@@ -14,11 +31,6 @@ exports[`form-control-select Renders with all props provided 1`] = `
         Delivery
       </option>
     </select>
-    <form-control-help-text>
-      <small class="form-text text-muted" id="form-help-text-delivery_method">
-        Select your preferred delivery method
-      </small>
-    </form-control-help-text>
     <form-control-error-text>
       <small class="form-text text-danger" id="form-error-text-delivery_method">
         This field is required.
@@ -31,11 +43,13 @@ exports[`form-control-select Renders with all props provided 1`] = `
 exports[`form-control-select Renders with default props 1`] = `
 <form-control-select exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <label class="form-label" htmlfor="delivery_method" part="label">
-      Select your delivery method
-    </label>
+    <div class="align-items-start d-flex gap-2">
+      <label class="form-label" htmlfor="delivery_method" part="label">
+        Select your delivery method
+      </label>
+      <form-control-tooltip></form-control-tooltip>
+    </div>
     <select class="form-select" id="delivery_method" name="delivery_method" part="input "></select>
-    <form-control-help-text></form-control-help-text>
     <form-control-error-text></form-control-error-text>
   </div>
 </form-control-select>

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-text.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-text.spec.tsx.snap
@@ -3,13 +3,13 @@
 exports[`form-control-text Renders with all props provided 1`] = `
 <form-control-text exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <div class="d-flex gap-2">
+    <div class="align-items-start d-flex gap-2">
       <label class="form-label" htmlfor="email" part="label">
         Email
       </label>
       <form-control-tooltip>
         <div class="tooltip-container">
-          <svg class="bi bi-question-square" fill="currentColor" height="16" part="tooltip-icon" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
+          <svg class="bi bi-question-square tooltip-icon" fill="currentColor" height="16" part="tooltip-icon" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg">
             <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"></path>
             <path d="M5.255 5.786a.237.237 0 0 0 .241.247h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286m1.557 5.763c0 .533.425.927 1.01.927.609 0 1.028-.394 1.028-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94"></path>
           </svg>
@@ -36,7 +36,7 @@ exports[`form-control-text Renders with all props provided 1`] = `
 exports[`form-control-text Renders with default props 1`] = `
 <form-control-text exportparts="label,input,input-invalid">
   <div class="d-flex flex-column form-group">
-    <div class="d-flex gap-2">
+    <div class="align-items-start d-flex gap-2">
       <label class="form-label" htmlfor="username" part="label">
         Username
       </label>

--- a/packages/webcomponents/src/components/form/test/form-control-date.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-date.spec.tsx
@@ -2,10 +2,10 @@ import { h } from '@stencil/core';
 import { newSpecPage } from "@stencil/core/testing";
 import { DateInput } from "../form-control-date";
 import { FormControlErrorText } from '../form-helpers/form-control-error-text/form-control-error-text';
-import { FormControlHelpText } from '../form-helpers/form-control-help-text/form-control-help-text';
+import { TooltipComponent } from '../form-helpers/form-control-tooltip/form-control-tooltip';
 
 describe('form-control-date', () => {
-  const components = [DateInput, FormControlErrorText, FormControlHelpText];
+  const components = [DateInput, FormControlErrorText, TooltipComponent];
   const mockInputHandler = jest.fn();
 
   it('Renders with default props', async () => {
@@ -165,11 +165,17 @@ describe('form-control-date', () => {
         />
     });
 
-    const helpTextComponent = page.root.querySelector('form-control-help-text');
-    expect(helpTextComponent).not.toBeNull();
+    const tooltipComponent = page.root.querySelector('form-control-tooltip');
+    expect(tooltipComponent).not.toBeNull();
 
-    const helpText = helpTextComponent.querySelector('.text-muted');
-    expect(helpText.textContent).toBe('Select your date');
+    const tooltipIcon = tooltipComponent.querySelector('.bi-question-square');
+    expect(tooltipIcon).not.toBeNull();
+
+    const tooltipElement = tooltipComponent.querySelector('.tooltip');
+    expect(tooltipElement).not.toBeNull();
+
+    const tooltipText = tooltipElement.querySelector('.tooltip-inner');
+    expect(tooltipText.textContent).toBe('Select your date');
   });
 
   it('Shows error and applies error styling when error prop is provided', async () => {

--- a/packages/webcomponents/src/components/form/test/form-control-number-masked.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-number-masked.spec.tsx
@@ -2,10 +2,10 @@ import { h } from '@stencil/core';
 import { newSpecPage } from "@stencil/core/testing";
 import { NumberInputMasked } from "../form-control-number-masked";
 import { FormControlErrorText } from '../form-helpers/form-control-error-text/form-control-error-text';
-import { FormControlHelpText } from '../form-helpers/form-control-help-text/form-control-help-text';
+import { TooltipComponent } from '../form-helpers/form-control-tooltip/form-control-tooltip';
 
 describe('form-control-number-masked', () => {
-  const components = [NumberInputMasked, FormControlErrorText, FormControlHelpText];
+  const components = [NumberInputMasked, FormControlErrorText, TooltipComponent];
   const mockInputHandler = jest.fn();
 
   it('Renders with default props', async () => {
@@ -174,11 +174,17 @@ describe('form-control-number-masked', () => {
         />
     });
 
-    const helpTextComponent = page.root.querySelector('form-control-help-text');
-    expect(helpTextComponent).not.toBeNull();
+    const tooltipComponent = page.root.querySelector('form-control-tooltip');
+    expect(tooltipComponent).not.toBeNull();
 
-    const helpText = helpTextComponent.querySelector('.text-muted');
-    expect(helpText.textContent).toBe('Enter your age');
+    const tooltipIcon = tooltipComponent.querySelector('.bi-question-square');
+    expect(tooltipIcon).not.toBeNull();
+
+    const tooltipElement = tooltipComponent.querySelector('.tooltip');
+    expect(tooltipElement).not.toBeNull();
+
+    const tooltipText = tooltipElement.querySelector('.tooltip-inner');
+    expect(tooltipText.textContent).toBe('Enter your age');
   });
 
   it('Shows error and applies error styling when error prop is provided', async () => {

--- a/packages/webcomponents/src/components/form/test/form-control-select.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-select.spec.tsx
@@ -2,10 +2,10 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { SelectInput } from '../form-control-select';
 import { FormControlErrorText } from '../form-helpers/form-control-error-text/form-control-error-text';
-import { FormControlHelpText } from '../form-helpers/form-control-help-text/form-control-help-text';
+import { TooltipComponent } from '../form-helpers/form-control-tooltip/form-control-tooltip';
 
 describe('form-control-select', () => {
-  const components = [SelectInput, FormControlErrorText, FormControlHelpText];
+  const components = [SelectInput, FormControlErrorText, TooltipComponent];
   const mockInputHandler = jest.fn();
   const options = [
     { label: 'Pickup', value: 'pickup' },
@@ -189,11 +189,17 @@ describe('form-control-select', () => {
         />
     });
 
-    const helpTextComponent = page.root.querySelector('form-control-help-text');
-    expect(helpTextComponent).not.toBeNull();
+    const tooltipComponent = page.root.querySelector('form-control-tooltip');
+    expect(tooltipComponent).not.toBeNull();
 
-    const helpText = helpTextComponent.querySelector('.text-muted');
-    expect(helpText.textContent).toBe('Select your preferred delivery method');
+    const tooltipIcon = tooltipComponent.querySelector('.bi-question-square');
+    expect(tooltipIcon).not.toBeNull();
+
+    const tooltipElement = tooltipComponent.querySelector('.tooltip');
+    expect(tooltipElement).not.toBeNull();
+
+    const tooltipText = tooltipElement.querySelector('.tooltip-inner');
+    expect(tooltipText.textContent).toBe('Select your preferred delivery method');
   });
 
   it('Shows error and applies error styling when error prop is provided', async () => {

--- a/packages/webcomponents/src/components/payments-list/readme.md
+++ b/packages/webcomponents/src/components/payments-list/readme.md
@@ -38,9 +38,9 @@ graph TD;
   form-control-text --> form-control-tooltip
   form-control-text --> form-control-error-text
   form-control-tooltip --> custom-popper
-  form-control-select --> form-control-help-text
+  form-control-select --> form-control-tooltip
   form-control-select --> form-control-error-text
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
   payments-list-core --> payments-list-filters
   style payments-list-filters fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/payouts-list/readme.md
+++ b/packages/webcomponents/src/components/payouts-list/readme.md
@@ -49,8 +49,9 @@
 graph TD;
   payouts-list-core --> form-control-date
   payouts-list-core --> pagination-menu
-  form-control-date --> form-control-help-text
+  form-control-date --> form-control-tooltip
   form-control-date --> form-control-error-text
+  form-control-tooltip --> custom-popper
   justifi-payouts-list --> payouts-list-core
   style payouts-list-core fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/webcomponents/src/ui-components/styled-host/styled-host.css
+++ b/packages/webcomponents/src/ui-components/styled-host/styled-host.css
@@ -463,7 +463,8 @@ svg {
   vertical-align: middle;
 }
 
-svg.bi.bi-question-square {
+ /* vertical alignment rule for tooltip SVG  */
+svg.tooltip-icon {
   vertical-align: text-top;
 }
 


### PR DESCRIPTION
### PaymentProvisioning Tooltips, Label refactors

This PR commits the following changes:

- Adds tooltips to several inputs in PaymentProvisioning component. 
- Refactors some labels and section headers in PaymentProvisioning
- Updates spec tests and snapshots


Links
-----

Closes #717 
Closes #718 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing

Developer QA steps
--------------------

There is potentially a lot to review here - so please check the linked task for a complete list of requested changes.
[Refactor Labels and Help Text on PaymentProvisioning to use consistent language](https://github.com/justifi-tech/web-component-library/issues/718)

- [x] Test suites pass
- [x] Form should function exactly as before
- [x] Please help check for typos and spelling errors in new tooltips and refactored labels
- [x] Reference linked story above to help check for completion of specific refactor requests
- [x] The following fields should now have (optional) appended to their labels: 
  - [x] Step 2 - Address Line 2
  - [x] Step 3 - Is there anything else you would like us to know about how your customers pay the business? / Last input  
  - [x] Step 4 and 5 - Apartment, Suite, etc.

