### PR TITLE
Add form step completed event

### DIFF
--- a/.changeset/slimy-monkeys-sneeze.md
+++ b/.changeset/slimy-monkeys-sneeze.md
@@ -5,3 +5,4 @@
 - Added new event to `payment-provisioning` component: `form-step-completed`
   - This event will be emitted at the end of every form step in the `payment-provisioning` component. 
   - Event payload contains server response, as well as the name of the completed form step.
+- Noted optional fields in the `document_upload` step of the `payment-provisioning` component by adding `(optional)` to the input label. 

--- a/.changeset/slimy-monkeys-sneeze.md
+++ b/.changeset/slimy-monkeys-sneeze.md
@@ -1,0 +1,7 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Added new event to `payment-provisioning` component: `form-step-completed`
+  - This event will be emitted at the end of every form step in the `payment-provisioning` component. 
+  - Event payload contains server response, as well as the name of the completed form step.

--- a/apps/docs/stories/components/PaymentProvisioning/example.ts
+++ b/apps/docs/stories/components/PaymentProvisioning/example.ts
@@ -21,6 +21,14 @@ ${codeExampleHead('justifi-payment-provisioning')}
       console.log("server response received", data);
     });
 
+    paymentProvisioning.addEventListener("form-step-completed", (data) => {
+      /* this event is raised when a form step is completed */
+      let serverResponse = data.detail.data;
+      let completedFormStep = data.detail.formStep;
+      console.log("data from server", serverResponse);
+      console.log("completed form step", completedFormStep);
+    }
+
     paymentProvisioning.addEventListener("click-event", (data) => {
       let name = data.detail.name;
 

--- a/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
+++ b/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
@@ -58,10 +58,14 @@ const meta: Meta = {
       },
     },
     'form-step-completed': {
-      description: 'Emitted when a form step is completed. Contains data from server response. The name of the completed form step is defined in `data.detail.formStep`.',
+      description: "Emitted when a form step is completed. Contains data from that form step's server response. The name of the completed form step is defined in `data.detail.formStep`.",
       table: {
-        category: 'events'
-      }
+        category: 'events',
+        defaultValue: {
+          summary: "Example Payload",
+          detail: `{ data: serverResponse, formStep: 'legal_address' }`
+        },
+      },
     },
     "click-event": {
       description:

--- a/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
+++ b/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
@@ -57,6 +57,12 @@ const meta: Meta = {
         category: "events",
       },
     },
+    'step-completed': {
+      description: 'Emitted when a form step is completed.',
+      table: {
+        category: 'events'
+      }
+    },
     "click-event": {
       description:
         "Emitted when controls are clicked.  Control name is defined in `data.detail.name`.",
@@ -73,7 +79,7 @@ const meta: Meta = {
   },
   parameters: {
     actions: {
-      handles: ["submitted", "click-event", "error-event"],
+      handles: ["submitted", "step-completed", "click-event", "error-event"],
     },
     chromatic: {
       delay: 2000,

--- a/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
+++ b/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta = {
     },
     submitted: {
       description:
-        "Emitted when the server response is received.  Will not be raised if form vailidation fails.",
+        "Emitted when the server response is received.  Will not be raised if form vailidation fails. <br> **NOTE**: This event's behavior will be modified in the next major release to only emit at the final form step completion. Please use the `form-step-completed` event to manage completion of individual form steps.",
       table: {
         category: "events",
       },

--- a/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
+++ b/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
@@ -57,8 +57,8 @@ const meta: Meta = {
         category: "events",
       },
     },
-    'step-completed': {
-      description: 'Emitted when a form step is completed.',
+    'form-step-completed': {
+      description: 'Emitted when a form step is completed. Contains data from server response. The name of the completed form step is defined in `data.detail.formStep`.',
       table: {
         category: 'events'
       }
@@ -79,7 +79,7 @@ const meta: Meta = {
   },
   parameters: {
     actions: {
-      handles: ["submitted", "step-completed", "click-event", "error-event"],
+      handles: ["submitted", "form-step-completed", "click-event", "error-event"],
     },
     chromatic: {
       delay: 2000,

--- a/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
+++ b/apps/docs/stories/components/PaymentProvisioning/index.stories.tsx
@@ -58,7 +58,7 @@ const meta: Meta = {
       },
     },
     'form-step-completed': {
-      description: "Emitted when a form step is completed. Contains data from that form step's server response. The name of the completed form step is defined in `data.detail.formStep`.",
+      description: "Emitted when a form step is completed after the user clicks 'Next'. Contains data from that form step's server response. The name of the completed form step is defined in `data.detail.formStep`.",
       table: {
         category: 'events',
         defaultValue: {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
@@ -2,7 +2,7 @@ import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil
 import { additionalQuestionsSchema } from '../../schemas/business-additional-questions-schema';
 import { FormController } from '../../../form/form';
 import { AdditionalQuestions, IAdditionalQuestions } from '../../../../api/Business';
-import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../components';
 import { CURRENCY_MASK } from '../../../../utils/form-input-masks';
 import { businessServiceReceivedOptions, recurringPaymentsOptions, seasonalBusinessOptions } from '../../utils/business-form-options';
@@ -20,6 +20,7 @@ export class AdditionalQuestionsFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
@@ -81,6 +82,7 @@ export class AdditionalQuestionsFormStepCore {
       },
       final: () => {
         this.submitted.emit({ data: { submittedData } });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.additionalQuestions });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
@@ -20,7 +20,7 @@ export class AdditionalQuestionsFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/readme.md
@@ -16,11 +16,12 @@
 
 ## Events
 
-| Event         | Description | Type                                   |
-| ------------- | ----------- | -------------------------------------- |
-| `error-event` |             | `CustomEvent<ComponentError>`          |
-| `formLoading` |             | `CustomEvent<boolean>`                 |
-| `submitted`   |             | `CustomEvent<BusinessFormSubmitEvent>` |
+| Event                 | Description | Type                                          |
+| --------------------- | ----------- | --------------------------------------------- |
+| `error-event`         |             | `CustomEvent<ComponentError>`                 |
+| `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
+| `formLoading`         |             | `CustomEvent<boolean>`                        |
+| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -109,8 +109,12 @@ export class BusinessBankAccountFormStep {
 
   @Method()
   async validateAndSubmit({ onSuccess }) {
-    this.formDisabled ? onSuccess() :
+    if (this.formDisabled) {
+      this.stepCompleted.emit({ data: null, formStep: BusinessFormStepV2.bankAccount, metadata: 'no data submitted' });
+      onSuccess();
+    } else {
       this.formController.validateAndSubmit(() => this.sendData(onSuccess));
+    };
   };
 
   componentWillLoad() {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Event, EventEmitter, Method } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { businessBankAccountSchema } from '../../schemas/business-bank-account-schema';
 import { bankAccountTypeOptions } from '../../utils/business-form-options';
 import { Api, IApiResponse } from '../../../../api';
@@ -33,6 +33,7 @@ export class BusinessBankAccountFormStep {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
@@ -103,6 +104,7 @@ export class BusinessBankAccountFormStep {
       onSuccess();
     }
     this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.bankAccount } });
+    this.stepCompleted.emit({ data: response, formStep: BusinessFormStepV2.bankAccount });
   }
 
   @Method()

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -33,7 +33,7 @@ export class BusinessBankAccountFormStep {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -2,7 +2,7 @@ import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil
 import { businessCoreInfoSchema } from '../../schemas/business-core-info-schema';
 import { FormController } from '../../../form/form';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
-import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormSubmitEvent, BusinessFormStepV2 } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import { businessClassificationOptions } from '../../utils/business-form-options';
 import { PHONE_MASKS } from '../../../../utils/form-input-masks';
@@ -22,6 +22,7 @@ export class BusinessCoreInfoFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
@@ -83,6 +84,7 @@ export class BusinessCoreInfoFormStepCore {
       },
       final: () => {
         this.submitted.emit({ data: { submittedData } });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.businessInfo });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -22,7 +22,7 @@ export class BusinessCoreInfoFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
@@ -17,11 +17,12 @@
 
 ## Events
 
-| Event         | Description | Type                                   |
-| ------------- | ----------- | -------------------------------------- |
-| `error-event` |             | `CustomEvent<ComponentError>`          |
-| `formLoading` |             | `CustomEvent<boolean>`                 |
-| `submitted`   |             | `CustomEvent<BusinessFormSubmitEvent>` |
+| Event                 | Description | Type                                          |
+| --------------------- | ----------- | --------------------------------------------- |
+| `error-event`         |             | `CustomEvent<ComponentError>`                 |
+| `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
+| `formLoading`         |             | `CustomEvent<boolean>`                        |
+| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Event, EventEmitter, Method, Listen, Watch } from '@stencil/core';
 import { ComponentError } from '../../../../api/ComponentError';
-import { BusinessFormClickActions, BusinessFormClickEvent, BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormClickActions, BusinessFormClickEvent, BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { Button } from '../../../../ui-components';
 
 interface ownerPayloadItem { id: string; }
@@ -20,6 +20,7 @@ export class BusinessOwnersFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<BusinessFormClickEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -83,6 +84,7 @@ export class BusinessOwnersFormStepCore {
       },
       final: () => {
         this.submitted.emit({ data: submittedData, metadata: { completedStep: BusinessFormStep.owners } });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.owners });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
@@ -20,7 +20,7 @@ export class BusinessOwnersFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<BusinessFormClickEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/readme.md
@@ -18,12 +18,13 @@
 
 ## Events
 
-| Event         | Description | Type                                   |
-| ------------- | ----------- | -------------------------------------- |
-| `click-event` |             | `CustomEvent<BusinessFormClickEvent>`  |
-| `error-event` |             | `CustomEvent<ComponentError>`          |
-| `formLoading` |             | `CustomEvent<boolean>`                 |
-| `submitted`   |             | `CustomEvent<BusinessFormSubmitEvent>` |
+| Event                 | Description | Type                                          |
+| --------------------- | ----------- | --------------------------------------------- |
+| `click-event`         |             | `CustomEvent<BusinessFormClickEvent>`         |
+| `error-event`         |             | `CustomEvent<ComponentError>`                 |
+| `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
+| `formLoading`         |             | `CustomEvent<boolean>`                        |
+| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
@@ -16,11 +16,12 @@
 
 ## Events
 
-| Event         | Description | Type                                   |
-| ------------- | ----------- | -------------------------------------- |
-| `error-event` |             | `CustomEvent<ComponentError>`          |
-| `formLoading` |             | `CustomEvent<boolean>`                 |
-| `submitted`   |             | `CustomEvent<BusinessFormSubmitEvent>` |
+| Event                 | Description | Type                                          |
+| --------------------- | ----------- | --------------------------------------------- |
+| `error-event`         |             | `CustomEvent<ComponentError>`                 |
+| `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
+| `formLoading`         |             | `CustomEvent<boolean>`                        |
+| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
@@ -18,7 +18,7 @@ export class BusinessRepresentativeFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { Identity, Representative } from '../../../../api/Identity';
 import { FormController } from '../../../form/form';
-import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import { identitySchema } from '../../schemas/business-identity-schema';
 
@@ -18,6 +18,7 @@ export class BusinessRepresentativeFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
@@ -79,6 +80,7 @@ export class BusinessRepresentativeFormStepCore {
       },
       final: () => {
         this.submitted.emit({ data: { submittedData } });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.representative });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { Business, IBusiness } from '../../../../api/Business';
 import Api, { IApiResponse } from '../../../../api/Api';
 import { config } from '../../../../../config';
@@ -27,6 +27,7 @@ export class BusinessDocumentFormStep {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
@@ -140,6 +141,7 @@ export class BusinessDocumentFormStep {
       return false;
     } else {
       this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.documentUpload } });
+      this.stepCompleted.emit({ data: response, formStep: BusinessFormStepV2.documentUpload });
       return true;
     }
   }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -27,7 +27,7 @@ export class BusinessDocumentFormStep {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -157,6 +157,7 @@ export class BusinessDocumentFormStep {
     try {
       const docArray = Object.values(this.documentData).flat();
       if (!docArray.length) {
+        this.stepCompleted.emit({ data: null, formStep: BusinessFormStepV2.documentUpload, metadata: 'no data submitted' });
         return onSuccess();
       }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/input-configurations.ts
@@ -23,7 +23,7 @@ const balanceSheet = {
 
 const governmentId = {
   name: 'government_id',
-  label: 'Upload Government ID',
+  label: 'Upload Government ID (optional)',
   documentType: EntityDocumentType.governmentId,
   helpText: 'Please upload a government issued ID for the business owner.'
 };
@@ -37,14 +37,14 @@ const profitAndLossStatement = {
 
 const ss4 = {
   name: 'ss4',
-  label: 'Upload SS4 / Article of Incorporation',
+  label: 'Upload SS4 / Article of Incorporation (optional)',
   documentType: EntityDocumentType.taxReturn,
   helpText: "Please upload the business's SS4 / Article of Incorporation."
 };
 
 const other = {
   name: 'other',
-  label: 'Upload any other documents',
+  label: 'Upload any other documents (optional)',
   documentType: EntityDocumentType.other,
   helpText: 'Please upload any other documents that may be relevant to your business.'
 };

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
@@ -20,7 +20,7 @@ export class LegalAddressFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
@@ -2,7 +2,7 @@ import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil
 import { addressSchema } from '../../schemas/business-address-schema';
 import { FormController } from '../../../form/form';
 import { Address, IAddress } from '../../../../api/Business';
-import { BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import StateOptions from '../../../../utils/state-options';
 import { numberOnlyHandler } from '../../../form/utils';
@@ -20,6 +20,7 @@ export class LegalAddressFormStepCore {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
@@ -81,6 +82,7 @@ export class LegalAddressFormStepCore {
       },
       final: () => {
         this.submitted.emit({ data: { submittedData } });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.legalAddress });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/readme.md
@@ -16,11 +16,12 @@
 
 ## Events
 
-| Event         | Description | Type                                   |
-| ------------- | ----------- | -------------------------------------- |
-| `error-event` |             | `CustomEvent<ComponentError>`          |
-| `formLoading` |             | `CustomEvent<boolean>`                 |
-| `submitted`   |             | `CustomEvent<BusinessFormSubmitEvent>` |
+| Event                 | Description | Type                                          |
+| --------------------- | ----------- | --------------------------------------------- |
+| `error-event`         |             | `CustomEvent<ComponentError>`                 |
+| `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
+| `formLoading`         |             | `CustomEvent<boolean>`                        |
+| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../form/form';
-import { BusinessFormStep, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
 import { config } from '../../../../../config';
 import { businessTermsConditionsSchema } from '../../schemas/business-terms-conditions-schema';
 import { Api, IApiResponse } from '../../../../api';
@@ -20,6 +20,7 @@ export class BusinessTermsConditionsFormStep {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
+  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 
@@ -100,6 +101,7 @@ export class BusinessTermsConditionsFormStep {
       onSuccess();
     }
     this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.termsAndConditions } });
+    this.stepCompleted.emit({ data: response, formStep: BusinessFormStepV2.termsAndConditions });
   }
 
   @Method()

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
@@ -20,7 +20,7 @@ export class BusinessTermsConditionsFormStep {
   @Prop() allowOptionalFields?: boolean;
 
   @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ eventName: 'step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
+  @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
@@ -27,8 +27,8 @@ interface BusinessFormEventMetaData {
 
 export enum BusinessFormStep {
   coreInfo = 'coreInfo',
-  legalAddress = 'legal_address',
-  additionalQuestions = 'additional_questions',
+  legalAddress = 'legalAddress',
+  additionalQuestions = 'additionalQuestions',
   representative = 'representative',
   owners = 'owners',
   bankAccount = 'bankAccount',

--- a/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
@@ -16,6 +16,7 @@ export interface BusinessFormServerErrorEvent {
 export interface BusinessFormStepCompletedEvent {
   data: any;
   formStep: BusinessFormStepV2;
+  metadata?: any;
 }
 
 // For right now we can use MetaData to track the step that was just completed during a submit event. 

--- a/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
@@ -13,6 +13,11 @@ export interface BusinessFormServerErrorEvent {
   message: BusinessFormServerErrors;
 }
 
+export interface BusinessFormStepCompletedEvent {
+  data: any;
+  formStep: BusinessFormStepV2;
+}
+
 // For right now we can use MetaData to track the step that was just completed during a submit event. 
 // Eventually we can find other uses for MetaData to present to the implementer. 
 interface BusinessFormEventMetaData {
@@ -22,13 +27,24 @@ interface BusinessFormEventMetaData {
 
 export enum BusinessFormStep {
   coreInfo = 'coreInfo',
-  legalAddress = 'legalAddress',
-  additionalQuestions = 'additionalQuestions',
+  legalAddress = 'legal_address',
+  additionalQuestions = 'additional_questions',
   representative = 'representative',
   owners = 'owners',
   bankAccount = 'bankAccount',
   documentUpload = 'documentUpload',
   termsAndConditions = 'termsAndConditions'
+}
+
+export enum BusinessFormStepV2 {
+  businessInfo = 'business_info',
+  legalAddress = 'legal_address',
+  additionalQuestions = 'additional_questions',
+  representative = 'representative',
+  owners = 'owners',
+  bankAccount = 'bank_account',
+  documentUpload = 'document_upload',
+  termsAndConditions = 'terms_and_conditions'
 }
 
 export enum BusinessFormServerErrors {


### PR DESCRIPTION
### Add new event to payment-provisioning: `form-step-completed`

In our 5.x.x release, we plan to adjust the expected behavior and payload of our `submitted` event in the `payment-provisioning` component. We plan to update the behavior of `submitted` so that it is only emitted at the very end of the component form UI flow. This will bring its behavior in line with our other components that also emit a `submitted` event. 

This change will be considered a breaking change, which is why we are waiting until our 5.x.x release to commit this change. In the mean time, this PR begins preparing for this change by adding a new event to the `payment-provisioning` component: `form-step-completed`

This new event will be emitted alongside `submitted` for now, until we alter the `submitted` event's behavior to only emit at the very end of the form flow. 

The story documentation and example have been updated as well to reflect the new event. It is also captured on the storybook action panel to view in storybook when it is emitted. 


Links
-----

Closes #715 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [ ] Each step of the payment provisioning component should now emit `form-step-completed` event. 
  - [ ] `Event.detail.data` contains the server response from the form step
  - [ ] `Event.detail.formStep` contains the name of the completed form step
- [ ] New event documentation in storybook looks OK
- [ ] Example usage in storybook docs looks OK
