### PR TITLE
Add conditional render logic to recurring payments followup question

### DIFF
--- a/.changeset/eight-bottles-punch.md
+++ b/.changeset/eight-bottles-punch.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Implemented small conditional render logic to the `additional_questions` form step of the `payment-provisioning` component. 
+  - `business_recurring_payments_percentage` field is only shown if the value of `business_recurring_payments` === `Yes`

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
+import { Component, h, Prop, State, Method, Event, EventEmitter, Watch } from '@stencil/core';
 import { additionalQuestionsSchema } from '../../schemas/business-additional-questions-schema';
 import { FormController } from '../../../form/form';
 import { AdditionalQuestions, IAdditionalQuestions } from '../../../../api/Business';
@@ -14,6 +14,16 @@ export class AdditionalQuestionsFormStepCore {
   @State() formController: FormController;
   @State() errors: any = {};
   @State() additional_questions: IAdditionalQuestions = {};
+  @State() recurringPayments: boolean = false;
+
+  @Watch('additional_questions')
+  recurringPaymentsWatcher(newValue: any) {
+    if (newValue?.business_recurring_payments === 'Yes') {
+      this.recurringPayments = true;
+    } else {
+      this.recurringPayments = false;
+    }
+  } 
 
   @Prop() getBusiness: Function;
   @Prop() patchBusiness: Function;
@@ -91,6 +101,7 @@ export class AdditionalQuestionsFormStepCore {
       ...this.formController.values.getValue(),
       [name]: value,
     });
+    this.additional_questions = new AdditionalQuestions({ ...this.formController.values.getValue(), [name]: value });
   }
 
   render() {
@@ -143,7 +154,7 @@ export class AdditionalQuestionsFormStepCore {
                 defaultValue={additionalQuestionsDefaultValue?.business_recurring_payments}
               />
             </div>
-            <div class='col-12'>
+            <div class='col-12' hidden={!this.recurringPayments}>
               <form-control-text
                 name='business_recurring_payments_percentage'
                 label='What percent of revenue is generated from each recurring payment type offered?'


### PR DESCRIPTION
### Add conditional render logic to recurring payments followup question

This PR commits a relatively straightforward change:

- Conditionally render `business_recurring_payments_percentage` input field based on value of `business_recurring_payments` input. 

Links
-----

Closes #734 


Developer QA steps
--------------------

- [x] If `business_recurring_payments` value === 'Yes' - `business_recurring_payments_percentage` field is visible
- [x] If `business_recurring_payments` value === 'No' - `business_recurring_payments_percentage` field is hidden
- [x] Form can be completed as normal regardless of the option selected for recurring_payments
