### PR TITLE
Payments List Refactors

### DIFF
--- a/.changeset/perfect-mice-clap.md
+++ b/.changeset/perfect-mice-clap.md
@@ -1,0 +1,12 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Committed the following updates to the `payments-list` component:
+  - Removed `Payment ID` column
+  - Updated column name `Card Holder` to now say `Account Holder`
+  - Now showing currency type in `Amount` column
+  - Added `Type` column to show Card and ACH payments
+  - Changed wording of `Successful` payment status badge to `Succeeded`
+  - Added `Canceled` payment status badge for canceled payments
+  - Updated start and end date filter inputs to allow user to choose times, allowing for even more granular payment filtering

--- a/packages/webcomponents/src/api/Payment.ts
+++ b/packages/webcomponents/src/api/Payment.ts
@@ -16,6 +16,7 @@ export enum PaymentStatuses {
   authorized = 'authorized',
   succeeded = 'succeeded',
   failed = 'failed',
+  canceled = 'canceled',
   disputed = 'disputed',
   fully_refunded = 'fully_refunded',
   partially_refunded = 'partially_refunded',

--- a/packages/webcomponents/src/api/Payment.ts
+++ b/packages/webcomponents/src/api/Payment.ts
@@ -10,6 +10,12 @@ export enum PaymentMethodTypes {
   saved = 'saved',
 }
 
+export enum PaymentTypes {
+  card = 'Card',
+  bankAccount = 'ACH',
+  unknown = 'Unknown'
+}
+
 export enum PaymentStatuses {
   pending = 'pending',
   automatic = 'automatic',
@@ -250,6 +256,14 @@ export class Payment implements IPayment {
       return PaymentDisputedStatuses.lost;
     } else {
       return PaymentDisputedStatuses.open;
+    }
+  }
+
+  get paymentType(): PaymentTypes {
+    if (this.payment_method) {
+      return this.payment_method.card ? PaymentTypes.card : PaymentTypes.bankAccount;
+    } else {
+      return PaymentTypes.unknown;
     }
   }
 }

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form-inputs.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form-inputs.tsx
@@ -25,7 +25,7 @@ export class BusinessOwnerFormInputs {
   render() {
     return (
       <div class="row gy-3">
-        <div class="col-12 col-md-6">
+        <div class="col-12 col-md-8">
           <form-control-text
             name="name"
             label="Full Name"

--- a/packages/webcomponents/src/components/form/form-control-date.tsx
+++ b/packages/webcomponents/src/components/form/form-control-date.tsx
@@ -26,7 +26,11 @@ export class DateInput {
   
   @Watch('defaultValue')
   handleDefaultValueChange(newValue: string) {
-    this.updateInput(this.convertToStandardDate(newValue));
+    if (this.filterTimeZone) {
+      this.updateInput(this.convertToLocal(newValue));
+    } else {
+      this.updateInput(newValue);
+    }
   }
 
   @Event() formControlInput: EventEmitter<any>;
@@ -41,7 +45,11 @@ export class DateInput {
   }
 
   componentDidLoad() {
-    this.updateInput(this.convertToStandardDate(this.defaultValue));
+    if (this.filterTimeZone) {
+      this.updateInput(this.convertToLocal(this.defaultValue));
+    } else {
+      this.updateInput(this.defaultValue);
+    }
   }
   
   handleFormControlInput = (event: any) => {
@@ -67,7 +75,7 @@ export class DateInput {
     return new Date(dateObj.toUTCString()).toISOString();
   }
 
-  convertToStandardDate(value: string): string {
+  convertToLocal(value: string): string {
     if (!value) return value;
     const date = new Date(value);
   

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-date.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-date.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`form-control-date Renders with all props provided 1`] = `
         </div>
       </form-control-tooltip>
     </div>
-    <input class="form-control is-invalid" disabled="" id="birthday" name="birthday" part="input input-invalid" type="date" value="1990-01-01">
+    <input class="form-control is-invalid" disabled="" id="birthday" max="2024-11-07" name="birthday" part="input input-invalid" type="date" value="1990-01-01">
     <form-control-error-text>
       <small class="form-text text-danger" id="form-error-text-birthday">
         Invalid date
@@ -42,7 +42,7 @@ exports[`form-control-date Renders with default props 1`] = `
       </label>
       <form-control-tooltip></form-control-tooltip>
     </div>
-    <input class="form-control" id="birthday" name="birthday" part="input undefined" type="date" value="undefined">
+    <input class="form-control" id="birthday" max="2024-11-07" name="birthday" part="input undefined" type="date" value="undefined">
     <form-control-error-text></form-control-error-text>
   </div>
 </form-control-date>

--- a/packages/webcomponents/src/components/payment-details/test/__snapshots__/payment-details-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payment-details/test/__snapshots__/payment-details-core.spec.tsx.snap
@@ -30,7 +30,7 @@ exports[`payment-details-core it renders properly with fetched data 1`] = `
         </h1>
         <span slot="badge">
           <span class="badge bg-success" title="This payment was successfully captured">
-            Successful
+            Succeeded
           </span>
         </span>
       </div>
@@ -105,7 +105,7 @@ exports[`payment-details-core it renders properly with fetched data 1`] = `
           </span>
           <span class="d-table-cell flex-1 px-2 text-wrap" part="detail-section-item-data">
             <span class="badge bg-success" title="This payment was successfully captured">
-              Successful
+              Succeeded
             </span>
           </span>
         </div>

--- a/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
@@ -116,7 +116,7 @@ export class PaymentsListCore {
         type: 'inner',
         value: MapPaymentStatusToBadge(payment.status),
       },
-      'payment type!',
+      payment.paymentType,
       payment.description,
       payment.payment_method.payersName,
       payment.payment_method.lastFourDigits,

--- a/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
@@ -111,7 +111,7 @@ export class PaymentsListCore {
           <div class="fw-bold">${formatTime(payment.created_at)}</div>
         `,
       },
-      formatCurrency(payment.amount),
+      formatCurrency(payment.amount, true, true),
       {
         type: 'inner',
         value: MapPaymentStatusToBadge(payment.status),

--- a/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
@@ -92,13 +92,13 @@ export class PaymentsListCore {
 
   get columnData() {
     return [
-      ['Made On', 'The date and time each payment was made'],
+      ['Date', 'The date and time each payment was made'],
       ['Amount', 'The dollar amount of each payment'],
-      ['Description', 'The payment description, if you provided one'],
-      ['Cardholder', 'The name associated with the payment method'],
-      ['Payment Method', 'The brand and last 4 digits of the payment method'],
       ['Status', 'The current status of each payment'],
-      ['Payment ID', 'The unique identifier of each payment'],
+      ['Type', 'The type of each payment'],
+      ['Description', 'The payment description, if you provided one'],
+      ['Account Holder', 'The name associated with the payment method'],
+      ['Payment Method', 'The brand and last 4 digits of the payment method'],
     ];
   }
 
@@ -112,14 +112,14 @@ export class PaymentsListCore {
         `,
       },
       formatCurrency(payment.amount),
-      payment.description,
-      payment.payment_method.payersName,
-      payment.payment_method.lastFourDigits,
       {
         type: 'inner',
         value: MapPaymentStatusToBadge(payment.status),
       },
-      payment.id,
+      'payment type!',
+      payment.description,
+      payment.payment_method.payersName,
+      payment.payment_method.lastFourDigits,
     ]);
   }
 

--- a/packages/webcomponents/src/components/payments-list/payments-list-filters.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-filters.tsx
@@ -64,6 +64,8 @@ export class PaymentsListFilters {
               label="Start Date"
               inputHandler={this.setParamsOnChange}
               defaultValue={this.params.created_after}
+              showTime
+              filterTimeZone
             />
           </div>
           <div class="p-2">
@@ -72,6 +74,8 @@ export class PaymentsListFilters {
               label="End Date"
               inputHandler={this.setParamsOnChange}
               defaultValue={this.params.created_before}
+              showTime
+              filterTimeZone
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/payments-list/test/__snapshots__/payments-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payments-list/test/__snapshots__/payments-list-core.spec.tsx.snap
@@ -13,25 +13,25 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
       <thead class="sticky-top table-head" part="table-head">
         <tr class="table-light text-nowrap" part="table-head-row">
           <th part="table-head-cell" scope="col" title="The date and time each payment was made">
-            Made On
+            Date
           </th>
           <th part="table-head-cell" scope="col" title="The dollar amount of each payment">
             Amount
+          </th>
+          <th part="table-head-cell" scope="col" title="The current status of each payment">
+            Status
+          </th>
+          <th part="table-head-cell" scope="col" title="The type of each payment">
+            Type
           </th>
           <th part="table-head-cell" scope="col" title="The payment description, if you provided one">
             Description
           </th>
           <th part="table-head-cell" scope="col" title="The name associated with the payment method">
-            Cardholder
+            Account Holder
           </th>
           <th part="table-head-cell" scope="col" title="The brand and last 4 digits of the payment method">
             Payment Method
-          </th>
-          <th part="table-head-cell" scope="col" title="The current status of each payment">
-            Status
-          </th>
-          <th part="table-head-cell" scope="col" title="The unique identifier of each payment">
-            Payment ID
           </th>
         </tr>
       </thead>
@@ -92,25 +92,25 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
       <thead class="sticky-top table-head" part="table-head">
         <tr class="table-light text-nowrap" part="table-head-row">
           <th part="table-head-cell" scope="col" title="The date and time each payment was made">
-            Made On
+            Date
           </th>
           <th part="table-head-cell" scope="col" title="The dollar amount of each payment">
             Amount
+          </th>
+          <th part="table-head-cell" scope="col" title="The current status of each payment">
+            Status
+          </th>
+          <th part="table-head-cell" scope="col" title="The type of each payment">
+            Type
           </th>
           <th part="table-head-cell" scope="col" title="The payment description, if you provided one">
             Description
           </th>
           <th part="table-head-cell" scope="col" title="The name associated with the payment method">
-            Cardholder
+            Account Holder
           </th>
           <th part="table-head-cell" scope="col" title="The brand and last 4 digits of the payment method">
             Payment Method
-          </th>
-          <th part="table-head-cell" scope="col" title="The current status of each payment">
-            Status
-          </th>
-          <th part="table-head-cell" scope="col" title="The unique identifier of each payment">
-            Payment ID
           </th>
         </tr>
       </thead>
@@ -125,7 +125,15 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
             </div>
           </td>
           <td part="table-cell">
-            $234.56
+            $234.56 USD
+          </td>
+          <td part="table-cell">
+            <span class="badge bg-success" title="This payment was successfully captured">
+              Succeeded
+            </span>
+          </td>
+          <td part="table-cell">
+            Card
           </td>
           <td part="table-cell">
             payment
@@ -135,14 +143,6 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
           </td>
           <td part="table-cell">
             **** 1111
-          </td>
-          <td part="table-cell">
-            <span class="badge bg-success" title="This payment was successfully captured">
-              Successful
-            </span>
-          </td>
-          <td part="table-cell">
-            py_66NWqoIBi7xnPmqv9By5jD
           </td>
         </tr>
         <tr data-row-entity-id="py_4VPDyBwelwI9HjufbgwqZK" data-test-id="table-row" part="table-row table-row-even">
@@ -155,7 +155,15 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
             </div>
           </td>
           <td part="table-cell">
-            $234.56
+            $234.56 USD
+          </td>
+          <td part="table-cell">
+            <span class="badge bg-success" title="This payment was successfully captured">
+              Succeeded
+            </span>
+          </td>
+          <td part="table-cell">
+            Card
           </td>
           <td part="table-cell">
             payment
@@ -165,14 +173,6 @@ empty-state,pagination-bar,page-arrow,page-button,page-button-disabled,page-butt
           </td>
           <td part="table-cell">
             **** 1111
-          </td>
-          <td part="table-cell">
-            <span class="badge bg-success" title="This payment was successfully captured">
-              Successful
-            </span>
-          </td>
-          <td part="table-cell">
-            py_4VPDyBwelwI9HjufbgwqZK
           </td>
         </tr>
       </tbody>

--- a/packages/webcomponents/src/utils/utils.ts
+++ b/packages/webcomponents/src/utils/utils.ts
@@ -4,17 +4,16 @@ import { Address } from '../api/Business';
 
 export const RegExZip = /^\d{5}/;
 
-export function formatCurrency(amount: number, withSymbol = true): string {
+export function formatCurrency(amount: number, withSymbol = true, withCurrencyName = false): string {
   if (!amount) amount = 0;
 
   function format(amount: number): string {
     const formattedString = withSymbol ? '$0,0.00' : '0,0.00';
-    return Dinero({ amount: amount, currency: 'USD' }).toFormat(
-      formattedString
-    );
+    return Dinero({ amount: amount, currency: 'USD' }).toFormat(formattedString);
   }
 
-  return amount < 0 ? `(${format(-amount)})` : format(amount);
+  const formattedAmount = amount < 0 ? `(${format(-amount)})` : format(amount);
+  return withCurrencyName ? `${formattedAmount} USD` : formattedAmount;
 }
 
 export function formatPercentage(amount: number): string {

--- a/packages/webcomponents/src/utils/utils.ts
+++ b/packages/webcomponents/src/utils/utils.ts
@@ -97,22 +97,24 @@ export function extractComputedFontsToLoad() {
 
 export const MapPaymentStatusToBadge = (status: string) => {
   switch (status) {
+    case 'succeeded':
+      return "<span class='badge bg-success' title='This payment was successfully captured'>Succeeded</span>";
     case 'authorized':
       return "<span class='badge bg-primary' title='This card payment was authorized, but not captured. It could still succeed or fail.'>Authorized</span>";
-    case 'disputed':
-      return "<span class='badge bg-primary' title='The account holder disputed this payment. The amount has been returned and a fee assessed.'>Disputed</span>";
+    case 'pending':
+      return "<span class='badge bg-primary' title='This ACH payment was processed, but the funds haven't settled. It could still succeed or fail.'>Pending</span>";
     case 'achFailed':
       return "<span class='badge bg-danger' title='The funds couldn't be collected for this ACH payment (in addition to the original payment, an ACH return and fee will appear in a payout)'>Failed</span>";
     case 'failed':
       return "<span class='badge bg-danger' title='This card payment didn't go through (it won't appear in a payout)'>Failed</span>";
+    case 'canceled':
+      return "<span class='badge bg-danger' title='This payment was canceled'>Canceled</span>";
+    case 'disputed':
+      return "<span class='badge bg-secondary' title='The account holder disputed this payment. The amount has been returned and a fee assessed.'>Disputed</span>";
     case 'fully_refunded':
-      return "<span class='badge bg-primary' title='The full amount of this payment has been refunded'>Fully Refunded</span>";
+      return "<span class='badge bg-secondary' title='The full amount of this payment has been refunded'>Fully Refunded</span>";
     case 'partially_refunded':
-      return "<span class='badge bg-primary' title='A portion of this payment has been refunded'>Partially Refunded</span>";
-    case 'pending':
-      return "<span class='badge bg-secondary' title='This ACH payment was processed, but the funds haven't settled. It could still succeed or fail.'>Pending</span>";
-    case 'succeeded':
-      return "<span class='badge bg-success' title='This payment was successfully captured'>Successful</span>";
+      return "<span class='badge bg-secondary' title='A portion of this payment has been refunded'>Partially Refunded</span>";
   }
 };
 


### PR DESCRIPTION
### Payments List Refactors

This PR commits a handful of smaller changes to `payments-list`

  - Removed `Payment ID` column
  - Updated column name `Card Holder` to now say `Account Holder`
  - Now showing currency type in `Amount` column
  - Added `Type` column to show Card and ACH payments
  - Changed wording of `Successful` payment status badge to `Succeeded`
  - Updated some status badge colors to reflect Figma mockup
  - Added `Canceled` payment status badge for canceled payments
  - Updated start and end date filter inputs to allow user to choose times, allowing for even more granular payment filtering
    - (I believe I fixed an issue with the date input that we hadn't discussed - it now converts the date string to UTC timezone when applying the filters for the payments list, and converts it back to local time for proper display in the input value.)

Links
-----

Closes #736 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

This PR has a number of random changes - so please bare with me on this QA 😆 🙏🏻 

- [x] `Payment ID` column is removed from payments list
- [x] Card Holder column now says Account Holder
- [x] Showing Payment Type column with either `Card` or `ACH` as the value
- [x] Showing currency type in the amount column
- [x] `Successful` status badge should now read as `Succeeded`
- [x] If payment has status canceled - we now show a status badge with the `bg-danger` class
- [x] form-control-date now includes a time picker in the payment list table filters
- [x] form-control-date does NOT include a time picker anywhere in the payment-provisioning component
- [x] the date filters on payments-list filters should now successfully apply the params in UTC timezone (in accordance with our API docs)
  - [x] the params are applied in UTC, but the value displayed in the input should still be local timezone

