### PR TITLE
Add maxDate as prop to form-control-date

### DIFF
--- a/packages/webcomponents/src/components/billing-form/readme.md
+++ b/packages/webcomponents/src/components/billing-form/readme.md
@@ -57,7 +57,6 @@ Type: `Promise<{ isValid: boolean; }>`
 
  - [justifi-new-payment-method](../checkout)
  - [justifi-payment-form](../payment-form)
- - [justifi-upload-dispute-evidence](../dispute-management)
 
 ### Depends on
 
@@ -76,7 +75,6 @@ graph TD;
   form-control-select --> form-control-error-text
   justifi-new-payment-method --> justifi-billing-form
   justifi-payment-form --> justifi-billing-form
-  justifi-upload-dispute-evidence --> justifi-billing-form
   style justifi-billing-form fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/packages/webcomponents/src/components/form/form-control-date.tsx
+++ b/packages/webcomponents/src/components/form/form-control-date.tsx
@@ -23,6 +23,7 @@ export class DateInput {
   @Prop() disabled?: boolean;
   @Prop() filterTimeZone?: boolean = false;
   @Prop() showTime?: boolean;
+  @Prop() maxDate?: string = this.currentDate;
   
   @Watch('defaultValue')
   handleDefaultValueChange(newValue: string) {
@@ -36,7 +37,7 @@ export class DateInput {
   @Event() formControlInput: EventEmitter<any>;
   @Event() formControlBlur: EventEmitter<any>;
 
-  get maxDate() {
+  get currentDate() {
     if (!this.showTime) {
       return new Date().toISOString().split('T')[0];
     } else {

--- a/packages/webcomponents/src/components/form/readme.md
+++ b/packages/webcomponents/src/components/form/readme.md
@@ -39,49 +39,32 @@
 
 ### Used by
 
- - [justifi-additional-questions](../business-forms/business-form/additional-questions)
- - [justifi-additional-questions-form-step-core](../business-forms/payment-provisioning/additional-questions)
- - [justifi-billing-form](../billing-form)
- - [justifi-business-bank-account-form-step](../business-forms/payment-provisioning/bank-account)
- - [justifi-business-core-info](../business-forms/business-form/business-core-info)
- - [justifi-business-core-info-form-step-core](../business-forms/payment-provisioning/business-core-info)
- - [justifi-business-representative](../business-forms/business-form/business-representative)
- - [justifi-business-representative-form-inputs](../business-forms/payment-provisioning/business-representative)
- - [justifi-identity-address-form](../business-forms/owner-form/identity-address)
- - [justifi-legal-address-form](../business-forms/business-form/legal-address-form)
- - [justifi-legal-address-form-step-core](../business-forms/payment-provisioning/legal-address-form)
- - [justifi-refund-form](../refund-form)
- - [justifi-upload-dispute-evidence](../dispute-management)
- - [owner-form-inputs](../business-forms/owner-form)
- - [payments-list-filters](../payments-list)
+ - [justifi-additional-statement](../dispute-management/counter-dispute)
+ - [justifi-cancellation-policy](../dispute-management/counter-dispute)
+ - [justifi-customer-details](../dispute-management/counter-dispute)
+ - [justifi-duplicate-charge](../dispute-management/counter-dispute)
+ - [justifi-electronic-evidence](../dispute-management/counter-dispute)
+ - [justifi-refund-policy](../dispute-management/counter-dispute)
+ - [justifi-shipping-details](../dispute-management/counter-dispute)
 
 ### Depends on
 
-- [form-control-tooltip](./form-helpers/form-control-tooltip)
+- [form-control-help-text](./form-helpers/form-control-help-text)
 - [form-control-error-text](./form-helpers/form-control-error-text)
 
 ### Graph
 ```mermaid
 graph TD;
-  form-control-text --> form-control-tooltip
-  form-control-text --> form-control-error-text
-  form-control-tooltip --> custom-popper
-  justifi-additional-questions --> form-control-text
-  justifi-additional-questions-form-step-core --> form-control-text
-  justifi-billing-form --> form-control-text
-  justifi-business-bank-account-form-step --> form-control-text
-  justifi-business-core-info --> form-control-text
-  justifi-business-core-info-form-step-core --> form-control-text
-  justifi-business-representative --> form-control-text
-  justifi-business-representative-form-inputs --> form-control-text
-  justifi-identity-address-form --> form-control-text
-  justifi-legal-address-form --> form-control-text
-  justifi-legal-address-form-step-core --> form-control-text
-  justifi-refund-form --> form-control-text
-  justifi-upload-dispute-evidence --> form-control-text
-  owner-form-inputs --> form-control-text
-  payments-list-filters --> form-control-text
-  style form-control-text fill:#f9f,stroke:#333,stroke-width:4px
+  form-control-textarea --> form-control-help-text
+  form-control-textarea --> form-control-error-text
+  justifi-additional-statement --> form-control-textarea
+  justifi-cancellation-policy --> form-control-textarea
+  justifi-customer-details --> form-control-textarea
+  justifi-duplicate-charge --> form-control-textarea
+  justifi-electronic-evidence --> form-control-textarea
+  justifi-refund-policy --> form-control-textarea
+  justifi-shipping-details --> form-control-textarea
+  style form-control-textarea fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
 ----------------------------------------------

--- a/packages/webcomponents/src/components/form/test/__snapshots__/form-control-date.spec.tsx.snap
+++ b/packages/webcomponents/src/components/form/test/__snapshots__/form-control-date.spec.tsx.snap
@@ -23,7 +23,7 @@ exports[`form-control-date Renders with all props provided 1`] = `
         </div>
       </form-control-tooltip>
     </div>
-    <input class="form-control is-invalid" disabled="" id="birthday" max="2024-11-07" name="birthday" part="input input-invalid" type="date" value="1990-01-01">
+    <input class="form-control is-invalid" disabled="" id="birthday" max="2020-01-01" name="birthday" part="input input-invalid" type="date" value="1990-01-01">
     <form-control-error-text>
       <small class="form-text text-danger" id="form-error-text-birthday">
         Invalid date
@@ -42,7 +42,7 @@ exports[`form-control-date Renders with default props 1`] = `
       </label>
       <form-control-tooltip></form-control-tooltip>
     </div>
-    <input class="form-control" id="birthday" max="2024-11-07" name="birthday" part="input undefined" type="date" value="undefined">
+    <input class="form-control" id="birthday" max="2020-01-01" name="birthday" part="input undefined" type="date" value="undefined">
     <form-control-error-text></form-control-error-text>
   </div>
 </form-control-date>

--- a/packages/webcomponents/src/components/form/test/form-control-date.spec.tsx
+++ b/packages/webcomponents/src/components/form/test/form-control-date.spec.tsx
@@ -11,7 +11,7 @@ describe('form-control-date', () => {
   it('Renders with default props', async () => {
     const page = await newSpecPage({
       components: components,
-      template: () => <form-control-date label='Birthday' name='birthday'/>,
+      template: () => <form-control-date label='Birthday' name='birthday' maxDate='2020-01-01'/>,
     });
 
     expect(page.root).toMatchSnapshot();
@@ -29,6 +29,7 @@ describe('form-control-date', () => {
           helpText='Enter your birthday'
           disabled
           inputHandler={mockInputHandler}
+          maxDate='2020-01-01'
         />
     });
 


### PR DESCRIPTION
Add logic to pass a maxDate prop to form-control-date component, uses current date as default value, but can pass maxDate as a prop if needed for some reason in the future. 

This is mainly to fix failing snapshot tests for the form-control-date component since adding the max date attribute


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

