### PR TITLE
Remove submitted from individual form steps in payment provisioning component

### DIFF
--- a/.changeset/popular-spoons-push.md
+++ b/.changeset/popular-spoons-push.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": major
+---
+
+- Modified behavior of `submitted` event emitted from `justifi-payment-provisioning`
+  - `submitted` is no longer emitted after each form step completion of the payment provisioning component. It is now emitted only once, at the end of the form flow, when a response is received from the provisioning API request. 

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form-core.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop, State, Event, EventEmitter, Method, Watch } from '@stencil/core';
 import { FormController } from '../../../ui-components/form/form';
 import { Identity, Owner } from '../../../api/Identity';
-import { BusinessFormClickActions, BusinessFormClickEvent, BusinessFormSubmitEvent } from '../utils/business-form-types';
+import { BusinessFormClickActions, BusinessFormClickEvent } from '../utils/business-form-types';
 import { ComponentError } from '../../../api/ComponentError';
 import { identitySchema } from '../schemas/business-identity-schema';
 import { Button } from '../../../ui-components';
@@ -30,8 +30,6 @@ export class BusinessOwnerFormCore {
     this.formLoading.emit(this.isLoading);
   }
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
-  @Event({ bubbles: true }) ownerSubmitted: EventEmitter<any>;
   @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<BusinessFormClickEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -135,16 +133,10 @@ export class BusinessOwnerFormCore {
         this.patchOwner({
           payload: this.payload,
           onSuccess: (response) => {
-            this.submitted.emit({
-              data: response,
-              metadata: { ownerID: response.data.id }
-            });
-            this.ownerSubmitted.emit({ id: response.data.id });
             this.instantiateOwner(response.data);
             resolve(true);
           },
           onError: ({ error, code, severity }) => {
-            this.submitted.emit({ data: { error } });
             this.errorEvent.emit({
               message: error,
               errorCode: code,
@@ -158,16 +150,10 @@ export class BusinessOwnerFormCore {
         this.postOwner({
           payload: this.payload,
           onSuccess: (response) => {
-            this.submitted.emit({
-              data: response,
-              metadata: { ownerID: response.data.id }
-            });
-            this.ownerSubmitted.emit({ id: response.data.id });
             this.instantiateOwner(response.data);
             resolve(true);
           },
           onError: ({ error, code, severity }) => {
-            this.submitted.emit({ data: { error } });
             this.errorEvent.emit({
               message: error,
               errorCode: code,

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form-core.tsx
@@ -33,6 +33,7 @@ export class BusinessOwnerFormCore {
   @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<BusinessFormClickEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
+  @Event({ bubbles: true }) ownerSubmitted: EventEmitter<any>;
 
   constructor() {
     this.validate = this.validate.bind(this);
@@ -133,6 +134,7 @@ export class BusinessOwnerFormCore {
         this.patchOwner({
           payload: this.payload,
           onSuccess: (response) => {
+            this.ownerSubmitted.emit({ id: response.data.id });
             this.instantiateOwner(response.data);
             resolve(true);
           },
@@ -150,6 +152,7 @@ export class BusinessOwnerFormCore {
         this.postOwner({
           payload: this.payload,
           onSuccess: (response) => {
+            this.ownerSubmitted.emit({ id: response.data.id });
             this.instantiateOwner(response.data);
             resolve(true);
           },

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/business-additional-questions-form-step-core.tsx
@@ -2,7 +2,7 @@ import { Component, h, Prop, State, Method, Event, EventEmitter, Watch } from '@
 import { additionalQuestionsSchema } from '../../schemas/business-additional-questions-schema';
 import { FormController } from '../../../../ui-components/form/form';
 import { AdditionalQuestions, IAdditionalQuestions } from '../../../../api/Business';
-import { BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../components';
 import { CURRENCY_MASK } from '../../../../utils/form-input-masks';
 import { businessServiceReceivedOptions, recurringPaymentsOptions, seasonalBusinessOptions } from '../../utils/business-form-options';
@@ -29,7 +29,6 @@ export class AdditionalQuestionsFormStepCore {
   @Prop() patchBusiness: Function;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -91,8 +90,7 @@ export class AdditionalQuestionsFormStepCore {
         });
       },
       final: () => {
-        this.submitted.emit({ data: { submittedData } });
-        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.additionalQuestions });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStep.additionalQuestions });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/readme.md
@@ -21,7 +21,6 @@
 | `error-event`         |             | `CustomEvent<ComponentError>`                 |
 | `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
 | `formLoading`         |             | `CustomEvent<boolean>`                        |
-| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Event, EventEmitter, Method } from '@stencil/core';
 import { FormController } from '../../../../ui-components/form/form';
-import { BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { businessBankAccountSchema } from '../../schemas/business-bank-account-schema';
 import { bankAccountTypeOptions } from '../../utils/business-form-options';
 import { Api, IApiResponse } from '../../../../api';
@@ -32,7 +32,6 @@ export class BusinessBankAccountFormStep {
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -103,14 +102,13 @@ export class BusinessBankAccountFormStep {
     } else {
       onSuccess();
     }
-    this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.bankAccount } });
-    this.stepCompleted.emit({ data: response, formStep: BusinessFormStepV2.bankAccount });
+    this.stepCompleted.emit({ data: response, formStep: BusinessFormStep.bankAccount });
   }
 
   @Method()
   async validateAndSubmit({ onSuccess }) {
     if (this.formDisabled) {
-      this.stepCompleted.emit({ data: null, formStep: BusinessFormStepV2.bankAccount, metadata: 'no data submitted' });
+      this.stepCompleted.emit({ data: null, formStep: BusinessFormStep.bankAccount, metadata: 'no data submitted' });
       onSuccess();
     } else {
       this.formController.validateAndSubmit(() => this.sendData(onSuccess));

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -2,7 +2,7 @@ import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil
 import { businessCoreInfoSchema } from '../../schemas/business-core-info-schema';
 import { FormController } from '../../../../ui-components/form/form';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
-import { BusinessFormStepCompletedEvent, BusinessFormSubmitEvent, BusinessFormStepV2 } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import { businessClassificationOptions } from '../../utils/business-form-options';
 import { PHONE_MASKS } from '../../../../utils/form-input-masks';
@@ -21,7 +21,6 @@ export class BusinessCoreInfoFormStepCore {
   @Prop() patchBusiness: Function;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -83,8 +82,7 @@ export class BusinessCoreInfoFormStepCore {
         });
       },
       final: () => {
-        this.submitted.emit({ data: { submittedData } });
-        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.businessInfo });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStep.businessInfo });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/readme.md
@@ -22,7 +22,6 @@
 | `error-event`         |             | `CustomEvent<ComponentError>`                 |
 | `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
 | `formLoading`         |             | `CustomEvent<boolean>`                        |
-| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step-core.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Event, EventEmitter, Method, Listen, Watch } from '@stencil/core';
 import { ComponentError } from '../../../../api/ComponentError';
-import { BusinessFormClickActions, BusinessFormClickEvent, BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormClickActions, BusinessFormClickEvent, BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { Button } from '../../../../ui-components';
 
 interface ownerPayloadItem { id: string; }
@@ -19,7 +19,6 @@ export class BusinessOwnersFormStepCore {
   @Prop() patchBusiness: Function;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<BusinessFormClickEvent>;
   @Event() formLoading: EventEmitter<boolean>;
@@ -83,8 +82,7 @@ export class BusinessOwnersFormStepCore {
         });
       },
       final: () => {
-        this.submitted.emit({ data: submittedData, metadata: { completedStep: BusinessFormStep.owners } });
-        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.owners });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStep.owners });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/readme.md
@@ -24,7 +24,6 @@
 | `error-event`         |             | `CustomEvent<ComponentError>`                 |
 | `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
 | `formLoading`         |             | `CustomEvent<boolean>`                        |
-| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/README.md
@@ -21,7 +21,6 @@
 | `error-event`         |             | `CustomEvent<ComponentError>`                 |
 | `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
 | `formLoading`         |             | `CustomEvent<boolean>`                        |
-| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step-core.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { Identity, Representative } from '../../../../api/Identity';
 import { FormController } from '../../../../ui-components/form/form';
-import { BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import { identitySchema } from '../../schemas/business-identity-schema';
 
@@ -17,7 +17,6 @@ export class BusinessRepresentativeFormStepCore {
   @Prop() patchBusiness: Function;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event({ bubbles: true }) formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -79,8 +78,7 @@ export class BusinessRepresentativeFormStepCore {
         });
       },
       final: () => {
-        this.submitted.emit({ data: { submittedData } });
-        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.representative });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStep.representative });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-uploads/business-document-upload-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../../ui-components/form/form';
-import { BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { Business, IBusiness } from '../../../../api/Business';
 import Api, { IApiResponse } from '../../../../api/Api';
 import { config } from '../../../../../config';
@@ -26,7 +26,6 @@ export class BusinessDocumentFormStep {
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -140,8 +139,7 @@ export class BusinessDocumentFormStep {
       })
       return false;
     } else {
-      this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.documentUpload } });
-      this.stepCompleted.emit({ data: response, formStep: BusinessFormStepV2.documentUpload });
+      this.stepCompleted.emit({ data: response, formStep: BusinessFormStep.documentUpload });
       return true;
     }
   }
@@ -157,7 +155,7 @@ export class BusinessDocumentFormStep {
     try {
       const docArray = Object.values(this.documentData).flat();
       if (!docArray.length) {
-        this.stepCompleted.emit({ data: null, formStep: BusinessFormStepV2.documentUpload, metadata: 'no data submitted' });
+        this.stepCompleted.emit({ data: null, formStep: BusinessFormStep.documentUpload, metadata: 'no data submitted' });
         return onSuccess();
       }
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step-core.tsx
@@ -2,7 +2,7 @@ import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil
 import { addressSchema } from '../../schemas/business-address-schema';
 import { FormController } from '../../../../ui-components/form/form';
 import { Address, IAddress } from '../../../../api/Business';
-import { BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { ComponentError } from '../../../../api/ComponentError';
 import StateOptions from '../../../../utils/state-options';
 import { numberOnlyHandler } from '../../../../ui-components/form/utils';
@@ -19,7 +19,6 @@ export class LegalAddressFormStepCore {
   @Prop() patchBusiness: Function;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -81,8 +80,7 @@ export class LegalAddressFormStepCore {
         });
       },
       final: () => {
-        this.submitted.emit({ data: { submittedData } });
-        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStepV2.legalAddress });
+        this.stepCompleted.emit({ data: submittedData, formStep: BusinessFormStep.legalAddress });
         this.formLoading.emit(false)
       }
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/readme.md
@@ -21,7 +21,6 @@
 | `error-event`         |             | `CustomEvent<ComponentError>`                 |
 | `form-step-completed` |             | `CustomEvent<BusinessFormStepCompletedEvent>` |
 | `formLoading`         |             | `CustomEvent<boolean>`                        |
-| `submitted`           |             | `CustomEvent<BusinessFormSubmitEvent>`        |
 
 
 ## Methods

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
@@ -68,6 +68,7 @@ export class PaymentProvisioningFormSteps {
       ref={(el) => this.refs[7] = el}
       onFormLoading={this.handleFormLoading}
       allowOptionalFields={this.allowOptionalFields}
+      onForm-step-completed={() => this.formCompleted.emit()}
     />,
   };
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
@@ -68,7 +68,6 @@ export class PaymentProvisioningFormSteps {
       ref={(el) => this.refs[7] = el}
       onFormLoading={this.handleFormLoading}
       allowOptionalFields={this.allowOptionalFields}
-      onSubmitted={() => this.formCompleted.emit()}
     />,
   };
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
@@ -1,6 +1,6 @@
 import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
 import { FormController } from '../../../../ui-components/form/form';
-import { BusinessFormStep, BusinessFormStepCompletedEvent, BusinessFormStepV2, BusinessFormSubmitEvent } from '../../utils/business-form-types';
+import { BusinessFormStepCompletedEvent, BusinessFormStep } from '../../utils/business-form-types';
 import { config } from '../../../../../config';
 import { businessTermsConditionsSchema } from '../../schemas/business-terms-conditions-schema';
 import { Api, IApiResponse } from '../../../../api';
@@ -19,7 +19,6 @@ export class BusinessTermsConditionsFormStep {
   @Prop() businessId: string;
   @Prop() allowOptionalFields?: boolean;
 
-  @Event({ bubbles: true }) submitted: EventEmitter<BusinessFormSubmitEvent>;
   @Event({ eventName: 'form-step-completed', bubbles: true }) stepCompleted: EventEmitter<BusinessFormStepCompletedEvent>;
   @Event() formLoading: EventEmitter<boolean>;
   @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentError>;
@@ -100,14 +99,13 @@ export class BusinessTermsConditionsFormStep {
     } else {
       onSuccess();
     }
-    this.submitted.emit({ data: response, metadata: { completedStep: BusinessFormStep.termsAndConditions } });
-    this.stepCompleted.emit({ data: response, formStep: BusinessFormStepV2.termsAndConditions });
+    this.stepCompleted.emit({ data: response, formStep: BusinessFormStep.termsAndConditions });
   }
 
   @Method()
   async validateAndSubmit({ onSuccess }) {
     if (this.acceptedTermsBefore) {
-      this.submitted.emit({ metadata: { completedStep: BusinessFormStep.termsAndConditions } });
+      this.stepCompleted.emit({ data: null, formStep: BusinessFormStep.termsAndConditions, metadata: 'no data submitted' });
       onSuccess();
     } else {
       this.formController.validateAndSubmit(() => this.sendData(onSuccess));

--- a/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/business-form-types.ts
@@ -1,6 +1,6 @@
 export interface BusinessFormSubmitEvent {
   data?: any;
-  metadata?: BusinessFormEventMetaData;
+  metadata?: any;
 }
 
 export interface BusinessFormClickEvent {
@@ -8,36 +8,14 @@ export interface BusinessFormClickEvent {
   name: BusinessFormClickActions;
 }
 
-export interface BusinessFormServerErrorEvent {
-  data?: any;
-  message: BusinessFormServerErrors;
-}
 
 export interface BusinessFormStepCompletedEvent {
   data: any;
-  formStep: BusinessFormStepV2;
+  formStep: BusinessFormStep;
   metadata?: any;
 }
 
-// For right now we can use MetaData to track the step that was just completed during a submit event. 
-// Eventually we can find other uses for MetaData to present to the implementer. 
-interface BusinessFormEventMetaData {
-  completedStep?: BusinessFormStep;
-  ownerID?: string; 
-}
-
 export enum BusinessFormStep {
-  coreInfo = 'coreInfo',
-  legalAddress = 'legalAddress',
-  additionalQuestions = 'additionalQuestions',
-  representative = 'representative',
-  owners = 'owners',
-  bankAccount = 'bankAccount',
-  documentUpload = 'documentUpload',
-  termsAndConditions = 'termsAndConditions'
-}
-
-export enum BusinessFormStepV2 {
   businessInfo = 'business_info',
   legalAddress = 'legal_address',
   additionalQuestions = 'additional_questions',
@@ -61,31 +39,4 @@ export enum BusinessFormClickActions {
   addOwner = 'addOwner',
   addOwnerForm = 'addOwnerForm',
   updateOwner = 'updateOwner'
-}
-
-export interface OwnerFormSubmitEvent {
-  data: any;
-  metadata?: any;
-}
-
-
-export interface OwnerFormServerErrorEvent {
-  data?: any;
-  message: OwnerFormServerErrors;
-}
-
-export enum OwnerFormServerErrors {
-  fetchData = 'Error retrieving owner data',
-  patchData = 'Error updating owner data',
-  postData = 'Error adding owner data'
-}
-
-export enum DocumentFormServerErrors {
-  fetchData = 'Error retrieving document data',
-  sendData = 'Error uploading document data'
-}
-
-export interface DocumentFormServerErrorEvent {
-  data?: any;
-  message: DocumentFormServerErrors;
 }


### PR DESCRIPTION
### Remove submitted from individual form steps in payment provisioning component

This PR modifies the `submitted` event behavior of the payment-provisioning component to only emit at the very end of the form after the provisioning request has been completed. 




Links
-----

Closes #716 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] `submitted` event no longer emits on each form step.
- [ ] `submitted` event emits at the end of the form's final step with the response from the provisioning request

