### PR TITLE
Refactor render timing for terminals and checkouts list components

### DIFF
--- a/.changeset/silly-pillows-check.md
+++ b/.changeset/silly-pillows-check.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Refactor render timing for list components that use new `columns` prop

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-core.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-core.tsx
@@ -3,7 +3,7 @@ import { Checkout, ICheckoutsParams, PagingInfo, SubAccount, pagingDefaults } fr
 import { ComponentError } from '../../api/ComponentError';
 import { onFilterChange } from '../../ui-components/filters/utils';
 import { TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
-import { defaultColumnsKeys, checkoutTableColumns, checkoutTableCells } from './checkouts-table';
+import { checkoutTableColumns, checkoutTableCells } from './checkouts-table';
 import { Table } from '../../utils/table';
 
 @Component({
@@ -12,10 +12,10 @@ import { Table } from '../../utils/table';
 export class CheckoutsListCore {
   @Prop() getCheckouts: Function;
   @Prop() getSubAccounts: Function;
-  @Prop() columns: string = defaultColumnsKeys;
+  @Prop() columns: string;
 
   @State() checkouts: Checkout[] = [];
-  @State() checkoutsTable: Table = new Table([], this.columns, checkoutTableColumns, checkoutTableCells);
+  @State() checkoutsTable: Table;
   @State() subAccounts: SubAccount[] = [];
   @State() loading: boolean = true;
   @State() errorMessage: string;
@@ -38,6 +38,7 @@ export class CheckoutsListCore {
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 
   componentWillLoad() {
+    this.checkoutsTable = new Table(this.checkouts, this.columns, checkoutTableColumns, checkoutTableCells);
     if (this.getCheckouts && this.getSubAccounts) {
       this.fetchCheckouts();
     }
@@ -51,7 +52,7 @@ export class CheckoutsListCore {
       onSuccess: async ({ checkouts, pagingInfo }) => {
         this.checkouts = checkouts;
         this.paging = pagingInfo;
-        this.checkoutsTable = new Table(this.checkouts, this.columns, checkoutTableColumns, checkoutTableCells);
+        this.checkoutsTable.collectionData = this.checkouts;
         const shouldFetchSubAccounts = this.checkoutsTable.columnKeys.includes('sub_account_name');
 
         if (shouldFetchSubAccounts) {

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
@@ -8,6 +8,7 @@ import { ComponentError, ComponentErrorCodes, ComponentErrorSeverity } from '../
 import { SubAccountService } from '../../api/services/subaccounts.service';
 import { makeGetSubAccounts } from '../../api/get-subaccounts';
 import { StyledHost, tableExportedParts } from '../../ui-components';
+import { defaultColumnsKeys } from './checkouts-table';
 
 /**
   * @exportedPart label: Label for inputs
@@ -44,7 +45,7 @@ export class CheckoutsList {
   @Prop() accountId: string;
   @Prop() authToken: string;
   @Prop() apiOrigin?: string = config.proxyApiOrigin;
-  @Prop() columns: string;
+  @Prop() columns: string = defaultColumnsKeys;
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-core.spec.tsx
@@ -44,7 +44,7 @@ describe('checkouts-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} />,
+      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -82,7 +82,7 @@ describe('checkouts-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} />,
+      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -158,7 +158,7 @@ describe('checkouts-list-core', () => {
 
     const page = await newSpecPage({
       components: [CheckoutsListCore, PaginationMenu, TableFiltersMenu, CheckoutsListFilters],
-      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} />,
+      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -199,7 +199,7 @@ describe('checkouts-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} />,
+      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     const filterButton = page.root.querySelector('[data-test-id="open-filters-button"]') as HTMLElement;
@@ -255,7 +255,7 @@ describe('checkouts-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} />,
+      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     const filterButton = page.root.querySelector('[data-test-id="open-filters-button"]') as HTMLElement;
@@ -316,7 +316,7 @@ describe('checkouts-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} />,
+      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -359,7 +359,7 @@ describe('checkouts-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} onError-event={errorEvent} />,
+      template: () => <checkouts-list-core getCheckouts={getCheckouts} getSubAccounts={getSubAccounts} onError-event={errorEvent} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();

--- a/packages/webcomponents/src/components/terminals-list/terminals-list-core.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-list-core.tsx
@@ -3,7 +3,7 @@ import { PagingInfo, SubAccount, Terminal, TerminalsTableFilterParams, pagingDef
 import { ComponentError } from '../../api/ComponentError';
 import { TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
 import { onFilterChange } from '../../ui-components/filters/utils';
-import { defaultColumnsKeys, terminalTableColumns, terminalTableCells } from './terminals-table';
+import { terminalTableColumns, terminalTableCells } from './terminals-table';
 import { Table } from '../../utils/table';
 
 @Component({
@@ -12,10 +12,10 @@ import { Table } from '../../utils/table';
 export class TerminalsListCore {
   @Prop() getTerminals: Function;
   @Prop() getSubAccounts: Function;
-  @Prop() columns: string = defaultColumnsKeys;
+  @Prop() columns: string;
 
   @State() terminals: Terminal[] = [];
-  @State() terminalsTable: Table = new Table([], this.columns, terminalTableColumns, terminalTableCells);
+  @State() terminalsTable: Table;
   @State() subAccounts: SubAccount[] = [];
   @State() loading: boolean = true;
   @State() errorMessage: string;
@@ -38,6 +38,7 @@ export class TerminalsListCore {
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 
   componentWillLoad() {
+    this.terminalsTable = new Table(this.terminals, this.columns, terminalTableColumns, terminalTableCells);
     if (this.getTerminals && this.getSubAccounts) {
       this.fetchTerminals();
     }
@@ -51,7 +52,7 @@ export class TerminalsListCore {
       onSuccess: async ({ terminals, pagingInfo }) => {
         this.terminals = terminals;
         this.paging = pagingInfo;
-        this.terminalsTable = new Table(this.terminals, this.columns, terminalTableColumns, terminalTableCells);
+        this.terminalsTable.collectionData = this.terminals;
         const shouldFetchSubAccounts = this.terminalsTable.columnKeys.includes('sub_account_name');
 
         if (shouldFetchSubAccounts) {

--- a/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
@@ -8,6 +8,7 @@ import { makeGetTerminals } from './get-terminals';
 import { SubAccountService } from '../../api/services/subaccounts.service';
 import { makeGetSubAccounts } from '../../api/get-subaccounts';
 import { StyledHost, tableExportedParts } from '../../ui-components';
+import { defaultColumnsKeys } from './terminals-table';
 
 /**
   * @exportedPart label: Label for inputs
@@ -44,7 +45,7 @@ export class TerminalsList {
   @Prop() accountId: string;
   @Prop() authToken: string;
   @Prop() apiOrigin?: string = config.proxyApiOrigin;
-  @Prop() columns: string;
+  @Prop() columns: string = defaultColumnsKeys;
   
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 

--- a/packages/webcomponents/src/components/terminals-list/test/terminals-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/terminals-list/test/terminals-list-core.spec.tsx
@@ -12,6 +12,7 @@ import { TerminalsListFilters } from '../terminals-list-filters';
 import { TableFiltersMenu } from '../../../ui-components/filters/table-filters-menu';
 import { SelectInput } from '../../../ui-components/form/form-control-select';
 import { makeGetSubAccounts } from '../../../api/get-subaccounts';
+import { defaultColumnsKeys } from '../terminals-table';
 
 const mockTerminalsResponse = mockTerminalSuccessResponse as IApiResponseCollection<ITerminal[]>;
 const mockSubAccountsResponse = mockSubAccountSuccessResponse as IApiResponseCollection<ISubAccount[]>;
@@ -43,7 +44,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -80,7 +81,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -114,7 +115,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -154,7 +155,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -194,7 +195,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     const filterButton = page.root.querySelector('[data-test-id="open-filters-button"]') as HTMLElement;
@@ -249,7 +250,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     const filterButton = page.root.querySelector('[data-test-id="open-filters-button"]') as HTMLElement;
@@ -309,7 +310,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} />,
     });
 
     await page.waitForChanges();
@@ -351,7 +352,7 @@ describe('terminals-list-core', () => {
 
     const page = await newSpecPage({
       components: components,
-      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} onError-event={errorEvent} />,
+      template: () => <terminals-list-core getTerminals={getTerminals} getSubAccounts={getSubAccounts} columns={defaultColumnsKeys} onError-event={errorEvent} />,
     });
 
     await page.waitForChanges();

--- a/packages/webcomponents/src/utils/table.ts
+++ b/packages/webcomponents/src/utils/table.ts
@@ -14,6 +14,10 @@ export class Table {
     });
   }
 
+  set collectionData(collection: any[]) {
+    this.collection = collection;
+  }
+
   constructor(
     collection: any[],
     columns: string,


### PR DESCRIPTION
### Fix render timing for columns props in checkouts and terminals list

Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [x] Rendering `terminals-list` with full columns list should show all columns when table initially renders: `nickname,provider_id,sub_account_name,status`\
  - [x] table should NOT render without Sub Account Column and then quickly re-render WITH Sub Account Column. It should render initially with the columns passed in the column prop.
- [x] Rendering `checkouts-list` with full columns list should show all columns when table initially renders:`'created_at,payment_amount,payment_description,payment_mode,sub_account_name,status'`
  - [x] table should NOT render without Sub Account Column and then quickly re-render WITH Sub Account Column. It should render initially with the columns passed in the column prop.

