### PR TITLE
Update Terminals and Checkouts List stories to use the new Theme logic and add missing table-cell part

### DIFF
--- a/apps/docs/stories/components/CheckoutsList/index.stories.tsx
+++ b/apps/docs/stories/components/CheckoutsList/index.stories.tsx
@@ -3,95 +3,7 @@ import { withActions } from "@storybook/addon-actions/decorator";
 import { StoryBaseArgs, customStoryDecorator } from "../../utils";
 
 import "@justifi/webcomponents/dist/module/justifi-checkouts-list";
-
-const themes = {
-  basic: {},
-  custom: {
-    "justifi-checkouts-list::part(label)": {
-      color: "#212529",
-      "font-family": "Calibri, sans-serif",
-      "font-weight": "700",
-      "font-size": ".8rem",
-      margin: "0 0 .5rem 0",
-    },
-    "justifi-checkouts-list::part(input)": {
-      "background-color": "#F4F4F6",
-      "border-color": "rgba(0, 0, 0, 0.42)",
-      "border-bottom-width": "1px",
-      "border-left-width": "0",
-      "border-right-width": "0",
-      "border-top-width": "0",
-      "border-radius": "4px 4px 0 0",
-      "border-style": "solid",
-      "box-shadow": "0 2px 4px rgba(0, 0, 0, 0.2)",
-      color: "#212529",
-      "font-size": ".8rem",
-      "font-weight": "400",
-      "line-height": "2",
-      margin: "0",
-      padding: ".5rem .875rem",
-    },
-    "justifi-checkouts-list::part(input):focus": {
-      color: "#212529",
-      "border-color": "#fccc32",
-      "box-shadow": "none",
-    },
-    "justifi-checkouts-list::part(input-invalid)": {
-      "border-color": "#C12727",
-      "box-shadow": "0 2px 4px rgba(0, 0, 0, 0.2)",
-    },
-    "justifi-checkouts-list::part(input-invalid):focus": {
-      "border-color": "#C12727",
-      "box-shadow": "none",
-    },
-    "justifi-checkouts-list::part(table-head)": {},
-    "justifi-checkouts-list::part(table-head-row)": {},
-    "justifi-checkouts-list::part(table-head-cell)": {
-      "background-color": "#fff",
-      "font-weight": "600",
-      "font-size": "0.8rem",
-      "text-transform": "uppercase",
-      "letter-spacing": "0.1em",
-    },
-    "justifi-checkouts-list::part(table-body)": {},
-    "justifi-checkouts-list::part(table-row)": {},
-    "justifi-checkouts-list::part(table-row):hover": {
-      cursor: "pointer",
-    },
-    "justifi-checkouts-list::part(table-row-even)": {},
-    "justifi-checkouts-list::part(table-row-odd)": {},
-    "justifi-checkouts-list::part(table-cell)": {
-      "background-color": "transparent",
-      "font-weight": "normal",
-      "font-size": "0.8rem",
-    },
-    "justifi-checkouts-list::part(loading-state-cell)": {},
-    "justifi-checkouts-list::part(loading-state-spinner)": {
-      color: "#ccc",
-    },
-    "justifi-checkouts-list::part(error-state)": {},
-    "justifi-checkouts-list::part(empty-state)": {},
-    "justifi-checkouts-list::part(pagination-bar)": {
-      "background-color": "#fff",
-      "border-bottom": "none",
-    },
-    "justifi-checkouts-list::part(page-button)": {
-      border: "none",
-      "background-color": "transparent",
-      "text-transform": "uppercase",
-      "font-weight": "normal",
-      "font-size": "0.8rem",
-    },
-    "justifi-checkouts-list::part(page-button-disabled)": {
-      opacity: "0.5",
-      cursor: "not-allowed",
-    },
-    "justifi-checkouts-list::part(page-arrow)": {
-      display: "none",
-    },
-    "justifi-checkouts-list::part(page-button-text)": {},
-  },
-};
+import { ThemeNames } from "../../themes";
 
 const storyBaseArgs = new StoryBaseArgs(["account-id", "auth-token", "theme"]);
 
@@ -100,9 +12,18 @@ const meta: Meta = {
   component: "justifi-checkouts-list",
   args: {
     ...storyBaseArgs.args,
+    Theme: ThemeNames.Light
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    Theme: {
+      description:
+        "Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling-components-with-variables)",
+      options: Object.values(ThemeNames),
+      control: {
+        type: "select",
+      },
+    },
     "checkout-row-clicked": {
       description: "`CheckoutRowClicked`",
       table: {
@@ -138,7 +59,6 @@ const meta: Meta = {
     chromatic: {
       delay: 2000,
     },
-    themes,
   },
   decorators: [
     customStoryDecorator,

--- a/apps/docs/stories/components/TerminalsList/index.stories.tsx
+++ b/apps/docs/stories/components/TerminalsList/index.stories.tsx
@@ -3,95 +3,7 @@ import { withActions } from "@storybook/addon-actions/decorator";
 import { StoryBaseArgs, customStoryDecorator } from "../../utils";
 
 import "@justifi/webcomponents/dist/module/justifi-terminals-list";
-
-const themes = {
-  basic: {},
-  custom: {
-    "justifi-terminals-list::part(label)": {
-      color: "#212529",
-      "font-family": "Calibri, sans-serif",
-      "font-weight": "700",
-      "font-size": ".8rem",
-      margin: "0 0 .5rem 0",
-    },
-    "justifi-terminals-list::part(input)": {
-      "background-color": "#F4F4F6",
-      "border-color": "rgba(0, 0, 0, 0.42)",
-      "border-bottom-width": "1px",
-      "border-left-width": "0",
-      "border-right-width": "0",
-      "border-top-width": "0",
-      "border-radius": "4px 4px 0 0",
-      "border-style": "solid",
-      "box-shadow": "0 2px 4px rgba(0, 0, 0, 0.2)",
-      color: "#212529",
-      "font-size": ".8rem",
-      "font-weight": "400",
-      "line-height": "2",
-      margin: "0",
-      padding: ".5rem .875rem",
-    },
-    "justifi-terminals-list::part(input):focus": {
-      color: "#212529",
-      "border-color": "#fccc32",
-      "box-shadow": "none",
-    },
-    "justifi-terminals-list::part(input-invalid)": {
-      "border-color": "#C12727",
-      "box-shadow": "0 2px 4px rgba(0, 0, 0, 0.2)",
-    },
-    "justifi-terminals-list::part(input-invalid):focus": {
-      "border-color": "#C12727",
-      "box-shadow": "none",
-    },
-    "justifi-terminals-list::part(table-head)": {},
-    "justifi-terminals-list::part(table-head-row)": {},
-    "justifi-terminals-list::part(table-head-cell)": {
-      "background-color": "#fff",
-      "font-weight": "600",
-      "font-size": "0.8rem",
-      "text-transform": "uppercase",
-      "letter-spacing": "0.1em",
-    },
-    "justifi-terminals-list::part(table-body)": {},
-    "justifi-terminals-list::part(table-row)": {},
-    "justifi-terminals-list::part(table-row):hover": {
-      cursor: "pointer",
-    },
-    "justifi-terminals-list::part(table-row-even)": {},
-    "justifi-terminals-list::part(table-row-odd)": {},
-    "justifi-terminals-list::part(table-cell)": {
-      "background-color": "transparent",
-      "font-weight": "normal",
-      "font-size": "0.8rem",
-    },
-    "justifi-terminals-list::part(loading-state-cell)": {},
-    "justifi-terminals-list::part(loading-state-spinner)": {
-      color: "#ccc",
-    },
-    "justifi-terminals-list::part(error-state)": {},
-    "justifi-terminals-list::part(empty-state)": {},
-    "justifi-terminals-list::part(pagination-bar)": {
-      "background-color": "#fff",
-      "border-bottom": "none",
-    },
-    "justifi-terminals-list::part(page-button)": {
-      border: "none",
-      "background-color": "transparent",
-      "text-transform": "uppercase",
-      "font-weight": "normal",
-      "font-size": "0.8rem",
-    },
-    "justifi-terminals-list::part(page-button-disabled)": {
-      opacity: "0.5",
-      cursor: "not-allowed",
-    },
-    "justifi-terminals-list::part(page-arrow)": {
-      display: "none",
-    },
-    "justifi-terminals-list::part(page-button-text)": {},
-  },
-};
+import { ThemeNames } from "../../themes";
 
 const storyBaseArgs = new StoryBaseArgs(["account-id", "auth-token", "theme"]);
 
@@ -99,10 +11,19 @@ const meta: Meta = {
   title: "Merchant Tools/Terminals List",
   component: "justifi-terminals-list",
   args: {
-    ...storyBaseArgs.args
+    ...storyBaseArgs.args,
+    Theme: ThemeNames.Light
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
+    Theme: {
+      description:
+        "Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling-components-with-variables)",
+      options: Object.values(ThemeNames),
+      control: {
+        type: "select",
+      },
+    },
     "terminal-row-clicked": {
       description: "`TerminalRowClicked`",
       table: {
@@ -138,7 +59,6 @@ const meta: Meta = {
     chromatic: {
       delay: 2000,
     },
-    themes,
   },
   decorators: [
     customStoryDecorator,

--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -61,7 +61,9 @@ justifi-tokenize-payment-method,
 justifi-payment-details,
 justifi-payouts-details,
 justifi-payments-list,
-justifi-payouts-list {
+justifi-payouts-list,
+justifi-checkouts-list,
+justifi-terminals-list {
   display: block;
   margin: 5% auto;
   background-color: #191919;
@@ -221,7 +223,9 @@ justifi-payment-provisioning,
 justifi-payment-details,
 justifi-payout-details,
 justifi-payments-list,
-justifi-payouts-list {
+justifi-payouts-list,
+justifi-checkouts-list,
+justifi-terminals-list {
   display: inline-block;
   padding: 40px;
 }

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -62,7 +62,9 @@ justifi-season-interruption-insurance,
 justifi-payment-details,
 justifi-payout-details,
 justifi-payments-list,
-justifi-payouts-list {
+justifi-payouts-list,
+justifi-checkouts-list,
+justifi-terminals-list, {
   display: block;
   margin: 5% auto;
   background-color: #fff;
@@ -327,14 +329,18 @@ justifi-payment-details::part(header-2) {
 justifi-payment-details,
 justifi-payout-details,
 justifi-payments-list,
-justifi-payouts-list {
+justifi-payouts-list,
+justifi-checkouts-list,
+justifi-terminals-list {
   background-color: #f9fafb; 
   color: #374151; 
   padding: 16px;
 }
 
 justifi-payments-list::part(label),
-justifi-payouts-list::part(label) {
+justifi-payouts-list::part(label),
+justifi-checkouts-list::part(label),
+justifi-terminals-list::part(label) {
   color: #212529;
   font-family: 'Roboto', sans-serif;
   font-weight: 700;
@@ -343,7 +349,9 @@ justifi-payouts-list::part(label) {
 }
 
 justifi-payments-list::part(input),
-justifi-payouts-list::part(input) {
+justifi-payouts-list::part(input),
+justifi-checkouts-list::part(input),
+justifi-terminals-list::part(input) {
   background-color: #F4F4F6;
   border-color: rgba(0, 0, 0, 0.42);
   border-bottom-width: 1px;
@@ -362,14 +370,18 @@ justifi-payouts-list::part(input) {
 }
 
 justifi-payments-list::part(input):focus,
-justifi-payouts-list::part(input):focus {
+justifi-payouts-list::part(input):focus,
+justifi-checkouts-list::part(input):focus,
+justifi-terminals-list::part(input):focus {
   color: #212529;
   border-color: #fccc32;
   box-shadow: none;
 }
 
 justifi-payments-list::part(input-invalid),
-justifi-payouts-list::part(input-invalid) {
+justifi-payouts-list::part(input-invalid),
+justifi-checkouts-list::part(input-invalid),
+justifi-terminals-list::part(input-invalid) {
   border-color: #C12727;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-core.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-core.tsx
@@ -182,7 +182,14 @@ export class CheckoutsListCore {
                   onClick={this.rowClickHandler}
                   part={`table-row ${index % 2 ? "table-row-even" : "table-row-odd"}`}
                 >
-                  {data}
+                  {data.map((dataEntry: any) => {
+                    let nestedHtml = dataEntry?.type;
+                    if (nestedHtml) {
+                      return <td part="table-cell" innerHTML={dataEntry.value}></td>;
+                    } else {
+                      return <td part="table-cell">{dataEntry}</td>;
+                    }
+                  })}
                 </tr>
               ))}
             </tbody>

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
@@ -23,13 +23,10 @@ import { StyledHost, tableExportedParts } from '../../ui-components';
   * @exportedPart loading-state-spinner: Spinner element for loading state
   * @exportedPart error-state: Row for Error state
   * @exportedPart empty-state: Row for Emtpy state
-  * @exportedPart pagination-bar: Pagination bar
-  * @exportedPart arrow: Both paging buttons
-  * @exportedPart arrow-left: Previous page button
-  * @exportedPart arrow-right: Next page button
-  * @exportedPart button-disabled: Disabled state for paging buttons
-  * @exportedPart previous-button-text: Text for Previous button
-  * @exportedPart next-button-text: Text for Next button
+  * @exportedPart pagination: Pagination bar
+  * @exportedPart page-item: Pagination button
+  * @exportedPart page-link: Pagination link
+  * @exportedPart page-link-disabled: Disabled pagination link
 */
 @Component({
   tag: 'justifi-checkouts-list',

--- a/packages/webcomponents/src/components/checkouts-list/test/__snapshots__/checkouts-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkouts-list/test/__snapshots__/checkouts-list-core.spec.tsx.snap
@@ -245,123 +245,173 @@ exports[`checkouts-list-core renders properly with fetched data 1`] = `
         </thead>
         <tbody class="table-body" part="table-body">
           <tr data-row-entity-id="cho_1a2b3c4d5e6f7g8h9i0j" data-test-id="table-row" part="table-row table-row-odd">
-            <th>
-              <div class="fw-bold">
-                Aug 8, 2024
-              </div>
-              <div class="fw-bold">
-                3:47pm
-              </div>
-            </th>
-            <td>
-              $3.99 USD
+            <td part="table-cell">
+              <th>
+                <div class="fw-bold">
+                  Aug 8, 2024
+                </div>
+                <div class="fw-bold">
+                  3:47pm
+                </div>
+              </th>
             </td>
-            <td>
-              One Chocolate Donut
+            <td part="table-cell">
+              <td>
+                $3.99 USD
+              </td>
             </td>
-            <td>
-              Card Present
+            <td part="table-cell">
+              <td>
+                One Chocolate Donut
+              </td>
             </td>
-            <td>
-              <span class="badge bg-success" title="The checkout has been completed">
-                Completed
-              </span>
+            <td part="table-cell">
+              <td>
+                Card Present
+              </td>
+            </td>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-success" title="The checkout has been completed">
+                  Completed
+                </span>
+              </td>
             </td>
           </tr>
           <tr data-row-entity-id="cho_2b3c4d5e6f7g8h9i0j1a" data-test-id="table-row" part="table-row table-row-even">
-            <th>
-              <div class="fw-bold">
-                Aug 8, 2024
-              </div>
-              <div class="fw-bold">
-                4:32pm
-              </div>
-            </th>
-            <td>
-              $10.99 USD
+            <td part="table-cell">
+              <th>
+                <div class="fw-bold">
+                  Aug 8, 2024
+                </div>
+                <div class="fw-bold">
+                  4:32pm
+                </div>
+              </th>
             </td>
-            <td>
-              1 Dozen Chocolate Donuts
+            <td part="table-cell">
+              <td>
+                $10.99 USD
+              </td>
             </td>
-            <td>
-              Card Present
+            <td part="table-cell">
+              <td>
+                1 Dozen Chocolate Donuts
+              </td>
             </td>
-            <td>
-              <span class="badge bg-danger" title="The checkout has expired">
-                Expired
-              </span>
+            <td part="table-cell">
+              <td>
+                Card Present
+              </td>
+            </td>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-danger" title="The checkout has expired">
+                  Expired
+                </span>
+              </td>
             </td>
           </tr>
           <tr data-row-entity-id="cho_3c4d5e6f7g8h9i0j1a2b" data-test-id="table-row" part="table-row table-row-odd">
-            <th>
-              <div class="fw-bold">
-                Aug 8, 2024
-              </div>
-              <div class="fw-bold">
-                4:32pm
-              </div>
-            </th>
-            <td>
-              $19.99 USD
+            <td part="table-cell">
+              <th>
+                <div class="fw-bold">
+                  Aug 8, 2024
+                </div>
+                <div class="fw-bold">
+                  4:32pm
+                </div>
+              </th>
             </td>
-            <td>
-              2 Dozen Chocolate Donuts - Website To Go Order
+            <td part="table-cell">
+              <td>
+                $19.99 USD
+              </td>
             </td>
-            <td>
-              E-commerce
+            <td part="table-cell">
+              <td>
+                2 Dozen Chocolate Donuts - Website To Go Order
+              </td>
             </td>
-            <td>
-              <span class="badge bg-primary" title="The checkout has been created">
-                Created
-              </span>
+            <td part="table-cell">
+              <td>
+                E-commerce
+              </td>
+            </td>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-primary" title="The checkout has been created">
+                  Created
+                </span>
+              </td>
             </td>
           </tr>
           <tr data-row-entity-id="cho_4d5e6f7g8h9i0j1a2b3c" data-test-id="table-row" part="table-row table-row-even">
-            <th>
-              <div class="fw-bold">
-                Aug 8, 2024
-              </div>
-              <div class="fw-bold">
-                4:32pm
-              </div>
-            </th>
-            <td>
-              $89.99 USD
+            <td part="table-cell">
+              <th>
+                <div class="fw-bold">
+                  Aug 8, 2024
+                </div>
+                <div class="fw-bold">
+                  4:32pm
+                </div>
+              </th>
             </td>
-            <td>
-              Weekly Donut Box Subscription
+            <td part="table-cell">
+              <td>
+                $89.99 USD
+              </td>
             </td>
-            <td>
-              Buy Now Pay Later
+            <td part="table-cell">
+              <td>
+                Weekly Donut Box Subscription
+              </td>
             </td>
-            <td>
-              <span class="badge bg-primary" title="The checkout has been created">
-                Created
-              </span>
+            <td part="table-cell">
+              <td>
+                Buy Now Pay Later
+              </td>
+            </td>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-primary" title="The checkout has been created">
+                  Created
+                </span>
+              </td>
             </td>
           </tr>
           <tr data-row-entity-id="cho_5e6f7g8h9i0j1a2b3c4d" data-test-id="table-row" part="table-row table-row-odd">
-            <th>
-              <div class="fw-bold">
-                Aug 8, 2024
-              </div>
-              <div class="fw-bold">
-                4:32pm
-              </div>
-            </th>
-            <td>
-              $24.99 USD
+            <td part="table-cell">
+              <th>
+                <div class="fw-bold">
+                  Aug 8, 2024
+                </div>
+                <div class="fw-bold">
+                  4:32pm
+                </div>
+              </th>
             </td>
-            <td>
-              Donut Shop Size M T Shirt - Website Order
+            <td part="table-cell">
+              <td>
+                $24.99 USD
+              </td>
             </td>
-            <td>
-              E-commerce
+            <td part="table-cell">
+              <td>
+                Donut Shop Size M T Shirt - Website Order
+              </td>
             </td>
-            <td>
-              <span class="badge bg-secondary" title="The checkout has been attempted">
-                Attempted
-              </span>
+            <td part="table-cell">
+              <td>
+                E-commerce
+              </td>
+            </td>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-secondary" title="The checkout has been attempted">
+                  Attempted
+                </span>
+              </td>
             </td>
           </tr>
         </tbody>

--- a/packages/webcomponents/src/components/terminals-list/terminals-list-core.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-list-core.tsx
@@ -45,7 +45,7 @@ export class TerminalsListCore {
 
   fetchTerminals(): void {
     this.loading = true;
-    
+
     this.getTerminals({
       params: this.params,
       onSuccess: async ({ terminals, pagingInfo }) => {
@@ -59,7 +59,7 @@ export class TerminalsListCore {
         } else {
           this.loading = false;
         }
-        
+
       },
       onError: ({ error, code, severity }) => {
         this.errorMessage = error;
@@ -157,7 +157,7 @@ export class TerminalsListCore {
         />
         <div class="table-wrapper">
           <table class="table table-hover">
-          <thead class="table-head sticky-top" part="table-head">
+            <thead class="table-head sticky-top" part="table-head">
               <tr class="table-light text-nowrap" part="table-head-row">
                 {this.terminalsTable.columnData.map((column) => column)}
               </tr>
@@ -182,7 +182,14 @@ export class TerminalsListCore {
                   onClick={this.rowClickHandler}
                   part={`table-row ${index % 2 ? "table-row-even" : "table-row-odd"}`}
                 >
-                  {data}
+                  {data.map((dataEntry: any) => {
+                    let nestedHtml = dataEntry?.type;
+                    if (nestedHtml) {
+                      return <td part="table-cell" innerHTML={dataEntry.value}></td>;
+                    } else {
+                      return <td part="table-cell">{dataEntry}</td>;
+                    }
+                  })}
                 </tr>
               ))}
             </tbody>

--- a/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
@@ -23,13 +23,10 @@ import { StyledHost, tableExportedParts } from '../../ui-components';
   * @exportedPart loading-state-spinner: Spinner element for loading state
   * @exportedPart error-state: Row for Error state
   * @exportedPart empty-state: Row for Emtpy state
-  * @exportedPart pagination-bar: Pagination bar
-  * @exportedPart arrow: Both paging buttons
-  * @exportedPart arrow-left: Previous page button
-  * @exportedPart arrow-right: Next page button
-  * @exportedPart button-disabled: Disabled state for paging buttons
-  * @exportedPart previous-button-text: Text for Previous button
-  * @exportedPart next-button-text: Text for Next button
+  * @exportedPart pagination: Pagination bar
+  * @exportedPart page-item: Pagination button
+  * @exportedPart page-link: Pagination link
+  * @exportedPart page-link-disabled: Disabled pagination link
 */
 @Component({
   tag: 'justifi-terminals-list',
@@ -40,12 +37,12 @@ export class TerminalsList {
   @State() getTerminals: Function;
   @State() getSubAccounts: Function;
   @State() errorMessage: string = null;
-  
+
   @Prop() accountId: string;
   @Prop() authToken: string;
   @Prop() apiOrigin?: string = config.proxyApiOrigin;
   @Prop() columns: string;
-  
+
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentError>;
 
   analytics: JustifiAnalytics;
@@ -108,7 +105,7 @@ export class TerminalsList {
   render() {
     return (
       <StyledHost exportparts={tableExportedParts}>
-        <terminals-list-core 
+        <terminals-list-core
           getTerminals={this.getTerminals}
           getSubAccounts={this.getSubAccounts}
           onError-event={this.handleErrorEvent}

--- a/packages/webcomponents/src/components/terminals-list/test/__snapshots__/terminals-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/terminals-list/test/__snapshots__/terminals-list-core.spec.tsx.snap
@@ -187,42 +187,60 @@ exports[`terminals-list-core renders properly with fetched data 1`] = `
         </thead>
         <tbody class="table-body" part="table-body">
           <tr data-row-entity-id="trm_43Y2lE9E2ULR8pvaKI6D5v" data-test-id="table-row" part="table-row table-row-odd">
-            <td>
-              Terminal 1
+            <td part="table-cell">
+              <td>
+                Terminal 1
+              </td>
             </td>
-            <td>
-              453-760-515
+            <td part="table-cell">
+              <td>
+                453-760-515
+              </td>
             </td>
-            <td>
-              <span class="badge bg-danger" title="This terminal is disconnected.">
-                Disconnected
-              </span>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-danger" title="This terminal is disconnected.">
+                  Disconnected
+                </span>
+              </td>
             </td>
           </tr>
           <tr data-row-entity-id="trm_6TFOXK5U0LZLyQ6y6t3sbj" data-test-id="table-row" part="table-row table-row-even">
-            <td>
-              Terminal 2
+            <td part="table-cell">
+              <td>
+                Terminal 2
+              </td>
             </td>
-            <td>
-              807-075-625
+            <td part="table-cell">
+              <td>
+                807-075-625
+              </td>
             </td>
-            <td>
-              <span class="badge bg-danger" title="This terminal is disconnected.">
-                Disconnected
-              </span>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-danger" title="This terminal is disconnected.">
+                  Disconnected
+                </span>
+              </td>
             </td>
           </tr>
           <tr data-row-entity-id="trm_F8UyFyXcaTBwSDh1cMxjc" data-test-id="table-row" part="table-row table-row-odd">
-            <td>
-              Terminal 3
+            <td part="table-cell">
+              <td>
+                Terminal 3
+              </td>
             </td>
-            <td>
-              450-060-752
+            <td part="table-cell">
+              <td>
+                450-060-752
+              </td>
             </td>
-            <td>
-              <span class="badge bg-success" title="This terminal is connected.">
-                Connected
-              </span>
+            <td part="table-cell">
+              <td>
+                <span class="badge bg-success" title="This terminal is connected.">
+                  Connected
+                </span>
+              </td>
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
This PR commits the following changes: 

- Use the same Theming logic of the other list components on Storybook stories for the `TerminalsList` and `CheckoutsList`
- Adds the `table-cell` part on both components

Links
-----
#770 


Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

CheckoutsList and Terminals list should now: 
[ ] - Display `default`, `Light`, and `Dark` theme as options
[ ] - Look like the other list components on each theme.

