### PR TITLE
Loosen string validation requirements for several fields in Payment Provisioning component

### DIFF
--- a/.changeset/wild-weeks-turn.md
+++ b/.changeset/wild-weeks-turn.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": minor
+---
+
+- Updated validation for multiple fields in `justifi-payment-provisioning` component - most text fields will now allow special characters in addition to alphanumerical characters.

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -17,7 +17,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     website_url: websiteUrlValidation.required('Enter business website url'),
     email: emailValidation.required('Enter business email'),
     phone: phoneValidation.required('Enter phone number'),
-    doing_business_as: doingBusinessAsValidation.required('Enter doing business as'),
+    doing_business_as: doingBusinessAsValidation.nullable(),
     classification: businessClassificationValidation.required('Select business classification'),
     industry: industryValidation.required('Enter a business industry'),
     tax_id: taxIdValidation.required('Enter tax id, SSN, or EIN'),

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -8,13 +8,10 @@ import {
   businessClassificationOptions
 } from '../utils/business-form-options';
 import {
-  businessNameRegex,
   numbersOnlyRegex,
   phoneRegex,
   poBoxRegex,
   ssnRegex,
-  streetAddressRegex,
-  stringLettersOnlyRegex,
   transformEmptyString,
   urlRegex,
   validateRoutingNumber
@@ -36,13 +33,11 @@ export const phoneValidation = string()
 export const businessNameValidation = string()
   .min(2, 'Name must be at least 2 characters')
   .max(100, 'Name must be less than 100 characters')
-  .matches(businessNameRegex, 'Enter valid business name')
   .transform(transformEmptyString);
 
 export const doingBusinessAsValidation = string()
   .min(2, 'Name must be at least 2 characters')
   .max(100, 'Name must be less than 100 characters')
-  .matches(businessNameRegex, 'Enter valid doing business as')
   .transform(transformEmptyString);
 
 export const websiteUrlValidation = string()
@@ -56,7 +51,6 @@ export const businessClassificationValidation = string()
 export const industryValidation = string()
   .min(2, 'Industry must be at least 2 characters')
   .max(50, 'Industry must be less than 50 characters')
-  .matches(stringLettersOnlyRegex, 'Enter valid industry')
   .transform(transformEmptyString);
 
 export const taxIdValidation = string()
@@ -87,7 +81,6 @@ export const identityNameValidation = string()
 export const identityTitleValidation = string()
   .min(2, 'Title must be at least 2 characters')
   .max(50, 'Title must be less than 50 characters')
-  .matches(stringLettersOnlyRegex, 'Enter valid title')
   .transform(transformEmptyString);
 
 export const dobValidation = (role: string) => {
@@ -128,7 +121,6 @@ export const ssnValidation = string()
 export const lineOneValidation = string()
   .min(5, 'Address must be at least 5 characters')
   .max(100, 'Address must be less than 100 characters')
-  .matches(streetAddressRegex, 'Enter valid address line 1')
   .test('not-po-box', 'A PO Box is not a valid address entry', (value) => {
     return !poBoxRegex.test(value);
   })
@@ -136,7 +128,6 @@ export const lineOneValidation = string()
 
 export const lineTwoValidation = string()
   .max(100, 'Address must be less than 100 characters')
-  .matches(streetAddressRegex, 'Enter valid address line 2')
   .test('not-po-box', 'A PO Box is not a valid address entry', (value) => {
     return !poBoxRegex.test(value);
   })
@@ -145,7 +136,6 @@ export const lineTwoValidation = string()
 export const cityValidation = string()
   .min(2, 'City must be at least 2 characters')
   .max(50, 'City must be less than 50 characters')
-  .matches(stringLettersOnlyRegex, 'Enter valid city')
   .transform(transformEmptyString);
 
 export const stateValidation = string()
@@ -194,13 +184,11 @@ export const otherPaymentDetailsValidation = string()
 export const bankNameValidation = string()
   .min(2, 'Name must be at least 2 characters')
   .max(50, 'Name must be less than 50 characters')
-  .matches(stringLettersOnlyRegex, 'Enter valid bank name')
   .transform(transformEmptyString);
 
 export const nicknameValidation = string()
   .min(2, 'Name must be at least 2 characters')
   .max(50, 'Name must be less than 50 characters')
-  .matches(stringLettersOnlyRegex, 'Enter valid nickname')
   .transform(transformEmptyString);
 
 export const accountTypeValidation = string()


### PR DESCRIPTION
### Loosen string validation requirements for several fields in Payment Provisioning component

Several fields in the Payment Provisioning component have had their validation rules relaxed to allow for special characters to be entered. 

Links
-----

Closes #780 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

Several fields in the Payment Provisioning component have had their validation rules relaxed to allow for special characters to be entered. 

Ensure that the following fields have looser validation requirements: 

`Step 1 - Core Info`

- [x] Business Name
- [x] Doing Business As
- [x] Industry


`Step 2 - Address`

- [x] Address Line 1
- [x] Address Line 2
- [x] City

`Step 4 - Representative`

- [x] Name
- [x] Title
- [x] Address Line 1
- [x] Address Line 2
- [x] City

`Step 5 - Owner`

- [x] Name
- [x] Title
- [x] Address Line 1
- [x] Address Line 2
- [x] City

`Step 6 - Bank`

- [x] Bank Name
- [x] Nickname
- [x] Account Owner Name