### PR TITLE
Update bank account schema to allow for 7 character account numbers

### DIFF
--- a/.changeset/ten-turkeys-grow.md
+++ b/.changeset/ten-turkeys-grow.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Adjusted minimum character length for bank account number field in bank account form step of `justifi-payment-provisioning` component. The minimum character length was previously 8 characfters, and is now 7.

--- a/.changeset/ten-turkeys-grow.md
+++ b/.changeset/ten-turkeys-grow.md
@@ -2,4 +2,4 @@
 "@justifi/webcomponents": patch
 ---
 
-- Adjusted minimum character length for bank account number field in bank account form step of `justifi-payment-provisioning` component. The minimum character length was previously 8 characfters, and is now 7.
+- Adjusted minimum character length for bank account number field in bank account form step of `justifi-payment-provisioning` component. The minimum character length has been adjusted from 8 to 7.

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -196,7 +196,7 @@ export const accountTypeValidation = string()
   .transform(transformEmptyString);
 
 export const accountNumberValidation = string()
-  .min(8, 'Account number must be at least 8 digits')
+  .min(7, 'Account number must be at least 7 digits')
   .max(17, 'Account number must be less than 17 digits')
   .matches(numbersOnlyRegex, 'Enter valid account number')
   .test('not-repeat', 'Enter valid account number', (value) => {


### PR DESCRIPTION
### Update bank account schema to allow for 7 character account numbers


Links
-----

Closes #785 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

- [ ] Bank Account Number field in bank account form step should now allow 7 character entries as minimum

