### PR TITLE
Improve story decorator to accect a render config function

### DIFF
--- a/apps/docs/stories/components/PaymentsList/index.stories.tsx
+++ b/apps/docs/stories/components/PaymentsList/index.stories.tsx
@@ -1,8 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/web-components";
-import { withActions } from "@storybook/addon-actions/decorator";
-import { StoryBaseArgs } from "../../utils";
-import themes, { ThemeNames } from "../../themes";
-import { setUpMocks } from "../../utils/mockAllServices";
+import { customStoryDecorator, StoryBaseArgs } from "../../utils";
+import { ThemeNames } from "../../themes";
 
 import "@justifi/webcomponents/dist/module/justifi-payments-list";
 import "@justifi/webcomponents/dist/module/justifi-payments-list-filters";
@@ -22,11 +20,11 @@ const examplePayload = {
   "currency": "usd",
   "description": "my_order_xyz",
   "disputed": false,
-  "disputes": [ ],
+  "disputes": [],
   "error_code": "credit_card_number_invalid",
   "error_description": "Credit Card Number Invalid (Failed LUHN checksum)",
   "is_test": true,
-  "metadata": { },
+  "metadata": {},
   "payment_intent_id": "pi_123xyz",
   "checkout_id": "cho_123",
   "payment_method": {},
@@ -36,7 +34,9 @@ const examplePayload = {
   "payment_mode": "ecom",
   "created_at": "2021-01-01T12:00:00Z",
   "updated_at": "2021-01-01T12:00:00Z"
-  };
+};
+
+type Story = StoryObj;
 
 const storyBaseArgs = new StoryBaseArgs(["account-id", "auth-token"]);
 
@@ -45,7 +45,7 @@ const meta: Meta = {
   component: "justifi-payments-list",
   args: {
     ...storyBaseArgs.args,
-    Theme: ThemeNames.Light
+    Theme: ThemeNames.Light,
   },
   argTypes: {
     ...storyBaseArgs.argTypes,
@@ -57,9 +57,6 @@ const meta: Meta = {
         type: "select",
       },
     },
-    'withFilters': {
-      table: { disable: true }
-    },
     "row-clicked": {
       description: "`RowClicked`",
       table: {
@@ -69,14 +66,12 @@ const meta: Meta = {
           detail: JSON.stringify(examplePayload)
         }
       },
-      action: true,
     },
     "error-event": {
       description: "`ComponentError`",
       table: {
         category: "events",
       },
-      action: true,
     },
     "columns": {
       description: "Columns to display in the table <br> Pass a comma separated list of columns to display in the table.",
@@ -100,50 +95,24 @@ const meta: Meta = {
       delay: 2000,
     },
   },
-  render: ({ label, ...args }) => {
-    let component = `<justifi-payments-list auth-token="${args["auth-token"]}" account-id="${args["account-id"]}"></justifi-payments-list>`;
-    
-    if (args.withFilters) {
-      component = `
-        <justifi-payments-list-filters></justifi-payments-list-filters>
-        <justifi-payments-list auth-token="${args["auth-token"]}" account-id="${args["account-id"]}"></justifi-payments-list>
-      `
-    }
-    
-    return component;
-  }
+  decorators: [
+    customStoryDecorator,
+  ]
 };
 
-export const Example: StoryObj = {};
-Example.decorators = [
-  (story: any, storyArgs: any) => {
-    setUpMocks();
+export const Example: Story = {};
 
-    // Import the style here to not pollute other framework stories
-    const selectedTheme = storyArgs.args["Theme"] as ThemeNames;
-    const styleElement = document.createElement("style");
-    styleElement.textContent = themes[selectedTheme];
-
-    return `${styleElement.outerHTML}${story()}`;
-  },
-  // @ts-ignore
-  withActions,
-];
-
-export const ExampleWithFilters: StoryObj = { args: { withFilters: true } };
-ExampleWithFilters.decorators = [
-  (story: any, storyArgs: any) => {
-    setUpMocks();
-
-    // Import the style here to not pollute other framework stories
-    const selectedTheme = storyArgs.args["Theme"] as ThemeNames;
-    const styleElement = document.createElement("style");
-    styleElement.textContent = themes[selectedTheme];
-
-    return `${styleElement.outerHTML}${story()}`;
-  },
-  // @ts-ignore
-  withActions,
-];
+export const ExampleWithFilters: Story = {
+  args: {},
+  render: (args) => `
+    <div>
+      <justifi-payments-list-filters></justifi-payments-list-filters>
+      <justifi-payments-list
+        auth-token="${args["auth-token"]}"
+        account-id="${args["account-id"]}">
+      </justifi-payments-list>
+    </div>
+  `
+};
 
 export default meta;

--- a/apps/docs/stories/utils/decorators.ts
+++ b/apps/docs/stories/utils/decorators.ts
@@ -23,10 +23,26 @@ const getPropsAndStyles = (storyContext: any) => {
 };
 
 const applyArgsToStoryComponent = (storyComponent: any, props: Props) => {
-  const component = storyComponent();
+  const componentOutput = storyComponent(); // Call the story function
+
+  let component: HTMLElement;
+
+  if (typeof componentOutput === 'string') {
+    // If the output is an HTML string, parse it into an element
+    const template = document.createElement('template');
+    template.innerHTML = componentOutput.trim();
+    component = template.content.firstElementChild as HTMLElement;
+  } else if (componentOutput instanceof HTMLElement) {
+    // If already a DOM element, use it directly
+    component = componentOutput;
+  } else {
+    throw new Error('Unsupported component output type');
+  }
 
   props.forEach((prop) => {
-    component.setAttribute(prop.name, prop.value, prop);
+    if (prop.value !== undefined) {
+      component.setAttribute(prop.name, prop.value);
+    }
   });
 
   return component;


### PR DESCRIPTION
This PR improves the `applyArgsToStoryComponent` in a way so if we pass `render` function in a story it will be handled alright. 

The `render` function should return HTML as a string, and this was making the `applyArgsToStoryComponent` to break. Right now if it receives a HTML string, it parses the string to a component first, and then applies the logic. 

This PR also implements a suggestion of improvement on the PaymentsList Story.


Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

