### PR TITLE
Return more accurate response data for payment provisioning mock data

### DIFF
--- a/apps/docs/stories/utils/mockAllServices.ts
+++ b/apps/docs/stories/utils/mockAllServices.ts
@@ -83,9 +83,14 @@ export const mockAllServices = (config: MockAllServicesConfig = {}): void => {
       this.get(API_PATHS.EXISTING_BUSINESS_OWNER, () => mockBusinessOwner);
 
       this.patch(API_PATHS.EXISTING_BUSINESS_OWNER, (_schema, request) => {
-        const id = request.params.id;
-        const newOwner = JSON.parse(request.requestBody);
-        return { ...mockBusinessOwner, ...newOwner, id };
+        const newRequestData = JSON.parse(request.requestBody);
+        let mergedRequestData = { ...mockBusinessDetails.data.owners[0], ...newRequestData };
+        return {
+          id: 2,
+          type: "identity",
+          data: mergedRequestData,
+          page_info: "string"
+        };
       });
 
       this.post(API_PATHS.NEW_BUSINESS_OWNER, () => mockBusinessOwner);
@@ -94,9 +99,14 @@ export const mockAllServices = (config: MockAllServicesConfig = {}): void => {
       this.get(API_PATHS.BUSINESS_DETAILS, () => mockBusinessDetails);
 
       this.patch(API_PATHS.BUSINESS_DETAILS, (_schema, request) => {
-        const id = request.params.id;
-        const newDetails = JSON.parse(request.requestBody);
-        return { ...mockBusinessDetails, ...newDetails, id };
+        const newRequestData = JSON.parse(request.requestBody);
+        let mergedRequestData = { ...mockBusinessDetails.data, ...newRequestData };
+        return {
+          id: 1,
+          type: "business",
+          data: mergedRequestData,
+          page_info: "string"
+        };
       });
 
       this.post(API_PATHS.BUSINESS_DOCUMENT_RECORD, () => mockDocumentUpload);

--- a/mockData/mockBusinessProvisioningSuccess.json
+++ b/mockData/mockBusinessProvisioningSuccess.json
@@ -5,7 +5,64 @@
     "account_type": "test",
     "sub_account_id": "acc_xyz",
     "platform_account_id": "acc_123",
-    "payload": {}
+    "payload": {
+      "onboarding_version": "v1.0",
+      "business_details": {
+        "legal": {
+          "name": "Business 165",
+          "address_line1": "123 Example St",
+          "address_city": "Minneapolis",
+          "address_state": "MN",
+          "address_postal_code": "55555",
+          "address_country": "USA"
+        },
+        "doing_business_as": {
+          "name": "Best Business"
+        },
+        "url": "https://justifi.ai",
+        "type": "for_profit",
+        "structure": "sole_proprietorship",
+        "industry": "Big Business",
+        "tax_id": "884351551",
+        "phone": "6124011111",
+        "email": "business@justifi.ai"
+      },
+      "representative": {
+        "name": "Person Name",
+        "title": "President",
+        "email": "person.name@justifi.ai",
+        "dob_month": "01",
+        "dob_day": "01",
+        "dob_year": "1980",
+        "address_line1": "123 Example St",
+        "address_city": "Minneapolis",
+        "address_state": "MN",
+        "address_postal_code": "55555",
+        "address_country": "USA",
+        "phone": "6124011111",
+        "ssn_last4": "6789",
+        "is_owner": true
+      },
+      "owners": [
+        {
+          "name": "Person Name",
+          "email": "person.name@justifi.ai"
+        }
+      ],
+      "bank_account": {
+        "bank_name": "Bank",
+        "account_nickname": "Test Bank",
+        "routing_number": "021000021",
+        "account_number": "1234567891",
+        "account_type": "checking",
+        "account_owner_name": "Person Name"
+      },
+      "terms_and_conditions": {
+        "accepted": true,
+        "ip": "72.211.73.132",
+        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36"
+      }
+    }
   },
   "page_info": "string"
 }


### PR DESCRIPTION
### Return accurate mock data for payment provisioning form's `complete-form-step-event`

This PR adjusts the mock data passthrough for patching business's to return a response object that is structured the same as a real world example. 

Also updated the mock response for the Provisioning request to include an accurate `payload` property. 

Note - this is purely for testing the component in Storybook with mock data enabled. 


Links
-----

Closes #810 


Developer QA steps
--------------------

- [x] `complete-form-step-event` returns an accurate response object at `event.detail.response`
- [x] `submit-event` includes payload property that uses our existing mock data, structured to resemble an actual payload response.  

