### PR TITLE
Add Payment provisioning example file

### DIFF
--- a/apps/component-examples/css/theme.css
+++ b/apps/component-examples/css/theme.css
@@ -4,6 +4,7 @@ body {
 
 justifi-checkout,
 justifi-season-interruption-insurance,
+justifi-payment-provisioning,
 justifi-dispute-management {
   margin: 5% auto;
 }
@@ -19,6 +20,7 @@ justifi-tokenize-payment-method {
 }
 
 justifi-season-interruption-insurance,
+justifi-payment-provisioning,
 justifi-dispute-management {
   display: block;
   background-color: #fff;

--- a/apps/component-examples/examples/payment-provisioning.js
+++ b/apps/component-examples/examples/payment-provisioning.js
@@ -1,0 +1,119 @@
+require('dotenv').config();
+
+const express = require('express');
+const { generateRandomLegalName } = require('../utils/random-business-names'); // Correct import path
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(
+  '/scripts',
+  express.static(__dirname + '/../node_modules/@justifi/webcomponents/dist/')
+);
+app.use('/styles', express.static(__dirname + '/../css/'));
+
+async function getToken() {
+  const requestBody = JSON.stringify({
+    client_id: process.env.CLIENT_ID,
+    client_secret: process.env.CLIENT_SECRET,
+  });
+
+  let response;
+  try {
+    response = await fetch('https://api.justifi.ai/oauth/token', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
+
+  const { access_token } = await response.json();
+  console.log('response from getToken', access_token);
+
+  return access_token;
+}
+
+async function createBusiness(token) {
+  const randomLegalName = generateRandomLegalName();
+  const response = await fetch('https://api.justifi.ai/v1/entities/business', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      legal_name: randomLegalName,
+    }),
+  });
+  const res = await response.json();
+  console.log('response from createBusiness', res);
+  return res.id;
+};
+
+async function getWebComponentToken(token, businessId) {
+  const response = await fetch(
+    'https://api.justifi.ai/v1/web_component_tokens',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        resources: [
+          `write:business:${businessId}`,
+        ],
+      }),
+    }
+  );
+
+  const res = await response.json();
+  console.log('response from getWebComponentToken', res);
+
+  return res.access_token;
+}
+
+app.get('/', async (req, res) => {
+  const token = await getToken();
+  const businessId = await createBusiness(token);
+  const webComponentToken = await getWebComponentToken(token, businessId);
+
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>JustiFi Payment Provisioning Component</title>
+        <script type="module" src="/scripts/webcomponents/webcomponents.esm.js"></script>
+        <link rel="stylesheet" href="/styles/theme.css">
+        <link rel="stylesheet" href="/styles/example.css">
+      </head>
+      <body>
+        <div style="margin:0 auto;max-width:700px;">
+          <justifi-payment-provisioning
+            business-id="${businessId}"
+            auth-token="${webComponentToken}">
+          </justifi-payment-provisioning>
+        </div>
+
+        <script>
+          const justifiPaymentProvisioning = document.querySelector('justifi-payment-provisioning');
+
+          justifiPaymentProvisioning.addEventListener('submit-event', (event) => console.log(event));
+
+          justifiPaymentProvisioning.addEventListener('complete-form-step-event', (event) => console.log(event));
+
+          justifiPaymentProvisioning.addEventListener('click-event', (event) => console.log(event));
+          
+          justifiPaymentProvisioning.addEventListener('error-event', (event) => console.log(event));
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/apps/component-examples/examples/payment-provisioning.js
+++ b/apps/component-examples/examples/payment-provisioning.js
@@ -1,7 +1,7 @@
 require('dotenv').config();
 
 const express = require('express');
-const { generateRandomLegalName } = require('../utils/random-business-names'); // Correct import path
+const { generateRandomLegalName } = require('../utils/random-business-names');
 const app = express();
 const port = process.env.PORT || 3000;
 

--- a/apps/component-examples/utils/random-business-names.js
+++ b/apps/component-examples/utils/random-business-names.js
@@ -1,10 +1,10 @@
-const adjectives = [
+const firstNames = [
   'Lemon', 'Orange', 'Apple', 'Berry', 'Cherry', 'Grape', 'Peach', 'Plum', 'Mango', 'Pineapple',
   'Banana', 'Coconut', 'Kiwi', 'Melon', 'Papaya', 'Strawberry', 'Blueberry', 'Raspberry', 'Blackberry', 'Cranberry',
   'Dragonfruit', 'Guava', 'Lychee', 'Passionfruit', 'Pomegranate', 'Tangerine', 'Watermelon', 'Apricot', 'Fig', 'Grapefruit'
 ];
 
-const nouns = [
+const lastNames = [
   'Juice', 'Stand', 'Shop', 'Market', 'Store', 'Cart', 'Stall', 'Bar', 'Corner', 'Spot',
   'Bistro', 'Cafe', 'Deli', 'Eatery', 'Grill', 'Joint', 'Lounge', 'Parlor', 'Place', 'Restaurant',
   'Tavern', 'Bakery', 'Buffet', 'Cantina', 'Diner', 'Inn', 'Kitchen', 'Pub', 'Ristorante', 'Saloon'
@@ -15,10 +15,10 @@ function getRandomElement(arr) {
 };
 
 function generateRandomLegalName() {
-  const adjective = getRandomElement(adjectives);
-  const noun = getRandomElement(nouns);
+  const firstName = getRandomElement(firstNames);
+  const lastName = getRandomElement(lastNames);
   const uniqueNumber = Math.floor(Math.random() * 1000); // Add a unique number to ensure uniqueness
-  return `${adjective} ${noun} ${uniqueNumber}`;
+  return `${firstName} ${lastName} ${uniqueNumber}`;
 };
 
 module.exports = { generateRandomLegalName };

--- a/apps/component-examples/utils/random-business-names.js
+++ b/apps/component-examples/utils/random-business-names.js
@@ -1,0 +1,24 @@
+const adjectives = [
+  'Lemon', 'Orange', 'Apple', 'Berry', 'Cherry', 'Grape', 'Peach', 'Plum', 'Mango', 'Pineapple',
+  'Banana', 'Coconut', 'Kiwi', 'Melon', 'Papaya', 'Strawberry', 'Blueberry', 'Raspberry', 'Blackberry', 'Cranberry',
+  'Dragonfruit', 'Guava', 'Lychee', 'Passionfruit', 'Pomegranate', 'Tangerine', 'Watermelon', 'Apricot', 'Fig', 'Grapefruit'
+];
+
+const nouns = [
+  'Juice', 'Stand', 'Shop', 'Market', 'Store', 'Cart', 'Stall', 'Bar', 'Corner', 'Spot',
+  'Bistro', 'Cafe', 'Deli', 'Eatery', 'Grill', 'Joint', 'Lounge', 'Parlor', 'Place', 'Restaurant',
+  'Tavern', 'Bakery', 'Buffet', 'Cantina', 'Diner', 'Inn', 'Kitchen', 'Pub', 'Ristorante', 'Saloon'
+];
+
+function getRandomElement(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+};
+
+function generateRandomLegalName() {
+  const adjective = getRandomElement(adjectives);
+  const noun = getRandomElement(nouns);
+  const uniqueNumber = Math.floor(Math.random() * 1000); // Add a unique number to ensure uniqueness
+  return `${adjective} ${noun} ${uniqueNumber}`;
+};
+
+module.exports = { generateRandomLegalName };


### PR DESCRIPTION
### Add Payment provisioning example file to `component-examples`

This PR commits the following changes:

- Adds code to `payment-provisioning.js` allowing file to fetch access token, create a business using a randomly generated name, post web component token for this business, and render the component to the page. 

Links
-----

Closes #826 


Developer QA steps
--------------------

- [ ] Example file looks good
- [ ] Rendered component looks acceptable
- [ ] component properly renders and retrieves business data that was created during startup

