### PR TITLE
Add checkoutSummary part to checkout component and update snapshots

### DIFF
--- a/.changeset/kind-parrots-roll.md
+++ b/.changeset/kind-parrots-roll.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Adds a `checkout-summary` part so the Summary section on the `justifi-checkout` can be hidden

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -6,7 +6,7 @@ import { ComponentErrorCodes, ComponentErrorSeverity } from '../../api/Component
 import { insuranceValues, insuranceValuesOn, validateInsuranceValues } from '../insurance/insurance-state';
 import { BillingFormFields, PostalFormFields } from '../billing-forms/billing-form-schema';
 import { Button, StyledHost, Skeleton, Header2, Header3 } from '../../ui-components';
-import { text } from '../../styles/parts';
+import { checkoutSummary, text } from '../../styles/parts';
 import { ComponentErrorEvent, ComponentSubmitEvent } from '../../api/ComponentEvents';
 
 @Component({
@@ -190,7 +190,7 @@ export class CheckoutCore {
     return (
       <StyledHost>
         <div class="row gy-3 jfi-checkout-core">
-          <div class="col-12">
+          <div class="col-12" part={checkoutSummary}>
             <Header2 text="Summary" class="fs-5 fw-bold pb-3" />
             {this.summary}
           </div>

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`justifi-checkout-core should display loading state correctly 1`] = `
   <template shadowrootmode="open">
     <style></style>
     <div class="gy-3 jfi-checkout-core row">
-      <div class="col-12">
+      <div class="col-12" part="checkout-summary">
         <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
           Summary
         </h2>
@@ -70,7 +70,7 @@ exports[`justifi-checkout-core should render the full billing form by default 1`
   <template shadowrootmode="open">
     <style></style>
     <div class="gy-3 jfi-checkout-core row">
-      <div class="col-12">
+      <div class="col-12" part="checkout-summary">
         <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
           Summary
         </h2>
@@ -186,7 +186,7 @@ exports[`justifi-checkout-core should render the postal form if hideCardBillingF
   <template shadowrootmode="open">
     <style></style>
     <div class="gy-3 jfi-checkout-core row">
-      <div class="col-12">
+      <div class="col-12" part="checkout-summary">
         <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
           Summary
         </h2>
@@ -282,7 +282,7 @@ exports[`justifi-checkout-core should set checkout correctly to state 1`] = `
   <template shadowrootmode="open">
     <style></style>
     <div class="gy-3 jfi-checkout-core row">
-      <div class="col-12">
+      <div class="col-12" part="checkout-summary">
         <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
           Summary
         </h2>

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`justifi-checkout renders loading 1`] = `
     <template shadowrootmode="open">
       <style></style>
       <div class="gy-3 jfi-checkout-core row">
-        <div class="col-12">
+        <div class="col-12" part="checkout-summary">
           <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
             Summary
           </h2>

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -96,3 +96,4 @@ export const skeleton = `skeleton`;
 // This allows the billing form to be hidden, for example
 // ::part(billing-form) { display: none; }
 export const billingForm = `billing-form`;
+export const checkoutSummary = `checkout-summary`;

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -93,7 +93,7 @@ export const radioListItem = `radio-list-item ${text}`;
 export const skeleton = `skeleton`;
 
 // Component specific
-// This allows the billing form to be hidden, for example
+// This allows specific sections of a component to be hidden, for example
 // ::part(billing-form) { display: none; }
 export const billingForm = `billing-form`;
 export const checkoutSummary = `checkout-summary`;


### PR DESCRIPTION
Based on a customer request, this PR adds the `checkout-summary` part, so it can be hidden.


Links
-----
#840 

Developer considerations
--------------

Developer QA steps
--------------------
 
To test this, add to `apps/component-examples/css/example.css` the following: 
```
::part(checkout-summary) { display: none; }
```

- [X] Run `pnpm dev:checkout` and the Summary section should be hidden.

