### PR TITLE
increment submit-event payload to include full payment-methods response and update documentation

### DIFF
--- a/.changeset/kind-hornets-divide.md
+++ b/.changeset/kind-hornets-divide.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": minor
+"@repo/docs": minor
+---
+
+Increments the `justifi-tokenize-payment-method` `submit-event` payload to return also the full api's `payment-methods` payload response

--- a/apps/docs/stories/components/TokenizePaymentMethod/index.stories.tsx
+++ b/apps/docs/stories/components/TokenizePaymentMethod/index.stories.tsx
@@ -105,7 +105,9 @@ const meta: Meta = {
       description: "Emitted upon successful tokenization of a payment method",
       table: {
         category: "events",
-        defaultValue: { summary: "Returns payment token as `event.detail.response.token`" },
+        defaultValue: {
+          summary: "Returns the payment token and the full `payment-method` response"
+        },
       },
       action: true
     },
@@ -118,7 +120,7 @@ const meta: Meta = {
       action: true,
     },
     fillBillingForm: {
-      description:"Fill the billing form with the provided fields",
+      description: "Fill the billing form with the provided fields",
       table: {
         category: "methods",
         defaultValue: { summary: "`fillBillingForm(fields: BillingFormFields) => Promise<void>`" }

--- a/packages/webcomponents/src/components/checkout/new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/new-payment-method.tsx
@@ -54,7 +54,10 @@ export class NewPaymentMethod {
         return { error: tokenizeResponse.error };
       } else {
         const tokenizeRessponseData = tokenizeResponse.data;
-        return { token: tokenizeRessponseData.card?.token || tokenizeRessponseData.bank_account?.token };
+        return {
+          token: tokenizeRessponseData.card?.token || tokenizeRessponseData.bank_account?.token,
+          data: tokenizeRessponseData
+        };
       }
     } catch (error) {
       return { error };
@@ -102,7 +105,7 @@ export class NewPaymentMethod {
           )}
 
         </div>
-        <justifi-billing-form-wrapper 
+        <justifi-billing-form-wrapper
           ref={(el) => (this.billingFormWrapperRef = el)}
           hideCardBillingForm={this.hideCardBillingForm}
           paymentMethodType={paymentMethodType}

--- a/packages/webcomponents/src/components/checkout/payment-method-payload.ts
+++ b/packages/webcomponents/src/components/checkout/payment-method-payload.ts
@@ -1,15 +1,17 @@
+import { CreatePaymentMethodResponse } from './payment-method-responses';
 
 export interface PaymentMethodPayload {
+  data?: CreatePaymentMethodResponse;
   token?: string;
   bnpl?: {
     order_uuid: string;
     status: string;
     session_uuid: string;
-  },
+  };
   error?: {
     code: string;
     message: string;
     decline_code: string;
-  },
+  };
   validationError?: boolean;
 }


### PR DESCRIPTION
Adds `data` alongside with the `token` on the `sumit-event`

```
export interface PaymentMethodPayload {
  data?: CreatePaymentMethodResponse;
  token?: string;
  bnpl?: {
    order_uuid: string;
    status: string;
    session_uuid: string;
  };
  error?: {
    code: string;
    message: string;
    decline_code: string;
  };
  validationError?: boolean;
}
```

Links
-----
#854 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [X]  The `<justifi-tokenize-payment-method />` should now return also `data` with the full response from `payment-methods` api call. You should be able to see it interacting with the example-app `pnpm dev:tokenize-payment-method`.
