### PR TITLE
Update bank account form schema to allow shorter bank account numbers to be entered

### DIFF
--- a/.changeset/silver-masks-confess.md
+++ b/.changeset/silver-masks-confess.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Updated `justifi-payment-provisioning` bank account form step. The account number field's minimum character count has been reduced to 4 to allow for shorter bank account numbers to be entered.

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -196,7 +196,7 @@ export const accountTypeValidation = string()
   .transform(transformEmptyString);
 
 export const accountNumberValidation = string()
-  .min(7, 'Account number must be at least 7 digits')
+  .min(4, 'Account number must be at least 4 digits')
   .max(17, 'Account number must be less than 17 digits')
   .matches(numbersOnlyRegex, 'Enter valid account number')
   .test('not-repeat', 'Enter valid account number', (value) => {


### PR DESCRIPTION
### Update bank account form schema to allow shorter bank account numbers to be entered


Links
-----

Closes #872 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

**General:**

- [x] Components build and run successfully
- [x] Test suites pass


Payment-provisioning component:

- [x] `account_number` field minimum character count updated to 4. Validation should only fire on submit if input is less than 4 or greater than 17. 

