### PR TITLE
Return PaymentMethodPayload in tokenize method in tokenize component

### DIFF
--- a/.changeset/cool-oranges-repair.md
+++ b/.changeset/cool-oranges-repair.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Updated `justifi-tokenize-payment-method` so that calling `tokenizePaymentMethod()` method now returns the full response or error from the request, instead of `void`. 

--- a/apps/component-examples/examples/tokenize-payment-method.js
+++ b/apps/component-examples/examples/tokenize-payment-method.js
@@ -63,7 +63,7 @@ app.get('/', async (req, res) => {
   const webComponentToken = await getWebComponentToken(token);
 
   const hideCardBillingForm = true;
-  const hideSubmitButton = true;
+  const hideSubmitButton = false;
 
   const billingFormFields = {
     name: 'John Doe',

--- a/apps/component-examples/examples/tokenize-payment-method.js
+++ b/apps/component-examples/examples/tokenize-payment-method.js
@@ -63,7 +63,7 @@ app.get('/', async (req, res) => {
   const webComponentToken = await getWebComponentToken(token);
 
   const hideCardBillingForm = true;
-  const hideSubmitButton = false;
+  const hideSubmitButton = true;
 
   const billingFormFields = {
     name: 'John Doe',
@@ -96,7 +96,8 @@ app.get('/', async (req, res) => {
             account-id="${subAccountId}"
             hide-card-billing-form="${hideCardBillingForm}"
             hide-submit-button="${hideSubmitButton}"
-          />
+          >
+          </justifi-tokenize-payment-method>
           <button id="fill-billing-form-button">Test Fill Billing Form</button>
           <button id="test-submit-button" ${hideSubmitButton ? '' : 'style="display: none;"'}>Test Submit</button>
         </div>
@@ -114,13 +115,20 @@ app.get('/', async (req, res) => {
         }
 
         justifiTokenizePaymentMethod.addEventListener('submit-event', (event) => {
-          console.log(event);
-          console.log('token', event.detail.response.token);
+          console.log('submit-event', event);
+
+          if (event.detail.response.token) {
+            console.log('Token from submit-event', event.detail.response.token);
+          }
+
+          if (event.detail.response.error) {
+            console.log('Error from submit-event', event.detail.response.error);
+          }
           writeOutputToPage(event);
         });
 
         justifiTokenizePaymentMethod.addEventListener('error-event', (event) => {
-          console.log(event);
+          console.log('Error-event', event);
           writeOutputToPage(event);
         });
 
@@ -128,8 +136,15 @@ app.get('/', async (req, res) => {
           justifiTokenizePaymentMethod.fillBillingForm(${JSON.stringify(fields)});
         });
 
-        testSubmitButton.addEventListener('click', () => {
-          justifiTokenizePaymentMethod.tokenizePaymentMethod();
+        testSubmitButton.addEventListener('click', async () => {
+          const response = await justifiTokenizePaymentMethod.tokenizePaymentMethod();
+          if (response.token) {
+            console.log('Token from tokenize method', response.token);
+          }
+          
+          if (response.error) {
+            console.log('Error from tokenize method', response.error);
+          };
         });
       </script>
     </html>

--- a/apps/docs/stories/components/TokenizePaymentMethod/index.stories.tsx
+++ b/apps/docs/stories/components/TokenizePaymentMethod/index.stories.tsx
@@ -127,10 +127,13 @@ const meta: Meta = {
       },
     },
     tokenizePaymentMethod: {
-      description: "Can be used to call the tokenizePaymentMethod method directly",
+      description: "Can be used to call the tokenizePaymentMethod method programmatically with an external button. Ideally used in conjunction with the `hide-submit-button` prop. Returns a promise with the tokenized payment method",
       table: {
         category: "methods",
-        defaultValue: { summary: "`tokenizePaymentMethod() => Promise<void>`" }
+        defaultValue: { 
+          summary: "`tokenizePaymentMethod() => Promise<PaymentMethodPayload>`",
+          detail: "PaymentMethodPayload: { data?: CreatePaymentMethodResponse; token?: string; bnpl?: { order_uuid: string; status: string; session_uuid: string; }; error?: { code: string; message: string; decline_code: string; }; validationError?: boolean; }"
+         }
       },
     },
   },


### PR DESCRIPTION
### Return PaymentMethodPayload in tokenize method in tokenize component

This PR commits the following changes:

- tokenize method in `tokenize-payment-method` component now returns the response from the tokenize request, the same as the submit-event in this component. 


Links
-----

Closes #875 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

Example file is already set up in this branch to make testing this easy. 

In `tokenize-payment-method.js`:

Update line 66:

`  const hideSubmitButton = false; =>   const hideSubmitButton = true;`


**General:**

- [x] Components build and run successfully
- [x] Test suites pass


tokenize component:

- [x] Component should build and function as normal
- [ ] Calling the `tokenizePaymentMethod` method manually should now return the full response instead of `void`

