### PR TITLE
Update iframe origin env variable URLs to ignore the version segment

### DIFF
--- a/packages/webcomponents/setupTests.js
+++ b/packages/webcomponents/setupTests.js
@@ -1,2 +1,2 @@
-global.IFRAME_ORIGIN = 'https://js.justifi.ai/v2';
+global.IFRAME_ORIGIN = 'https://components.justifi.ai';
 global.PROXY_API_ORIGIN = 'https://wc-proxy.justifi.ai';

--- a/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
+++ b/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
@@ -5,7 +5,7 @@ import { Component, h, Host, Method, Prop } from "@stencil/core";
 })
 export class BankAccountForm {
   @Prop() iframeOrigin: string;
-  
+
   private accountNumberIframeElement!: HTMLIframeInputElement;
   private routingNumberIframeElement!: HTMLIframeInputElement;
 
@@ -38,7 +38,7 @@ export class BankAccountForm {
               inputId="accountNumber"
               ref={(el) => (this.accountNumberIframeElement = el as HTMLIframeInputElement)}
               label="Account Number"
-              iframeOrigin={`${this.iframeOrigin}/accountNumber`}
+              iframeOrigin={`${this.iframeOrigin}/v2/accountNumber`}
             />
           </div>
           <div class="row">
@@ -46,7 +46,7 @@ export class BankAccountForm {
               inputId="routingNumber"
               ref={(el) => (this.routingNumberIframeElement = el as HTMLIframeInputElement)}
               label="Routing Number"
-              iframeOrigin={`${this.iframeOrigin}/routingNumber`}
+              iframeOrigin={`${this.iframeOrigin}/v2/routingNumber`}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
+++ b/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
@@ -41,7 +41,7 @@ export class CardForm {
             inputId="cardNumber"
             ref={(el) => (this.cardNumberIframeElement = el as HTMLIframeInputElement)}
             label="Card Number"
-            iframeOrigin={`${this.iframeOrigin}/cardNumber`}
+            iframeOrigin={`${this.iframeOrigin}/v2/cardNumber`}
           />
         </div>
         <div class="row">
@@ -50,7 +50,7 @@ export class CardForm {
               inputId="expirationMonth"
               ref={(el) => (this.expirationMonthIframeElement = el as HTMLIframeInputElement)}
               label="Expiration"
-              iframeOrigin={`${this.iframeOrigin}/expirationMonth`}
+              iframeOrigin={`${this.iframeOrigin}/v2/expirationMonth`}
             />
           </div>
           <div class="col-4 align-content-end">
@@ -58,7 +58,7 @@ export class CardForm {
               inputId="expirationYear"
               ref={(el) => (this.expirationYearIframeElement = el as HTMLIframeInputElement)}
               label=""
-              iframeOrigin={`${this.iframeOrigin}/expirationYear`}
+              iframeOrigin={`${this.iframeOrigin}/v2/expirationYear`}
             />
           </div>
           <div class="col-4 align-content-end">
@@ -66,7 +66,7 @@ export class CardForm {
               inputId="CVV"
               ref={(el) => (this.cvvIframeElement = el as HTMLIframeInputElement)}
               label="CVV"
-              iframeOrigin={`${this.iframeOrigin}/CVV`}
+              iframeOrigin={`${this.iframeOrigin}/v2/CVV`}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`justifi-checkout renders loading 1`] = `
                 <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="height: 300px;"></div>
               </div>
               <div class="visually-hidden">
-                <justifi-payment-method-options iframeorigin="https://js.justifi.ai/v2" show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
+                <justifi-payment-method-options iframeorigin="https://components.justifi.ai" show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
               </div>
             </section>
           </div>


### PR DESCRIPTION
Change our .env files to not use the version number on the route path.

- `IFRAME_ORIGIN=http://localhost:3003/v2` - 👎
- `IFRAME_ORIGIN=http://localhost:3003` - 👍

**REMINDER** : The `IFRAME_ORIGIN` Github Environment secret must be updated before this gets published
https://github.com/justifi-tech/web-component-library/settings/secrets/actions

Links
-----
#877 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
In order to test this, remove the `/v2` from `IFRAME_ORIGIN` env variable on `packages/webcomponents/.env`.

[ ] - `pnpm dev:checkout`, `pnpm dev:checkout-with-insurance` and `pnpm dev:tokenize-payment-method` should display correctly the card and bank account form payment methods. (If the iframe origin is wrong, the inputs will load a 404 error message)
