### PR TITLE
Checkouts list filters query param props

### DIFF
--- a/.changeset/clever-cars-search.md
+++ b/.changeset/clever-cars-search.md
@@ -1,0 +1,8 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Added new optional props to `justifi-checkouts-list-filters` allowing prescribed filter selections. The following props are now available: `checkout-status` and `payment-mode`.
+  - Values passed via these props will be automatically applied to the `justifi-checkouts-list`'s API requests as query params.
+  - If a value is passed to these props, the corresponding input in the filter menu UI will be disabled.
+  - Add new CSS parts to `justifi-checkouts-list-filters` to allow for more customization. The following parts have been added: `checkouts-list-filter-menu`, `checkout-status-checkouts-list-filter-param`, and `payment-mode-checkouts-list-filter-param`.

--- a/apps/component-examples/examples/checkouts-list-with-filters.js
+++ b/apps/component-examples/examples/checkouts-list-with-filters.js
@@ -3,6 +3,11 @@ require('dotenv').config();
 const express = require('express');
 const app = express();
 const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const subAccountId = process.env.SUB_ACCOUNT_ID;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
 
 app.use(
   '/scripts',
@@ -12,13 +17,13 @@ app.use('/styles', express.static(__dirname + '/../css/'));
 
 async function getToken() {
   const requestBody = JSON.stringify({
-    client_id: process.env.CLIENT_ID,
-    client_secret: process.env.CLIENT_SECRET,
+    client_id: clientId,
+    client_secret: clientSecret
   });
 
   let response;
   try {
-    response = await fetch('https://api.justifi.ai/oauth/token', {
+    response = await fetch(authTokenEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -34,8 +39,7 @@ async function getToken() {
 }
 
 async function getWebComponentToken(token) {
-  const response = await fetch(
-    'https://api.justifi.ai/v1/web_component_tokens',
+  const response = await fetch(webComponentTokenEndpoint,
     {
       method: 'POST',
       headers: {
@@ -43,9 +47,7 @@ async function getWebComponentToken(token) {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        resources: [
-          `read:account:${process.env.SUB_ACCOUNT_ID}`,
-        ],
+        resources: [`read:account:${subAccountId}`],
       }),
     }
   );
@@ -55,7 +57,6 @@ async function getWebComponentToken(token) {
 }
 
 app.get('/', async (req, res) => {
-  const accountId = process.env.SUB_ACCOUNT_ID;
   const token = await getToken();
   const webComponentToken = await getWebComponentToken(token);
 
@@ -71,10 +72,13 @@ app.get('/', async (req, res) => {
       <body>
         <div style="padding:25px;">
           <div>
-            <justifi-checkouts-list-filters></justifi-checkouts-list-filters>
+            <justifi-checkouts-list-filters status="completed" />
           </div>
           <div>
-            <justifi-checkouts-list auth-token="${webComponentToken}" account-id="${accountId}"></justifi-checkouts-list>
+            <justifi-checkouts-list 
+              account-id="${subAccountId}"
+              auth-token="${webComponentToken}"
+            />
           </div>
         </div>
         <script>

--- a/apps/component-examples/examples/checkouts-list-with-filters.js
+++ b/apps/component-examples/examples/checkouts-list-with-filters.js
@@ -72,7 +72,7 @@ app.get('/', async (req, res) => {
       <body>
         <div style="padding:25px;">
           <div>
-            <justifi-checkouts-list-filters status="completed" />
+            <justifi-checkouts-list-filters />
           </div>
           <div>
             <justifi-checkouts-list 

--- a/apps/component-examples/examples/checkouts-list.js
+++ b/apps/component-examples/examples/checkouts-list.js
@@ -3,6 +3,11 @@ require('dotenv').config();
 const express = require('express');
 const app = express();
 const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const subAccountId = process.env.SUB_ACCOUNT_ID;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
 
 app.use(
   '/scripts',
@@ -12,13 +17,13 @@ app.use('/styles', express.static(__dirname + '/../css/'));
 
 async function getToken() {
   const requestBody = JSON.stringify({
-    client_id: process.env.CLIENT_ID,
-    client_secret: process.env.CLIENT_SECRET,
+    client_id: clientId,
+    client_secret: clientSecret
   });
 
   let response;
   try {
-    response = await fetch('https://api.justifi.ai/oauth/token', {
+    response = await fetch(authTokenEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -34,8 +39,7 @@ async function getToken() {
 }
 
 async function getWebComponentToken(token) {
-  const response = await fetch(
-    'https://api.justifi.ai/v1/web_component_tokens',
+  const response = await fetch(webComponentTokenEndpoint,
     {
       method: 'POST',
       headers: {
@@ -43,9 +47,7 @@ async function getWebComponentToken(token) {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        resources: [
-          `read:account:${process.env.SUB_ACCOUNT_ID}`,
-        ],
+        resources: [`read:account:${subAccountId}`],
       }),
     }
   );
@@ -69,8 +71,11 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="margin:0 auto;max-width:700px;">
-          <justifi-checkouts-list auth-token="${webComponentToken}" account-id="${subAccountID}"></justifi-checkouts-list>
+        <div style="padding:25px;">
+          <justifi-checkouts-list 
+            account-id="${subAccountId}"
+            auth-token="${webComponentToken}"
+          />
         </div>
         <script>
           const justifiCheckoutsList = document.querySelector('justifi-checkouts-list');

--- a/apps/component-examples/examples/payments-list.js
+++ b/apps/component-examples/examples/payments-list.js
@@ -3,6 +3,11 @@ require('dotenv').config();
 const express = require('express');
 const app = express();
 const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const subAccountId = process.env.SUB_ACCOUNT_ID;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
 
 app.use(
   '/scripts',
@@ -12,13 +17,13 @@ app.use('/styles', express.static(__dirname + '/../css/'));
 
 async function getToken() {
   const requestBody = JSON.stringify({
-    client_id: process.env.CLIENT_ID,
-    client_secret: process.env.CLIENT_SECRET,
+    client_id: clientId,
+    client_secret: clientSecret
   });
 
   let response;
   try {
-    response = await fetch('https://api.justifi.ai/oauth/token', {
+    response = await fetch(authTokenEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -35,7 +40,7 @@ async function getToken() {
 
 async function getWebComponentToken(token) {
   const response = await fetch(
-    'https://api.justifi.ai/v1/web_component_tokens',
+    webComponentTokenEndpoint,
     {
       method: 'POST',
       headers: {
@@ -43,21 +48,16 @@ async function getWebComponentToken(token) {
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        resources: [
-          `read:account:${process.env.SUB_ACCOUNT_ID}`,
-        ],
+        resources: [`read:account:${subAccountId}`],
       }),
     }
   );
-
-  console.log('Web Component Token Response:', response);
 
   const { access_token } = await response.json();
   return access_token;
 }
 
 app.get('/', async (req, res) => {
-  const accountId = process.env.SUB_ACCOUNT_ID;
   const token = await getToken();
   const webComponentToken = await getWebComponentToken(token);
 
@@ -71,8 +71,11 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="margin:0 auto;max-width:700px;">
-          <justifi-payments-list auth-token="${webComponentToken}" account-id="${accountId}"></justifi-payments-list>
+        <div style="padding:25px;">
+          <justifi-payments-list
+            account-id="${subAccountId}"
+            auth-token="${webComponentToken}"
+          />
         </div>
         <script>
           const justifiPaymentsList = document.querySelector('justifi-payments-list');

--- a/packages/webcomponents/src/api/Checkout.ts
+++ b/packages/webcomponents/src/api/Checkout.ts
@@ -158,7 +158,7 @@ export class Checkout implements ICheckout {
     this.bnpl = data.bnpl;
     this.total_amount = data.total_amount;
     this.insurance_amount = data.insurance_amount;
-    this.status = data.status as ICheckoutStatus;
+    this.status = ICheckoutStatus[data.status];
     this.payment_currency = data.payment_currency;
     this.mode = data.mode;
     this.statement_descriptor = data.statement_descriptor;
@@ -207,12 +207,17 @@ export enum ICheckoutPaymentMode {
   unknown = ''
 }
 
+export enum ICheckoutStatus {
+  created = 'created',
+  completed = 'completed',
+  attempted = 'attempted',
+  expired = 'expired'
+}
+
 export enum CompletionStatuses {
   failed = 'failed',
   succeeded = 'succeeded'
 }
-
-export type ICheckoutStatus = 'created' | 'completed' | 'attempted' | 'expired';
 
 export type ICheckoutCompleteResponse = IApiResponse<{
   payment_mode: ICheckoutPaymentMode;

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-core.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-core.tsx
@@ -3,7 +3,7 @@ import { Checkout, PagingInfo, SubAccount, pagingDefaults } from '../../api';
 import { TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
 import { checkoutTableColumns, checkoutTableCells } from './checkouts-table';
 import { Table } from '../../utils/table';
-import { queryParams, onQueryParamsChange } from './checkouts-list-params-state';
+import { getRequestParams, onQueryParamsChange } from './checkouts-list-params-state';
 import { table, tableCell } from '../../styles/parts';
 import { ComponentClickEvent, ComponentErrorEvent } from '../../api/ComponentEvents';
 import { TableClickActions } from '../../ui-components/table/event-types';
@@ -24,7 +24,6 @@ export class CheckoutsListCore {
   @State() paging: PagingInfo = pagingDefaults;
   @State() pagingParams: any = {};
 
-  @Watch('queryParams')
   @Watch('pagingParams')
   @Watch('getCheckouts')
   @Watch('getSubAccounts')
@@ -56,7 +55,7 @@ export class CheckoutsListCore {
     this.loading = true;
 
     this.getCheckouts({
-      params: this.requestParams,
+      params: this.checkoutParams,
       onSuccess: async ({ checkouts, pagingInfo }) => {
         this.checkouts = checkouts;
         this.paging = pagingInfo;
@@ -123,9 +122,10 @@ export class CheckoutsListCore {
     this.clickEvent.emit({ name: TableClickActions.row, data: checkoutData });
   };
 
-  get requestParams() {
-    const combinedParams = { ...queryParams, ...this.pagingParams };
-    return combinedParams;
+  get checkoutParams() {
+    const requestParams = getRequestParams();
+    const params = { ...requestParams, ...this.pagingParams };
+    return params;
   }
 
   get subAccountParams() {

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop } from '@stencil/core';
-import { ICheckoutStatus } from '../../api';
+import { ICheckoutPaymentMode, ICheckoutStatus } from '../../api';
 import { filterParams, propsParams, clearParams } from './checkouts-list-params-state';
 import { StyledHost } from '../../ui-components';
 import { checkoutsListFilterMenu, paymentModeCheckoutsListFilterParam, statusCheckoutsListFilterParam } from '../../styles/parts';
@@ -10,7 +10,7 @@ import { checkoutsListFilterMenu, paymentModeCheckoutsListFilterParam, statusChe
 })
 export class CheckoutsListFilters {
   @Prop() checkoutStatus?: ICheckoutStatus;
-  @Prop() paymentMode?: string;
+  @Prop() paymentMode?: ICheckoutPaymentMode;
 
   componentWillLoad() {
     const propsToSet = {
@@ -32,18 +32,18 @@ export class CheckoutsListFilters {
   get checkoutStatusOptions(): { label: string, value: ICheckoutStatus | '' }[] {
     return [
       { label: 'All', value: '' },
-      { label: 'Created', value: 'created' },
-      { label: 'Completed', value: 'completed' },
-      { label: 'Attempted', value: 'attempted' },
-      { label: 'Expired', value: 'expired' },
+      { label: 'Created', value: ICheckoutStatus.created },
+      { label: 'Completed', value: ICheckoutStatus.completed },
+      { label: 'Attempted', value: ICheckoutStatus.attempted },
+      { label: 'Expired', value: ICheckoutStatus.expired },
     ]
   }
 
-  get checkoutPaymentModeOptions(): { label: string, value: string }[] {
+  get checkoutPaymentModeOptions(): { label: string, value: ICheckoutPaymentMode | '' }[] {
     return [
       { label: 'All', value: '' },
-      { label: 'E-commerce', value: 'ecom' },
-      { label: 'BNPL', value: 'bnpl' },
+      { label: 'E-commerce', value: ICheckoutPaymentMode.ecom },
+      { label: 'BNPL', value: ICheckoutPaymentMode.bnpl },
     ]
   }
 

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
@@ -1,16 +1,32 @@
-import { Component, h } from '@stencil/core';
+import { Component, h, Prop } from '@stencil/core';
 import { ICheckoutStatus } from '../../api';
-import { queryParams, clearParams } from './checkouts-list-params-state';
+import { filterParams, propsParams, clearParams } from './checkouts-list-params-state';
 import { StyledHost } from '../../ui-components';
+import { checkoutsListFilterMenu, paymentModeCheckoutsListFilterParam, statusCheckoutsListFilterParam } from '../../styles/parts';
 
 @Component({
   tag: 'justifi-checkouts-list-filters',
   shadow: true
 })
 export class CheckoutsListFilters {
+  @Prop() status?: ICheckoutStatus;
+  @Prop() paymentMode?: string;
+
+  componentWillLoad() {
+    const propsToSet = {
+      status: this.status,
+      payment_mode: this.paymentMode,
+    };
+
+    Object.entries(propsToSet).forEach(([key, value]) => {
+      if (value) {
+        propsParams[key] = value;
+      }
+    });
+  }
   
   setParamsOnChange = (name: string, value: string) => {
-    queryParams[name] = value;
+    filterParams[name] = value;
   }
 
   get checkoutStatusOptions(): { label: string, value: ICheckoutStatus | '' }[] {
@@ -32,9 +48,11 @@ export class CheckoutsListFilters {
   }
 
   render() {
+    const filterMenuParams = { ...filterParams }
+
     return (
       <StyledHost>
-        <table-filters-menu params={ {...queryParams} } clearParams={clearParams}>
+        <table-filters-menu params={filterMenuParams} clearParams={clearParams} part={checkoutsListFilterMenu}>
           <div class="grid-cols-2 gap-3 p-1">
             <div class="p-2">
               <form-control-select
@@ -42,7 +60,9 @@ export class CheckoutsListFilters {
                 label="Status"
                 options={this.checkoutStatusOptions}
                 inputHandler={this.setParamsOnChange}
-                defaultValue={queryParams.status || ''}
+                defaultValue={this.status || filterParams.status}
+                disabled={!!this.status}
+                part={statusCheckoutsListFilterParam}
               />
             </div>
             <div class="p-2">
@@ -51,7 +71,9 @@ export class CheckoutsListFilters {
                 label="Payment Mode"
                 options={this.checkoutPaymentModeOptions}
                 inputHandler={this.setParamsOnChange}
-                defaultValue={queryParams.payment_mode || ''}
+                defaultValue={this.paymentMode || filterParams.payment_mode}
+                disabled={!!this.paymentMode}
+                part={paymentModeCheckoutsListFilterParam}
               />
             </div>
           </div>

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
@@ -9,12 +9,12 @@ import { checkoutsListFilterMenu, paymentModeCheckoutsListFilterParam, statusChe
   shadow: true
 })
 export class CheckoutsListFilters {
-  @Prop() status?: ICheckoutStatus;
+  @Prop() checkoutStatus?: ICheckoutStatus;
   @Prop() paymentMode?: string;
 
   componentWillLoad() {
     const propsToSet = {
-      status: this.status,
+      status: this.checkoutStatus,
       payment_mode: this.paymentMode,
     };
 
@@ -60,8 +60,8 @@ export class CheckoutsListFilters {
                 label="Status"
                 options={this.checkoutStatusOptions}
                 inputHandler={this.setParamsOnChange}
-                defaultValue={this.status || filterParams.status}
-                disabled={!!this.status}
+                defaultValue={this.checkoutStatus || filterParams.status}
+                disabled={!!this.checkoutStatus}
                 part={statusCheckoutsListFilterParam}
               />
             </div>

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-params-state.ts
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-params-state.ts
@@ -1,18 +1,30 @@
 import { createStore } from '@stencil/store';
 import { CheckoutsQueryParams } from '../../api';
 
-const initialState = {};
+const filterParamsInitialState = {};
+const propsParamsInitialState = {};
 
-const checkoutsListQueryParams = createStore<CheckoutsQueryParams>(() => initialState);
-const { state: queryParams, on: onQueryParamsChange } = checkoutsListQueryParams;
+const filterParamsStore = createStore<CheckoutsQueryParams>(() => filterParamsInitialState);
+const { state: filterParams, on: onQueryParamsChange } = filterParamsStore;
+
+const propsParamsStore = createStore<CheckoutsQueryParams>(() => propsParamsInitialState);
+const { state: propsParams } = propsParamsStore;
+
+const getRequestParams = (): CheckoutsQueryParams => {
+  return {
+    ...filterParams,
+    ...propsParams
+  };
+};
 
 const clearParams = () => {
-  checkoutsListQueryParams.reset();
+  filterParamsStore.reset();
 }
 
 export {
-  checkoutsListQueryParams,
-  queryParams,
+  filterParams,
+  propsParams,
   onQueryParamsChange,
-  clearParams
+  clearParams,
+  getRequestParams
 };

--- a/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-with-filters.spec.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-with-filters.spec.tsx
@@ -8,7 +8,7 @@ import { TableFiltersMenu } from '../../../ui-components/filters/table-filters-m
 import { CheckoutsListFilters } from '../checkouts-list-filters';
 import { SelectInput } from '../../../ui-components/form/form-control-select';
 import { defaultColumnsKeys } from '../checkouts-table';
-import { queryParams } from '../checkouts-list-params-state';
+import { filterParams } from '../checkouts-list-params-state';
 
 const components = [CheckoutsList, CheckoutsListCore, TableFiltersMenu, CheckoutsListFilters, SelectInput];
 
@@ -88,7 +88,7 @@ describe('justifi-checkouts-list with filters', () => {
     selectFilterInput.dispatchEvent(new Event('input'));
 
     expect(fetchDataSpy).toHaveBeenCalled();
-    const updatedParams = queryParams;
+    const updatedParams = filterParams;
     expect(updatedParams).toEqual({"status": "succeeded"});
   });
 

--- a/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-core.tsx
@@ -52,7 +52,7 @@ export class PaymentsListCore {
     this.loading = true;
 
     this.getPayments({
-      params: this.params,
+      params: this.paymentParams,
       onSuccess: ({ payments, pagingInfo }) => {
         this.payments = payments;
         this.paging = pagingInfo;
@@ -90,6 +90,12 @@ export class PaymentsListCore {
     this.clickEvent.emit({ name: TableClickActions.row, data: paymentData });
   };
 
+  get paymentParams() {
+    const requestParams = getRequestParams();
+    const params = { ...requestParams, ...this.pagingParams };
+    return params;
+  }
+
   get entityId() {
     return this.payments.map((payment) => payment.id);
   }
@@ -104,12 +110,6 @@ export class PaymentsListCore {
 
   get showRowData() {
     return !this.showEmptyState && !this.showErrorState && !this.loading;
-  }
-
-  get params() {
-    const requestParams = getRequestParams();
-    const params = { ...requestParams, ...this.pagingParams };
-    return params;
   }
 
   render() {

--- a/packages/webcomponents/src/components/payments-list/payments-list-filters.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list-filters.tsx
@@ -3,7 +3,14 @@ import { debounce } from 'lodash';
 import { filterParams, propsParams, clearParams } from './payments-list-params-state';
 import { StyledHost } from '../../ui-components';
 import { convertToLocal, convertToUTC } from '../../utils/utils';
-import { createdAfterPaymentsListFilterParam, createdBeforePaymentsListFilterParam, filterMenu, paymentIdPaymentsListFilterParam, paymentStatusPaymentsListFilterParam, terminalIdPaymentsListFilterParam } from '../../styles/parts';
+import {
+  paymentsListFilterMenu,
+  createdAfterPaymentsListFilterParam,
+  createdBeforePaymentsListFilterParam,
+  paymentIdPaymentsListFilterParam,
+  paymentStatusPaymentsListFilterParam,
+  terminalIdPaymentsListFilterParam
+} from '../../styles/parts';
 
 @Component({
   tag: 'justifi-payments-list-filters',
@@ -63,7 +70,7 @@ export class PaymentsListFilters {
 
     return (
       <StyledHost>
-        <table-filters-menu params={filterMenuParams} clearParams={clearParams} part={filterMenu}>
+        <table-filters-menu params={filterMenuParams} clearParams={clearParams} part={paymentsListFilterMenu}>
           <div class="grid-cols-2 gap-3 p-1">
             <div class="p-2">
               <form-control-text

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -100,6 +100,8 @@ export const checkoutSummary = `checkout-summary`;
 
 // Filters
 export const filterMenu = `filter-menu`;
+
+// Payments List Filters
 export const paymentsListFilterMenu = `${filterMenu} payments-list-filter-menu`;
 export const paymentsListFilterParam = `payments-list-filter-param`;
 export const paymentIdPaymentsListFilterParam = `${paymentsListFilterParam} payment-id-payments-list-filter-param`;
@@ -107,3 +109,9 @@ export const terminalIdPaymentsListFilterParam = `${paymentsListFilterParam} ter
 export const paymentStatusPaymentsListFilterParam = `${paymentsListFilterParam} payment-status-payments-list-filter-param`;
 export const createdAfterPaymentsListFilterParam = `${paymentsListFilterParam} created-after-payments-list-filter-param`;
 export const createdBeforePaymentsListFilterParam = `${paymentsListFilterParam} created-before-payments-list-filter-param`;
+
+// Checkouts List Filters
+export const checkoutsListFilterMenu = `${filterMenu} checkouts-list-filter-menu`;
+export const checkoutsListFilterParam = `checkouts-list-filter-param`;
+export const statusCheckoutsListFilterParam = `${checkoutsListFilterParam} status-checkouts-list-filter-param`;
+export const paymentModeCheckoutsListFilterParam = `${checkoutsListFilterParam} payment-mode-checkouts-list-filter-param`;

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -113,5 +113,5 @@ export const createdBeforePaymentsListFilterParam = `${paymentsListFilterParam} 
 // Checkouts List Filters
 export const checkoutsListFilterMenu = `${filterMenu} checkouts-list-filter-menu`;
 export const checkoutsListFilterParam = `checkouts-list-filter-param`;
-export const statusCheckoutsListFilterParam = `${checkoutsListFilterParam} status-checkouts-list-filter-param`;
+export const statusCheckoutsListFilterParam = `${checkoutsListFilterParam} checkout-status-checkouts-list-filter-param`;
 export const paymentModeCheckoutsListFilterParam = `${checkoutsListFilterParam} payment-mode-checkouts-list-filter-param`;


### PR DESCRIPTION
### Pass query params as props to `justifi-checkouts-list-filters`

This PR commits the following changes:

- Allows query params for checkout status and payment mode to be passed as props to `checkouts-list-filters` component
- Adds new parts to adjust or hide checkouts filters menu, or specific inputs.
- Updates example files `payments-list`, `payments-list-with-filters`, `checkouts-list`, and `checkouts-list-with-filters` with organized env variables. Update sizing and display for payments-list and checkouts-list example files.

Links
-----

Closes #861 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

**General:**

- [x] App builds and runs normally
- [x] Test Suites pass

**Checkouts-List:**

For these you should run `pnpm dev:checkouts-list-with-filters` example file. 

- [x] Component builds and functions normally without passing any props to `checkouts-list-filters`
- [x] Passing in props to `checkouts-list-filters` applies corresponding query param to component's API request
- [x] Passing in props to `checkouts-list-filters` disables corresponding input in filter menu UI
- [x] Other filter UI inputs can be used in conjunction with params passed as prop. 
- [x] Clear filters button should NOT render until user manually interacts with filters UI, IE you won't see the Clear Filters button just for passing in a param as a prop
- [x] Clear filters clears out filters that were applied by the UI, but retains the ones set by props. 
- [ ] Pagination works as expected, with params supplied by props, or without it. 

