### PR TITLE
Add Order Terminals component and example setup

### DIFF
--- a/apps/component-examples/examples/order-terminals.js
+++ b/apps/component-examples/examples/order-terminals.js
@@ -1,4 +1,4 @@
-require('dotenv').config();
+require('dotenv').config({ path: '../../.env' });
 
 const express = require('express');
 const app = express();

--- a/apps/component-examples/examples/order-terminals.js
+++ b/apps/component-examples/examples/order-terminals.js
@@ -1,0 +1,89 @@
+require('dotenv').config();
+
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(
+  '/scripts',
+  express.static(__dirname + '/../node_modules/@justifi/webcomponents/dist/')
+);
+app.use('/styles', express.static(__dirname + '/../css/'));
+
+async function getToken() {
+  const requestBody = JSON.stringify({
+    client_id: process.env.CLIENT_ID,
+    client_secret: process.env.CLIENT_SECRET,
+  });
+
+  let response;
+  try {
+    response = await fetch(process.env.AUTH_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
+
+  const data = await response.json();
+
+  return data.access_token;
+}
+
+async function getWebComponentToken(token, businessId) {
+  try {
+    const response = await fetch(process.env.WEB_COMPONENT_TOKEN_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `${token}`,
+      },
+      body: JSON.stringify({
+        resources: [`write:business:${businessId}`],
+      }),
+    });
+    const responseJson = await response.json();
+    return responseJson.access_token;
+  } catch (error) {
+    console.log('ERROR getWebComponentToken:', error);
+    return { error };
+  }
+}
+
+app.get('/', async (req, res) => {
+  const token = await getToken();
+  const businessId = process.env.BUSINESS_ID;
+  const webComponentToken = await getWebComponentToken(token, businessId);
+
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>Order Terminals Example</title>
+        <script type="module" src="/scripts/webcomponents/webcomponents.esm.js"></script>
+        <link rel="stylesheet" href="/styles/theme.css">
+        <link rel="stylesheet" href="/styles/example.css">
+      </head>
+      <body>
+        <div style="margin:0 auto;max-width:700px;">
+          <justifi-order-terminals
+            auth-token="${webComponentToken}"
+            business-id="${businessId}"
+          ></justifi-order-terminals>
+        </div>
+        <script>
+          console.log('token', '${token}');
+          console.log('webComponentToken', '${webComponentToken}');
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening at http://localhost:${port}`);
+});

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -19,7 +19,8 @@
     "start:payments-list": "npx nodemon ./examples/payments-list.js",
     "start:payments-list-with-filters": "npx nodemon ./examples/payments-list-with-filters.js",
     "start:payouts-list": "npx nodemon ./examples/payouts-list.js",
-    "start:payouts-list-with-filters": "npx nodemon ./examples/payouts-list-with-filters.js"
+    "start:payouts-list-with-filters": "npx nodemon ./examples/payouts-list-with-filters.js",
+    "start:order-terminals": "npx nodemon ./examples/order-terminals.js"
   },
   "author": "",
   "license": "ISC",

--- a/apps/docs/stories/components/OrderTerminals/Docs.mdx
+++ b/apps/docs/stories/components/OrderTerminals/Docs.mdx
@@ -1,0 +1,59 @@
+import { Meta, Title, ArgTypes, Source } from '@storybook/blocks';
+import { filterDocsByTag, ExportedParts } from '../../utils';
+import { codeExampleFull } from './example';
+import {
+  Authorization,
+  ComponentBox,
+} from '../../utils/documentation-components';
+import * as JustifiOrderTerminals from './index.stories.tsx';
+import { setUpMocks } from '../../utils/mockAllServices';
+
+{setUpMocks()}
+
+<Meta
+  title="Merchant Tools/Order Terminals"
+  Components="justifi-order-terminals"
+  of={JustifiOrderTerminals}
+/>
+
+<Title />
+
+---
+
+Component to render a form to create a new order requesting terminals.
+
+# Index
+
+---
+
+- [Props and methods](#props-and-methods)
+- [Authorization](#authorization)
+- [Example usage](#example-usage)
+
+# Props and methods
+
+---
+
+<ArgTypes exclude={['Theme']} />
+
+# Authorization
+
+---
+
+<Authorization
+  actions={['read']}
+  entity="business"
+  identification="business_id"
+/>
+
+# Example Usage
+
+---
+
+<ComponentBox>
+  <justifi-order-terminals business-id="123" auth-token="123abc" />
+</ComponentBox>
+
+---
+
+<Source dark language="html" code={codeExampleFull} />

--- a/apps/docs/stories/components/OrderTerminals/example.ts
+++ b/apps/docs/stories/components/OrderTerminals/example.ts
@@ -1,0 +1,41 @@
+import { codeExampleHead } from '../../utils';
+
+export const codeExampleFull = `
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+${codeExampleHead(
+  'justifi-order-terminals',
+  `<style>
+      ::part(font-family) {
+        font-family: georgia;   
+      }
+        
+      ::part(color) {
+        color: darkslategray;
+      }
+
+      ::part(background-color) {
+        background-color: transparent;
+      }
+    </style>`
+)}
+
+<body>
+  <justifi-order-terminals
+    business-id="123" auth-token="your-auth-token"
+  ></justifi-order-terminals>
+</body>
+
+<script>
+  (function () {
+    const orderTerminals = document.querySelector('justifi-order-terminals');
+
+    orderTerminals.addEventListener('error-event', (event) => {
+      // here is where you would handle the error
+      console.error('error-event', event.detail);
+    });
+  })();
+</script>
+</html>
+`;

--- a/apps/docs/stories/components/OrderTerminals/index.stories.tsx
+++ b/apps/docs/stories/components/OrderTerminals/index.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { withActions } from "@storybook/addon-actions/decorator";
+import { customStoryDecorator, StoryBaseArgs } from "../../utils";
+
+import "@justifi/webcomponents/dist/module/justifi-order-terminals";
+import { ThemeNames } from "../../themes";
+
+type Story = StoryObj;
+
+const storyBaseArgs = new StoryBaseArgs(["business-id", "auth-token"]);
+
+const meta: Meta = {
+  title: "Merchant Tools/Order Terminals",
+  component: "justifi-order-terminals",
+  args: {
+    ...storyBaseArgs.args,
+    Theme: ThemeNames.Light,
+  },
+  argTypes: {
+    ...storyBaseArgs.argTypes,
+    Theme: {
+      description:
+        "Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling)",
+      options: Object.values(ThemeNames),
+      control: {
+        type: "select",
+      },
+    },
+    "error-event": {
+      description: "`ComponentError`",
+      table: {
+        category: "events",
+      },
+      action: true,
+    },
+  },
+  parameters: {
+    actions: {
+      handles: ["error-event"],
+    },
+    chromatic: {
+      delay: 2000,
+    },
+  },
+  decorators: [
+    customStoryDecorator,
+    // @ts-ignore
+    withActions, // https://github.com/storybookjs/storybook/issues/22384
+  ],
+};
+
+export const Example: Story = {};
+
+export default meta;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dev:payments-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payments-list-with-filters'",
     "dev:payouts-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payouts-list'",
     "dev:payouts-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payouts-list-with-filters'",
+    "dev:order-terminals": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:order-terminals'",
     "preview-storybook": "turbo run preview-storybook",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -7,7 +7,7 @@ import { BusinessService } from "../../api/services/business.service";
 import { ErrorState } from "../../ui-components/details/utils";
 import { ComponentErrorEvent } from "../../api";
 import { Business } from "../../api/Business";
-import { makeGetBusiness } from "../business-forms/payment-provisioning/payment-provisioning-actions";
+import { makeGetBusiness } from "../../actions/business/get-business";
 
 @Component({
   tag: 'justifi-order-terminals',
@@ -45,7 +45,7 @@ export class OrderTerminals {
     }
 
     const getBusiness = makeGetBusiness({
-      businessId: this.businessId,
+      id: this.businessId,
       authToken: this.authToken,
       service: new BusinessService(),
     });

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -1,0 +1,90 @@
+import { Component, Event, EventEmitter, h, Prop, State } from "@stencil/core";
+import { StyledHost } from "../../ui-components";
+import { checkPkgVersion } from "../../utils/check-pkg-version";
+import JustifiAnalytics from "../../api/Analytics";
+import { ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
+import { BusinessService } from "../../api/services/business.service";
+import { ErrorState } from "../../ui-components/details/utils";
+import { ComponentErrorEvent } from "../../api";
+import { Business } from "../../api/Business";
+import { makeGetBusiness } from "../business-forms/payment-provisioning/payment-provisioning-actions";
+
+@Component({
+  tag: 'justifi-order-terminals',
+  shadow: true,
+})
+export class OrderTerminals {
+  @Prop() businessId: string;
+  @Prop() authToken: string;
+
+  @State() errorMessage: string;
+  @State() isLoading: boolean = true;
+  @State() business: Business;
+
+  analytics: JustifiAnalytics;
+
+  @Event({
+    eventName: 'error-event'
+  }) errorEvent: EventEmitter<ComponentErrorEvent>;
+
+  componentWillLoad() {
+    checkPkgVersion();
+    this.analytics = new JustifiAnalytics(this);
+    this.initializeGetBusiness();
+  }
+
+  private initializeGetBusiness() {
+    if (!this.businessId || !this.authToken) {
+      this.errorMessage = 'Invalid business id or auth token';
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.MISSING_PROPS,
+        message: this.errorMessage,
+        severity: ComponentErrorSeverity.ERROR,
+      });
+      return;
+    }
+
+    const getBusiness = makeGetBusiness({
+      businessId: this.businessId,
+      authToken: this.authToken,
+      service: new BusinessService(),
+    });
+
+    getBusiness({
+      onSuccess: ({ business }) => {
+        this.business = new Business(business);
+        this.isLoading = false;
+      },
+      onError: ({ error, code, severity }) => {
+        this.errorMessage = error;
+
+        this.errorEvent.emit({
+          errorCode: code,
+          message: error,
+          severity,
+        });
+        this.isLoading = false;
+      }
+    });
+  }
+
+  render() {
+    if (this.errorMessage) {
+      return <StyledHost>{ErrorState(this.errorMessage)}</StyledHost>;
+    }
+
+    if (this.isLoading) {
+      return (
+        <StyledHost>
+          <p>Loading...</p>
+        </StyledHost>
+      );
+    }
+
+    return (
+      <StyledHost>
+        <p>Business Legal Name: {this.business.legal_name}</p>
+      </StyledHost>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/order-terminals/test/order-terminals.spec.tsx
+++ b/packages/webcomponents/src/components/order-terminals/test/order-terminals.spec.tsx
@@ -1,0 +1,47 @@
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+import { OrderTerminals } from '../order-terminals';
+import JustifiAnalytics from '../../../api/Analytics';
+
+beforeEach(() => {
+  // Bypass Analytics to avoid errors. Analytics attaches events listeners to HTML elements
+  // which are not available in Jest/node environment
+  // @ts-ignore
+  JustifiAnalytics.prototype.trackCustomEvents = jest.fn();
+});
+
+describe('justifi-order-terminals', () => {
+  it('should instantiate JustifiAnalytics on componentWillLoad', async () => {
+    const page = await newSpecPage({
+      components: [OrderTerminals],
+      template: () => <justifi-order-terminals />,
+    });
+
+    await page.rootInstance.componentWillLoad();
+
+    expect(page.rootInstance.analytics).toBeInstanceOf(JustifiAnalytics);
+  });
+
+  it('should set error message if businessId or authToken is missing', async () => {
+    const page = await newSpecPage({
+      components: [OrderTerminals],
+      template: () => <justifi-order-terminals />,
+    });
+
+    await page.rootInstance.componentWillLoad();
+
+    expect(page.rootInstance.errorMessage).toBe('Invalid business id or auth token');
+  });
+
+  it('should emit an error event if businessId or authToken is missing', async () => {
+    const errorEvent = jest.fn();
+    const page = await newSpecPage({
+      components: [OrderTerminals],
+      template: () => <justifi-order-terminals onerror-event={errorEvent} />,
+    });
+
+    await page.rootInstance.componentWillLoad();
+
+    expect(errorEvent).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR commits the following: 

- Creates the basic boilerplate code for the `justifi-order-terminals` component.
- Creates an initial Docs file and Storybook story with some information about the component (can be improved later).
- Create some basic unit tests (smoke tests so far).
- Create an example file that can be run by the command: `pnpm dev:order-terminals`.

**NOTE** - I haven't implemented yet the `core component` pattern that we have, because I wanna test an alternative for mocking services in the test files. So this part I'll add later when the component actually have more api interaction.

Links
-----
#865 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [x] App should build and tests should pass

Running Storybook: `pnpm dev`;

- [x] A new sidebar item "Merchant Tools/Order Terminals" should be visible.
- [x] It should display basic Docs text.
- [x] A basic example that displays only the business name should be visible for now.

Running `pnpm dev:order-terminals` => `localhost:3420`

- [x] A very basic component should fetch and display the business name, accordingly with the business-id passed as props.
