### PR TITLE
Refactor Analytics logic to bypass calls from localhost and storybook

### DIFF
--- a/apps/component-examples/examples/checkout-with-insurance.js
+++ b/apps/component-examples/examples/checkout-with-insurance.js
@@ -3,6 +3,13 @@ require('dotenv').config({ path: '../../.env' });
 const express = require('express');
 const app = express();
 const port = process.env.PORT || 3000;
+const proxyApiOrigin = process.env.PROXY_API_ORIGIN;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webcomponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
+const subAccountId = process.env.SUB_ACCOUNT_ID;
+const paymentMethodId = process.env.PAYMENT_METHOD_ID;
 
 app.use(
   '/scripts',
@@ -32,13 +39,13 @@ const insurance = {
 
 async function getToken() {
   const requestBody = JSON.stringify({
-    client_id: process.env.CLIENT_ID,
-    client_secret: process.env.CLIENT_SECRET,
+    client_id: clientId,
+    client_secret: clientSecret,
   });
 
   let response;
   try {
-    response = await fetch('https://api.justifi.ai/oauth/token', {
+    response = await fetch(authTokenEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -54,41 +61,40 @@ async function getToken() {
 }
 
 async function makeCheckout(token) {
-  const response = await fetch('https://api.justifi.ai/v1/checkouts', {
+  const response = await fetch(`${proxyApiOrigin}/v1/checkouts`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
-      'Sub-Account': process.env.SUB_ACCOUNT_ID,
+      'Sub-Account': subAccountId,
     },
     body: JSON.stringify({
       amount: 1799,
       description: 'One Chocolate Donut',
-      payment_method_group_id: process.env.PAYMENT_METHOD_GROUP_ID,
+      payment_method_group_id: paymentMethodId,
       origin_url: `http://localhost:${port}`,
     }),
   });
-  const { data } = await response.json();
+  const responseJson = await response.json();
+  console.log('responseJson:', responseJson);
+  const { data } = responseJson;
   return data;
 }
 
 async function getWebComponentToken(token, checkoutId) {
-  const response = await fetch(
-    'https://api.justifi.ai/v1/web_component_tokens',
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({
-        resources: [
-          `write:checkout:${checkoutId}`,
-          `write:tokenize:${process.env.SUB_ACCOUNT_ID}`,
-        ],
-      }),
-    }
-  );
+  const response = await fetch(webcomponentTokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      resources: [
+        `write:checkout:${checkoutId}`,
+        `write:tokenize:${subAccountId}`,
+      ],
+    }),
+  });
   const { access_token } = await response.json();
   return access_token;
 }

--- a/apps/docs/stories/utils/mockAllServices.ts
+++ b/apps/docs/stories/utils/mockAllServices.ts
@@ -156,9 +156,6 @@ export const setUpMocks = () => {
       // SubAccounts
       this.get(API_PATHS.SUB_ACCOUNTS_LIST, () => mockSubAccounts);
 
-      // Analytics
-      this.post(API_PATHS.ANALYTICS, () => null);
-
       // InsuranceQuotes
       this.post(
         API_PATHS.INSURANCE_QUOTES,

--- a/packages/webcomponents/src/api/Analytics.ts
+++ b/packages/webcomponents/src/api/Analytics.ts
@@ -25,6 +25,13 @@ class JustifiAnalytics {
   basicData: iBasicData;
 
   constructor(component: ComponentInterface) {
+    // dont track analytics in local or storybook
+    if (
+      window.location.origin.includes('localhost') ||
+      window.location.origin.includes('storybook')
+    ) {
+      return;
+    }
     this.service = new AnalyticsService();
     this.componentInstance = component;
     this.setUpBasicData();


### PR DESCRIPTION
**Description**
The main focus of this PR is to add some logic to bypass the Analytics service call when origin is localhost and storybook.

This will help to maintain Datadog data clean.

Also this PR commits some improvements in the checkout example variables organization.

Links
-----
#886 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [x] No Analytics call should happen if running from localhost or storybook (local and prod)

