### PR TITLE
Create terminal orders list component

### DIFF
--- a/apps/component-examples/css/example.css
+++ b/apps/component-examples/css/example.css
@@ -26,7 +26,7 @@
   width: 50%;
 }
 
-.list-wrapper {
+.list-component-wrapper {
   display: flex;
   flex-direction: column;
   padding: 25px;

--- a/apps/component-examples/css/example.css
+++ b/apps/component-examples/css/example.css
@@ -26,4 +26,10 @@
   width: 50%;
 }
 
+.list-wrapper {
+  display: flex;
+  flex-direction: column;
+  padding: 25px;
+}
+
 /* End: example purposes only */

--- a/apps/component-examples/examples/checkouts-list-with-filters.js
+++ b/apps/component-examples/examples/checkouts-list-with-filters.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <div>
             <justifi-checkouts-list-filters />
           </div>

--- a/apps/component-examples/examples/checkouts-list-with-filters.js
+++ b/apps/component-examples/examples/checkouts-list-with-filters.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <div>
             <justifi-checkouts-list-filters />
           </div>

--- a/apps/component-examples/examples/checkouts-list.js
+++ b/apps/component-examples/examples/checkouts-list.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <justifi-checkouts-list 
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/examples/checkouts-list.js
+++ b/apps/component-examples/examples/checkouts-list.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <justifi-checkouts-list 
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/examples/payments-list-with-filters.js
+++ b/apps/component-examples/examples/payments-list-with-filters.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <div>
             <justifi-payments-list-filters />
           </div>

--- a/apps/component-examples/examples/payments-list-with-filters.js
+++ b/apps/component-examples/examples/payments-list-with-filters.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <div>
             <justifi-payments-list-filters />
           </div>

--- a/apps/component-examples/examples/payments-list.js
+++ b/apps/component-examples/examples/payments-list.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <justifi-payments-list
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/examples/payments-list.js
+++ b/apps/component-examples/examples/payments-list.js
@@ -68,7 +68,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <justifi-payments-list
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/examples/payouts-list-with-filters.js
+++ b/apps/component-examples/examples/payouts-list-with-filters.js
@@ -70,7 +70,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <div>
             <justifi-payouts-list-filters />
           </div>

--- a/apps/component-examples/examples/payouts-list-with-filters.js
+++ b/apps/component-examples/examples/payouts-list-with-filters.js
@@ -70,7 +70,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <div>
             <justifi-payouts-list-filters />
           </div>

--- a/apps/component-examples/examples/payouts-list.js
+++ b/apps/component-examples/examples/payouts-list.js
@@ -71,7 +71,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <justifi-payouts-list
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/examples/payouts-list.js
+++ b/apps/component-examples/examples/payouts-list.js
@@ -71,7 +71,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <justifi-payouts-list
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/examples/terminal-orders-list.js
+++ b/apps/component-examples/examples/terminal-orders-list.js
@@ -1,0 +1,89 @@
+require('dotenv').config({ path: '../../.env' });
+
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+// const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+// const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+// const subAccountId = process.env.SUB_ACCOUNT_ID;
+const businessId = process.env.BUSINESS_ID;
+// const clientId = process.env.CLIENT_ID;
+// const clientSecret = process.env.CLIENT_SECRET;
+
+app.use(
+  '/scripts',
+  express.static(__dirname + '/../node_modules/@justifi/webcomponents/dist/')
+);
+app.use('/styles', express.static(__dirname + '/../css/'));
+
+// async function getToken() {
+//   const requestBody = JSON.stringify({
+//     client_id: clientId,
+//     client_secret: clientSecret
+//   });
+
+//   let response;
+//   try {
+//     response = await fetch(authTokenEndpoint, {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//       },
+//       body: requestBody,
+//     });
+//   } catch (error) {
+//     console.log('ERROR:', error);
+//   }
+
+//   const { access_token } = await response.json();
+//   return access_token;
+// }
+
+// async function getWebComponentToken(token) {
+//   const response = await fetch(webComponentTokenEndpoint,
+//     {
+//       method: 'POST',
+//       headers: {
+//         'Content-Type': 'application/json',
+//         Authorization: `Bearer ${token}`,
+//       },
+//       body: JSON.stringify({
+//         resources: [`read:account:${subAccountId}`],
+//       }),
+//     }
+//   );
+
+//   const { access_token } = await response.json();
+//   return access_token;
+// }
+
+app.get('/', async (req, res) => {
+  // const token = await getToken();
+  // const webComponentToken = await getWebComponentToken(token);
+
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>JustiFi Terminal Orders List Component</title>
+        <script type="module" src="/scripts/webcomponents/webcomponents.esm.js"></script>
+        <link rel="stylesheet" href="/styles/theme.css">
+        <link rel="stylesheet" href="/styles/example.css">
+      </head>
+      <body>
+        <div style="padding:25px;">
+          <justifi-terminal-orders-list 
+            business-id="${businessId}"
+            auth-token="authToken123"
+          />
+        </div>
+        <script>
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/apps/component-examples/examples/terminal-orders-list.js
+++ b/apps/component-examples/examples/terminal-orders-list.js
@@ -71,7 +71,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <justifi-terminal-orders-list 
             business-id="${businessId}"
             auth-token="authToken123"

--- a/apps/component-examples/examples/terminal-orders-list.js
+++ b/apps/component-examples/examples/terminal-orders-list.js
@@ -71,7 +71,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <justifi-terminal-orders-list 
             business-id="${businessId}"
             auth-token="authToken123"

--- a/apps/component-examples/examples/terminals-list-with-filters.js
+++ b/apps/component-examples/examples/terminals-list-with-filters.js
@@ -70,7 +70,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <div>
             <justifi-terminals-list-filters />
           </div>

--- a/apps/component-examples/examples/terminals-list-with-filters.js
+++ b/apps/component-examples/examples/terminals-list-with-filters.js
@@ -70,7 +70,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <div>
             <justifi-terminals-list-filters />
           </div>

--- a/apps/component-examples/examples/terminals-list.js
+++ b/apps/component-examples/examples/terminals-list.js
@@ -70,7 +70,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div style="padding:25px;">
+        <div class="list-wrapper">
           <justifi-terminals-list 
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/examples/terminals-list.js
+++ b/apps/component-examples/examples/terminals-list.js
@@ -70,7 +70,7 @@ app.get('/', async (req, res) => {
         <link rel="stylesheet" href="/styles/example.css">
       </head>
       <body>
-        <div class="list-wrapper">
+        <div class="list-component-wrapper">
           <justifi-terminals-list 
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -20,7 +20,8 @@
     "start:payments-list-with-filters": "npx nodemon ./examples/payments-list-with-filters.js",
     "start:payouts-list": "npx nodemon ./examples/payouts-list.js",
     "start:payouts-list-with-filters": "npx nodemon ./examples/payouts-list-with-filters.js",
-    "start:order-terminals": "npx nodemon ./examples/order-terminals.js"
+    "start:order-terminals": "npx nodemon ./examples/order-terminals.js",
+    "start:terminal-orders-list": "npx nodemon ./examples/terminal-orders-list.js"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "dev:payouts-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payouts-list'",
     "dev:payouts-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payouts-list-with-filters'",
     "dev:order-terminals": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:order-terminals'",
+    "dev:terminal-orders-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:terminal-orders-list'",
     "preview-storybook": "turbo run preview-storybook",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/packages/webcomponents/src/components/pagination-menu/readme.md
+++ b/packages/webcomponents/src/components/pagination-menu/readme.md
@@ -20,6 +20,7 @@
  - [checkouts-list-core](../checkouts-list)
  - [payments-list-core](../payments-list)
  - [payouts-list-core](../payouts-list)
+ - [terminal-orders-list-core](../terminal-orders-list)
  - [terminals-list-core](../terminals-list)
 
 ### Graph
@@ -28,6 +29,7 @@ graph TD;
   checkouts-list-core --> pagination-menu
   payments-list-core --> pagination-menu
   payouts-list-core --> pagination-menu
+  terminal-orders-list-core --> pagination-menu
   terminals-list-core --> pagination-menu
   style pagination-menu fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
@@ -3,6 +3,7 @@ import { Table } from '../../utils/table';
 import { table, tableCell } from '../../styles/parts';
 import { TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
 import { pagingDefaults, PagingInfo } from '../../api';
+import { terminalOrdersTableCells, terminalOrdersTableColumns } from './terminal-orders-table';
 
 @Component({
   tag: 'terminal-orders-list-core',
@@ -29,6 +30,7 @@ export class TerminalOrdersListCore {
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<any>;
 
   componentWillLoad() {
+    this.terminalOrdersTable = new Table<any>(this.terminalOrders, this.columns, terminalOrdersTableColumns, terminalOrdersTableCells);
     if (this.getTerminalOrders) {
       this.fetchData();
     }
@@ -36,7 +38,8 @@ export class TerminalOrdersListCore {
 
   fetchData(): void {
     this.loading = true;
-    console.log('fetching data');
+    console.log('fetching terminal orders');
+    this.loading = false;
   }
 
   handleClickPrevious = (beforeCursor: string) => {

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
@@ -1,0 +1,125 @@
+import { Component, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
+import { Table } from '../../utils/table';
+import { table, tableCell } from '../../styles/parts';
+import { TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
+import { pagingDefaults, PagingInfo } from '../../api';
+
+@Component({
+  tag: 'terminal-orders-list-core',
+})
+
+export class TerminalOrdersListCore {
+  @Prop() getTerminalOrders: Function;
+  @Prop() columns: string;
+
+  @State() terminalOrders: any[] = [];
+  @State() terminalOrdersTable: Table<any>;
+  @State() loading: boolean = true;
+  @State() errorMessage: string;
+  @State() paging: PagingInfo = pagingDefaults;
+  @State() pagingParams: any = {};
+
+  @Watch('pagingParams')
+  @Watch('getTerminalOrders')
+  @Watch('columns')
+  updateOnPropChange() {
+    this.fetchData();
+  }
+
+  @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<any>;
+
+  componentWillLoad() {
+    if (this.getTerminalOrders) {
+      this.fetchData();
+    }
+  }
+
+  fetchData(): void {
+    this.loading = true;
+    console.log('fetching data');
+  }
+
+  handleClickPrevious = (beforeCursor: string) => {
+    this.pagingParams = { before_cursor: beforeCursor };
+  };
+
+  handleClickNext = (afterCursor: string) => {
+    this.pagingParams = { after_cursor: afterCursor };
+  };
+
+  rowClickHandler = (e) => {
+    const clickedOrderId = e.target.closest('tr').dataset.rowEntityId;
+    if (!clickedOrderId) return;
+    console.log('clickedOrderId', clickedOrderId);
+  };
+
+  get entityId() {
+    return this.terminalOrders.map((terminalOrder) => terminalOrder.id);
+  }
+
+  get showEmptyState() {
+    return !this.loading && !this.errorMessage && this.terminalOrdersTable.rowData.length < 1;
+  }
+
+  get showErrorState() {
+    return !this.loading && !!this.errorMessage;
+  }
+
+  get showRowData() {
+    return !this.showEmptyState && !this.showErrorState && !this.loading;
+  }
+
+  render() {
+    return (
+      <div>
+        <div class="table-wrapper">
+          <table class="table table-hover" part={table}>
+            <thead class="table-head sticky-top">
+              <tr class="table-light text-nowrap">
+                {this.terminalOrdersTable.columnData.map((column) => column)}
+              </tr>
+            </thead>
+            <tbody class="table-body">
+              <TableLoadingState
+                columnSpan={this.terminalOrdersTable.columnKeys.length}
+                isLoading={this.loading}
+              />
+              <TableEmptyState
+                isEmpty={this.showEmptyState}
+                columnSpan={this.terminalOrdersTable.columnKeys.length}
+              />
+              <TableErrorState
+                columnSpan={this.terminalOrdersTable.columnKeys.length}
+                errorMessage={this.errorMessage}
+              />
+              {this.showRowData && this.terminalOrdersTable.rowData.map((data, index) => (
+                <tr
+                  data-test-id="table-row"
+                  data-row-entity-id={this.entityId[index]}
+                  onClick={this.rowClickHandler}
+                >
+                  {data}
+                </tr>
+              ))}
+            </tbody>
+            {this.paging && (
+              <tfoot class="sticky-bottom">
+                <tr class="table-light align-middle">
+                  <td part={tableCell} colSpan={this.terminalOrdersTable.columnData.length}>
+                    <pagination-menu
+                      paging={{
+                        ...this.paging,
+                        handleClickPrevious: this.handleClickPrevious,
+                        handleClickNext: this.handleClickNext,
+                      }}
+                    />
+                  </td>
+                </tr>
+              </tfoot>
+            )}
+          </table>
+        </div>
+      </div>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
@@ -1,0 +1,44 @@
+import { Component, h, Prop, State } from '@stencil/core';
+import { StyledHost } from '../../ui-components';
+import { checkPkgVersion } from '../../utils/check-pkg-version';
+
+@Component({
+  tag: 'justifi-terminal-orders-list',
+  shadow: true
+})
+
+export class TerminalOrdersList {
+  @State() getTerminalOrders: Function;
+  @State() errorMessage: string = null;
+
+  @Prop() businessId: string;
+  @Prop() authToken: string;
+  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
+  @Prop() columns?: string;
+  
+  componentWillLoad() {
+    checkPkgVersion();
+    this.initializeGetTerminalOrders();
+  }
+
+  private initializeGetTerminalOrders() {
+    if (this.businessId && this.authToken) {
+      this.getTerminalOrders = () => {
+        console.log('getTerminalOrders');
+      }
+    } else {
+      this.errorMessage = 'Business ID and Auth Token are required';
+    }
+  }
+
+  render() {
+    return (
+      <StyledHost>
+        <terminal-orders-list-core 
+          getTerminalOrders={this.getTerminalOrders} 
+          columns={this.columns}
+        />
+      </StyledHost>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, State } from '@stencil/core';
 import { StyledHost } from '../../ui-components';
 import { checkPkgVersion } from '../../utils/check-pkg-version';
+import { defaultColumnsKeys } from './terminal-orders-table';
 
 @Component({
   tag: 'justifi-terminal-orders-list',
@@ -14,7 +15,7 @@ export class TerminalOrdersList {
   @Prop() businessId: string;
   @Prop() authToken: string;
   @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
-  @Prop() columns?: string;
+  @Prop() columns?: string = defaultColumnsKeys
   
   componentWillLoad() {
     checkPkgVersion();

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
@@ -1,0 +1,26 @@
+import { h } from '@stencil/core';
+import { getAlternateTableCellPart, tableHeadCell } from '../../styles/parts';
+
+export const defaultColumnsKeys = 'id,status';
+
+export const terminalOrdersTableColumns = {
+  id: () => (
+    <th part={tableHeadCell} scope="col" title="The ID of the terminal order">
+      ID
+    </th>
+  ),
+  status: () => (
+    <th part={tableHeadCell} scope="col" title="The status of the terminal order">
+      Status
+    </th>
+  ),
+}
+
+export const terminalOrdersTableCells = {
+  id: (terminalOrder, index) => (
+    <td part={getAlternateTableCellPart(index)}>{terminalOrder.id}</td>
+  ),
+  status: (terminalOrder, index) => (
+    <td part={getAlternateTableCellPart(index)}>{terminalOrder.status}</td>
+  ),
+};


### PR DESCRIPTION
### Create terminal orders list component

This PR commits the following changes:

- Creates `justifi-terminal-orders-list` component, `terminal-orders-list-core` component, `terminal-orders-table` logic, and `terminal-orders-list` js example file. 
  - there is no data being fetched yet as the API is not ready, so API service files will come later
  - columns are placeholder values for now until we decide how the data should be rendered and organized
  - classes and types are `any` for now until we have a firm idea of what the shape of the data is
  - tests will come in a later PR


Links
-----

Closes #887 


Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

- [x] Component library builds and runs


To run the new component's example file: `pnpm dev:terminal-orders-list`

- [x] Table component renders with `No Results` / empty state displayed

