### PR TITLE
terminals-list: Rename provider id column to Serial Number

### DIFF
--- a/.changeset/stupid-boats-peel.md
+++ b/.changeset/stupid-boats-peel.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Updated data column header in `justifi-terminals-list` from `Provider ID` to `Serial Number`

--- a/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
@@ -12,8 +12,8 @@ export const terminalTableColumns = {
     </th>
   ),
   provider_id: () => (
-    <th part={tableHeadCell} scope="col" title="The provider ID of the terminal">
-      Provider ID
+    <th part={tableHeadCell} scope="col" title="The serial number / provider ID of the terminal">
+      Serial Number
     </th>
   ),
   sub_account_name: () => (

--- a/packages/webcomponents/src/components/terminals-list/test/__snapshots__/terminals-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/terminals-list/test/__snapshots__/terminals-list-core.spec.tsx.snap
@@ -10,8 +10,8 @@ exports[`terminals-list-core displays an error state on failed data fetch 1`] = 
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The nickname associated with the terminal">
               Nickname
             </th>
-            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The provider ID of the terminal">
-              Provider ID
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The serial number / provider ID of the terminal">
+              Serial Number
             </th>
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The current status of each terminal">
               Status
@@ -73,8 +73,8 @@ exports[`terminals-list-core renders properly with fetched data 1`] = `
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The nickname associated with the terminal">
               Nickname
             </th>
-            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The provider ID of the terminal">
-              Provider ID
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The serial number / provider ID of the terminal">
+              Serial Number
             </th>
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The current status of each terminal">
               Status


### PR DESCRIPTION
### terminals-list: Rename provider id column to Serial Number


Links
-----

Closes #904 


Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [ ] Component library builds and runs
- [ ] Test suites pass
- [ ] Provider ID column in terminals-list should now be shown as `Serial Number` in the column header

