### PR TITLE
Improve CSV Download on Payouts List

### DIFF
--- a/.changeset/ten-geckos-jump.md
+++ b/.changeset/ten-geckos-jump.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Fixed bug in `justifi-payouts-list` where downloading the payout CSV could return an error from a bad request. 
+- Updated behavior of `click-event` in `justifi-payouts-list` to not emit when clicking on the CSV download link.

--- a/packages/webcomponents/src/api/Payout.ts
+++ b/packages/webcomponents/src/api/Payout.ts
@@ -91,10 +91,6 @@ export class Payout implements IPayout {
     this.updated_at = payout.updated_at;
   }
 
-  get csv(): string {
-    return this.id;
-  }
-
   formattedPaymentAmount(amount: number): string {
     return formatCurrency(amount, this.currency);
   }

--- a/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
@@ -130,13 +130,12 @@ export class PayoutsListCore {
 
   rowClickHandler = (e) => {
     const clickedRow = e.target.closest('tr');
+    
     const clickedPayoutID = clickedRow.dataset.rowEntityId;
-    const clickedCSV = clickedRow.querySelector('a');
     if (!clickedPayoutID) return;
-    if (clickedCSV === e.target) {
-      this.clickEvent.emit({ name: TableClickActions.payoutCSV, data: clickedPayoutID });
-      return;
-    }
+    
+    const clickedCSV = clickedRow.querySelector('a');
+    if (clickedCSV === e.target) return;
 
     const payoutData = this.payouts.find((payout) => payout.id === clickedPayoutID);
     this.clickEvent.emit({ name: TableClickActions.row, data: payoutData });

--- a/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list-core.tsx
@@ -129,8 +129,14 @@ export class PayoutsListCore {
   };
 
   rowClickHandler = (e) => {
-    const clickedPayoutID = e.target.closest('tr').dataset.rowEntityId;
+    const clickedRow = e.target.closest('tr');
+    const clickedPayoutID = clickedRow.dataset.rowEntityId;
+    const clickedCSV = clickedRow.querySelector('a');
     if (!clickedPayoutID) return;
+    if (clickedCSV === e.target) {
+      this.clickEvent.emit({ name: TableClickActions.payoutCSV, data: clickedPayoutID });
+      return;
+    }
 
     const payoutData = this.payouts.find((payout) => payout.id === clickedPayoutID);
     this.clickEvent.emit({ name: TableClickActions.row, data: payoutData });

--- a/packages/webcomponents/src/components/payouts-list/payouts-table.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-table.tsx
@@ -81,7 +81,7 @@ export const payoutTableCells = (downloadCSV) => ({
   ),
   csv: (payout: Payout, index: number) => (
     <td part={getAlternateTableCellPart(index)}>
-      <a href="#" onClick={(event) => { event.preventDefault(); downloadCSV(payout); }}>
+      <a href="#" onClick={(event) => { event.preventDefault(); downloadCSV(payout.id); }}>
         CSV
       </a>
     </td>

--- a/packages/webcomponents/src/ui-components/table/event-types.ts
+++ b/packages/webcomponents/src/ui-components/table/event-types.ts
@@ -1,5 +1,6 @@
 export enum TableClickActions {
   row = 'tableRow',
   next = 'nextPage',
-  previous = 'previousPage'
+  previous = 'previousPage',
+  payoutCSV = 'payoutCSV',
 }

--- a/packages/webcomponents/src/ui-components/table/event-types.ts
+++ b/packages/webcomponents/src/ui-components/table/event-types.ts
@@ -1,6 +1,5 @@
 export enum TableClickActions {
   row = 'tableRow',
   next = 'nextPage',
-  previous = 'previousPage',
-  payoutCSV = 'payoutCSV',
+  previous = 'previousPage'
 }


### PR DESCRIPTION
### Improve CSV Download on Payouts List

This PR commits the following changes:

- Prevents table row click event from being emitted when user clicks on the CSV Download link
- Fixes cases where CSV download link was incorrectly formed, leading to failed download requests.


Links
-----

Closes #903 
Closes #899 


Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

General:

- [ ] Components build and run
- [ ] Test suites pass


`payouts-list`:

- [ ] Component builds
- [ ] Clicking on CSV download link correctly triggers download request to browser
- [ ] Clicking on CSV download link does NOT emit click event
- [ ] Clicking elsewhere on the table row still emits click event as expected.

