### PR TITLE
Remove 'ready' event

### DIFF
--- a/apps/component-examples/examples/checkout-with-insurance.js
+++ b/apps/component-examples/examples/checkout-with-insurance.js
@@ -144,10 +144,6 @@ app.get('/', async (req, res) => {
           document.getElementById('output-pane').innerHTML = '<code><pre>' + JSON.stringify(event.detail, null, 2) + '</pre></code>';
         }
 
-        justifiCheckout.addEventListener('ready-event', (event) => {
-          console.log('ready-event', event);
-        });
-
         justifiCheckout.addEventListener('submit-event', (event) => {
           console.log(event);
           writeOutputToPage(event);

--- a/apps/component-examples/examples/checkout.js
+++ b/apps/component-examples/examples/checkout.js
@@ -128,10 +128,6 @@ app.get('/', async (req, res) => {
           document.getElementById('output-pane').innerHTML = '<code><pre>' + JSON.stringify(event.detail, null, 2) + '</pre></code>';
         }
 
-        justifiCheckout.addEventListener('ready-event', (event) => {
-          console.log('ready-event', event);
-        });
-
         justifiCheckout.addEventListener('submit-event', (event) => {
           console.log(event);
           writeOutputToPage(event);

--- a/apps/component-examples/examples/tokenize-payment-method.js
+++ b/apps/component-examples/examples/tokenize-payment-method.js
@@ -109,10 +109,6 @@ app.get('/', async (req, res) => {
           document.getElementById('output-pane').innerHTML = '<code><pre>' + JSON.stringify(event.detail, null, 2) + '</pre></code>';
         }
 
-        justifiTokenizePaymentMethod.addEventListener('ready-event', (event) => {
-          console.log('ready-event', event);
-        });
-
         justifiTokenizePaymentMethod.addEventListener('submit-event', (event) => {
           console.log('submit-event', event);
 

--- a/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
+++ b/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, Method, Prop, Event, EventEmitter, State } from "@stencil/core";
+import { Component, h, Host, Method, Prop, State } from "@stencil/core";
 import BankAccountFormSkeleton from "./bank-account-form-skeleton";
 
 @Component({

--- a/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
+++ b/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
@@ -7,8 +7,6 @@ import BankAccountFormSkeleton from "./bank-account-form-skeleton";
 export class BankAccountForm {
   @Prop() iframeOrigin: string;
 
-  @Event({ eventName: 'ready-event' }) eventReady: EventEmitter<void>;
-
   @State() isReady: boolean = false;
 
   private accountNumberIframeElement!: HTMLIframeInputElement;
@@ -46,7 +44,6 @@ export class BankAccountForm {
       });
     })).then(() => {
       this.isReady = true;
-      this.eventReady.emit();
     });
   }
 

--- a/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
+++ b/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Host, Method, Prop, State } from "@stencil/core";
+import { Component, h, Host, Method, Prop, State } from "@stencil/core";
 import CardFormSkeleton from "./card-form-skeleton";
 
 @Component({

--- a/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
+++ b/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
@@ -7,8 +7,6 @@ import CardFormSkeleton from "./card-form-skeleton";
 export class CardForm {
   @Prop() iframeOrigin: string;
 
-  @Event({ eventName: 'ready-event' }) eventReady: EventEmitter<void>;
-
   @State() isReady: boolean = false;
 
   private cardNumberIframeElement!: HTMLIframeInputElement;
@@ -30,7 +28,6 @@ export class CardForm {
       });
     })).then(() => {
       this.isReady = true;
-      this.eventReady.emit();
     });
   }
 


### PR DESCRIPTION
Removing this once again as it does not seem especially helpful now that we have proper loading states for the card and bank account forms. We can add it back later if there is a good reason for it, but once it's introduced in a published package deprecating would be a breaking change.


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

