### PR TITLE
Show `provider_serial_number` property in `terminals-list`

### DIFF
--- a/.changeset/forty-shirts-exist.md
+++ b/.changeset/forty-shirts-exist.md
@@ -1,0 +1,9 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Reverted change introduced in 5.3.3 to `justifi-terminals-list` - aa808c7 
+  - The table column that displays the `provider_id` value has had its column header restored to it's original value: `Provider ID`.
+- Added new table column to display `provider_serial_number` property from terminal response.
+- `provider_serial_number` column is now loaded by default in the table, replacing `provider_id` column.
+  - `provider_id` column is no longer shown by default on the component, but is still available to use when using the `columns` prop to configure the columns shown in the table.

--- a/apps/docs/stories/components/TerminalsList/index.stories.tsx
+++ b/apps/docs/stories/components/TerminalsList/index.stories.tsx
@@ -48,7 +48,8 @@ const meta: Meta = {
       table: {
         category: "props",
         defaultValue: {
-          summary: "nickname,provider_id,status"
+          summary: "nickname,provider_serial_number,status",
+          detail: "The following values are available to pass to the columns prop as a comma separated string: `nickname`, `provider_serial_number`, `provider_id`, `status`"
         }
       },
       control: {

--- a/mockData/mockTerminalsListSuccess.json
+++ b/mockData/mockTerminalsListSuccess.json
@@ -16,6 +16,7 @@
         "account_id": "subaccount_1",
         "platform_account_id": "acc_1vhq44La3BeJGXRsjZbXwM",
         "provider_id": "453-760-515",
+        "provider_serial_number": "453-760-515",
         "verified_at": null,
         "created_at": "2024-08-05T20:48:29.158Z",
         "updated_at": "2024-09-25T15:52:31.298Z"
@@ -28,6 +29,7 @@
         "account_id": "subaccount_2",
         "platform_account_id": "acc_1vhq44La3BeJGXRsjZbXwM",
         "provider_id": "807-075-625",
+        "provider_serial_number": "807-075-625",
         "verified_at": null,
         "created_at": "2024-08-05T20:15:21.765Z",
         "updated_at": "2024-10-31T19:21:51.886Z"
@@ -40,6 +42,7 @@
         "account_id": "subaccount_3",
         "platform_account_id": "acc_1vhq44La3BeJGXRsjZbXwM",
         "provider_id": "450-060-752",
+        "provider_serial_number": "450-060-752",
         "verified_at": null,
         "created_at": "2023-11-21T21:34:35.521Z",
         "updated_at": "2023-11-29T21:36:29.026Z"

--- a/packages/webcomponents/src/api/Terminal.ts
+++ b/packages/webcomponents/src/api/Terminal.ts
@@ -18,6 +18,7 @@ export interface ITerminal {
   gateway_ref_id?: string | null;
   provider?: string | null;
   provider_id?: string | null;
+  provider_serial_number?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
   verified_at?: string | null;
@@ -35,6 +36,7 @@ export class Terminal implements ITerminal {
   public platform_account_id: string;
   public provider: string;
   public provider_id: string;
+  public provider_serial_number: string;
   public created_at: string;
   public updated_at: string;
   public verified_at: string;
@@ -48,6 +50,7 @@ export class Terminal implements ITerminal {
     this.platform_account_id = data.platform_account_id || '';
     this.provider = data.provider || '';
     this.provider_id = data.provider_id || '';
+    this.provider_serial_number = data.provider_serial_number || '';
     this.created_at = data.created_at || '';
     this.updated_at = data.updated_at || '';
     this.verified_at = data.verified_at || '';

--- a/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
@@ -3,7 +3,7 @@ import { MapTerminalStatusToBadge } from './terminals-status';
 import { getAlternateTableCellPart, tableHeadCell } from '../../styles/parts';
 import { Terminal } from '../../api/Terminal';
 
-export const defaultColumnsKeys = 'nickname,provider_id,status';
+export const defaultColumnsKeys = 'nickname,provider_serial_number,status';
 
 export const terminalTableColumns = {
   nickname: () => (
@@ -11,9 +11,14 @@ export const terminalTableColumns = {
       Nickname
     </th>
   ),
-  provider_id: () => (
-    <th part={tableHeadCell} scope="col" title="The serial number / provider ID of the terminal">
+  provider_serial_number: () => (
+    <th part={tableHeadCell} scope="col" title="The serial number of the terminal">
       Serial Number
+    </th>
+  ),
+  provider_id: () => (
+    <th part={tableHeadCell} scope="col" title="The provider ID of the terminal">
+      Provider ID
     </th>
   ),
   sub_account_name: () => (
@@ -31,6 +36,9 @@ export const terminalTableColumns = {
 export const terminalTableCells = {
   nickname: (terminal: Terminal, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminal.nickname}</td>
+  ),
+  provider_serial_number: (terminal: Terminal, index: number) => (
+    <td part={getAlternateTableCellPart(index)}>{terminal.provider_serial_number}</td>
   ),
   provider_id: (terminal: Terminal, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminal.provider_id}</td>

--- a/packages/webcomponents/src/components/terminals-list/test/__snapshots__/terminals-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/terminals-list/test/__snapshots__/terminals-list-core.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`terminals-list-core displays an error state on failed data fetch 1`] = 
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The nickname associated with the terminal">
               Nickname
             </th>
-            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The serial number / provider ID of the terminal">
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The serial number of the terminal">
               Serial Number
             </th>
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The current status of each terminal">
@@ -73,7 +73,7 @@ exports[`terminals-list-core renders properly with fetched data 1`] = `
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The nickname associated with the terminal">
               Nickname
             </th>
-            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The serial number / provider ID of the terminal">
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The serial number of the terminal">
               Serial Number
             </th>
             <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The current status of each terminal">


### PR DESCRIPTION
### Show `provider_serial_number` property in `terminals-list`

This PR commits the following changes:

- Renames `provider_id` column back to `Provider ID`
- adds new column `provider_serial_number` / `Serial Number` used to display new property from terminals response: `provider_serial_number`
- Replaces `provider_id` with `provider_serial_number` in default column configuration for terminals-list
  - `provider_id` is still available to be used as an optional column for now.


Links
-----

Closes #915 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] Component library builds and runs as normal
- [x] Test suites pass
- [x] Default columns shown should be: `nickname, provider_serial_number, status`
- [x] `provider_id` can still be shown as a column by using the `columns` prop on `justifi-terminals-list`
- [x] Changeset makes sense? Acceptable way to communicate that we're reverting a previous change? 🤔 
- [x] Storybook docs are updated with new default value for `columns` prop.

