### PR TITLE
Fix broken checkouts payment mode filter

### DIFF
--- a/.changeset/rotten-kangaroos-perform.md
+++ b/.changeset/rotten-kangaroos-perform.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Fixes issue in `justifi-checkouts-list-filters` where the Payment Mode filter sends incorrect value and returns an API error. Payment Mode filter now correctly sends `ecom` or `bnpl` when input selection is made.

--- a/packages/webcomponents/src/api/Checkout.ts
+++ b/packages/webcomponents/src/api/Checkout.ts
@@ -207,6 +207,11 @@ export enum ICheckoutPaymentMode {
   unknown = ''
 }
 
+export enum ICheckoutPaymentModeParam {
+  bnpl = 'bnpl',
+  ecom = 'ecom'
+}
+
 export enum ICheckoutStatus {
   created = 'created',
   completed = 'completed',

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list-filters.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop } from '@stencil/core';
-import { ICheckoutPaymentMode, ICheckoutStatus } from '../../api';
+import { ICheckoutPaymentModeParam, ICheckoutStatus } from '../../api';
 import { filterParams, propsParams, clearParams } from './checkouts-list-params-state';
 import { StyledHost } from '../../ui-components';
 import { checkoutsListFilterMenu, paymentModeCheckoutsListFilterParam, statusCheckoutsListFilterParam } from '../../styles/parts';
@@ -10,7 +10,7 @@ import { checkoutsListFilterMenu, paymentModeCheckoutsListFilterParam, statusChe
 })
 export class CheckoutsListFilters {
   @Prop() checkoutStatus?: ICheckoutStatus;
-  @Prop() paymentMode?: ICheckoutPaymentMode;
+  @Prop() paymentMode?: ICheckoutPaymentModeParam;
 
   componentWillLoad() {
     const propsToSet = {
@@ -39,11 +39,11 @@ export class CheckoutsListFilters {
     ]
   }
 
-  get checkoutPaymentModeOptions(): { label: string, value: ICheckoutPaymentMode | '' }[] {
+  get checkoutPaymentModeOptions(): { label: string, value: ICheckoutPaymentModeParam | '' }[] {
     return [
       { label: 'All', value: '' },
-      { label: 'E-commerce', value: ICheckoutPaymentMode.ecom },
-      { label: 'BNPL', value: ICheckoutPaymentMode.bnpl },
+      { label: 'E-commerce', value: ICheckoutPaymentModeParam.ecom },
+      { label: 'BNPL', value: ICheckoutPaymentModeParam.bnpl },
     ]
   }
 


### PR DESCRIPTION
### Fix broken checkouts payment mode filter

This PR commits the following change:

- Fixes bug in `checkouts-list-filters` where `payment_mode` filter input sends wrong value. 
  - Incorrectly sending `E-Commerce` and `Buy Now Pay Later`
  - Fixed to send `ecom` and `bnpl`


Links
-----

Closes #920 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

To test this - run `pnpm dev:checkouts-list-with-filters`

- [x] Component library builds and runs as expected
- [x] test suites pass
- [x] Payment Mode filter sends correct values when making input selection: `ecom` or `bnpl` and does not return API error

