### PR TITLE
Fix submission bug in payment-provisioning component

### DIFF
--- a/.changeset/dirty-maps-reflect.md
+++ b/.changeset/dirty-maps-reflect.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Fixed submit error that sometimes occured in `justifi-payment-provisioning` component's final form step.

--- a/apps/component-examples/examples/payment-provisioning.js
+++ b/apps/component-examples/examples/payment-provisioning.js
@@ -4,6 +4,11 @@ const express = require('express');
 const { generateRandomLegalName } = require('../utils/random-business-names');
 const app = express();
 const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const businessEndpoint = process.env.BUSINESS_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
 
 app.use(
   '/scripts',
@@ -13,13 +18,13 @@ app.use('/styles', express.static(__dirname + '/../css/'));
 
 async function getToken() {
   const requestBody = JSON.stringify({
-    client_id: process.env.CLIENT_ID,
-    client_secret: process.env.CLIENT_SECRET,
+    client_id: clientId,
+    client_secret: clientSecret,
   });
 
   let response;
   try {
-    response = await fetch('https://api.justifi.ai/oauth/token', {
+    response = await fetch(authTokenEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -38,7 +43,7 @@ async function getToken() {
 
 async function createBusiness(token) {
   const randomLegalName = generateRandomLegalName();
-  const response = await fetch('https://api.justifi.ai/v1/entities/business', {
+  const response = await fetch(businessEndpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -54,9 +59,7 @@ async function createBusiness(token) {
 }
 
 async function getWebComponentToken(token, businessId) {
-  const response = await fetch(
-    'https://api.justifi.ai/v1/web_component_tokens',
-    {
+  const response = await fetch(webComponentTokenEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-core.tsx
@@ -34,7 +34,7 @@ export class PaymentProvisioningCore {
   componentWillLoad() {
     this.getBusiness && this.setBusinessProvisioned();
 
-    this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef, this.bankAccountRef, this.documentUploadRef, this.termsRef];
+    this.refs = [this.coreInfoRef, this.legalAddressRef, this.additionalQuestionsRef, this.representativeRef, this.ownersRef, this.bankAccountRef, this.termsRef];
   }
 
   setBusinessProvisioned = () => {
@@ -81,7 +81,6 @@ export class PaymentProvisioningCore {
   private representativeRef: any;
   private ownersRef: any;
   private bankAccountRef: any;
-  private documentUploadRef: any;
   private termsRef: any;
   private refs = [];
 


### PR DESCRIPTION
### Fix submission bug in payment-provisioning component

This PR commits the following change:

- Fixes bug in payment-provisioning component where submit button returns console error. We removed the document upload form step recently and seems we did not remove the `ref` to this step when we removed it. 
- Updates example file with organized env variables used at the top of the file


Links
-----

Closes #923

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

To test this - run `pnpm dev:payment-provisioning` - the example file will generate a new business for you upon load.

- [x] Component library builds and runs normally
- [x] Test suites pass
- [x] Payment provisioning component can be completed entirely without error
- [x] Number of form steps should now be correctly showing 7 form steps instead of 8 (it was showing 8 when it was still accounting for the document upload form step, which has been removed)

