### PR TITLE
Dispute component bug fixes

### DIFF
--- a/.changeset/seven-eels-peel.md
+++ b/.changeset/seven-eels-peel.md
@@ -1,0 +1,9 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Surface `justifi-dispute-response` file pre-signing errors in the UI
+- Fix typos in `justifi-dispute-notification` messages
+- Fix `justifi-dispute-response` evidence type name: `cancellation_policy_file` -> `cancellation_policy`
+- Update `justifi-dispute-response` "Service Date" to use a date selector
+- Clear/replace file selections in `justifi-dispute-response` when file selection changes. Change handler for file inputs has been abstracted for consistency.

--- a/packages/webcomponents/src/api/DisputeEvidenceDocument.ts
+++ b/packages/webcomponents/src/api/DisputeEvidenceDocument.ts
@@ -15,7 +15,6 @@ export class DisputeEvidenceDocument {
   public file_name: string;
   public file_type: string;
   public dispute_evidence_type: DisputeEvidenceDocumentType;
-  public error: string;
 
   private _file: File;
   private _presignedUrl: string;

--- a/packages/webcomponents/src/api/DisputeEvidenceDocument.ts
+++ b/packages/webcomponents/src/api/DisputeEvidenceDocument.ts
@@ -15,6 +15,7 @@ export class DisputeEvidenceDocument {
   public file_name: string;
   public file_type: string;
   public dispute_evidence_type: DisputeEvidenceDocumentType;
+  public error: string;
 
   private _file: File;
   private _presignedUrl: string;

--- a/packages/webcomponents/src/components/dispute-management/dispute-notification.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-notification.tsx
@@ -99,7 +99,7 @@ export class DisputeNotification {
         {this.dispute?.underReview && (
           <div>
             <h1 class="h4">This payment is disputed and under review</h1>
-            <p>The cardholder is disputing this payment. A counter dispute has been submitEvent and is under review.</p>
+            <p>The cardholder is disputing this payment. A counter dispute has been submitted and is under review.</p>
           </div>
         )}
 
@@ -113,7 +113,7 @@ export class DisputeNotification {
         {this.dispute?.lost && (
           <div>
             <h1 class="h4">This payment was disputed</h1>
-            <p>The cardholder disputed this payment and the card issuer has settled it their favor.</p>
+            <p>The cardholder disputed this payment and the card issuer has settled it in their favor.</p>
           </div>
         )}
       </StyledHost>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/additional-statement.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/additional-statement.tsx
@@ -10,16 +10,22 @@ import { heading5 } from "../../../styles/parts";
 })
 export class AdditionalStatement {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
+  @State() documentErrors: any = {};
   @State() acceptedTerms: boolean = false;
   @State() acceptedTermsErrorText: string;
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.additionalStatement));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -71,7 +77,7 @@ export class AdditionalStatement {
               multiple={true}
               helpText="Upload any additional pieces of evidence that have not already been provided."
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.uncategorized_file}
+              errorText={this.documentErrors?.uncategorized_file}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/additional-statement.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/additional-statement.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class AdditionalStatement {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
@@ -70,6 +71,7 @@ export class AdditionalStatement {
               multiple={true}
               helpText="Upload any additional pieces of evidence that have not already been provided."
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.uncategorized_file}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/additional-statement.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/additional-statement.tsx
@@ -1,31 +1,28 @@
 import { Component, h, State, Method, Prop } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import AdditionalStatementSchema from "./schemas/additional-statement-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-additional-statement',
 })
 export class AdditionalStatement {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documentList: DisputeEvidenceDocument[] = [];
-  @State() documentErrors: any = {};
   @State() acceptedTerms: boolean = false;
   @State() acceptedTermsErrorText: string;
+  @State() documents: { uncategorized_file: DisputeEvidenceDocument[] } = { uncategorized_file: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.additionalStatement));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.additionalStatement));
   };
 
   componentWillLoad() {
@@ -43,15 +40,6 @@ export class AdditionalStatement {
       ...this.form.values.getValue(),
       [name]: value
     });
-  }
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   render() {
@@ -76,7 +64,7 @@ export class AdditionalStatement {
               name="uncategorized_file"
               multiple={true}
               helpText="Upload any additional pieces of evidence that have not already been provided."
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.uncategorized_file}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class CancellationPolicy {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
@@ -75,6 +76,7 @@ export class CancellationPolicy {
               label="Upload Cancellation Policy"
               name="cancellation_policy_file"
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.cancellation_policy_file}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
@@ -10,14 +10,20 @@ import { heading5 } from "../../../styles/parts";
 })
 export class CancellationPolicy {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
+  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.cancellationPolicy));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -76,7 +82,7 @@ export class CancellationPolicy {
               label="Upload Cancellation Policy"
               name="cancellation_policy_file"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.cancellation_policy_file}
+              errorText={this.documentErrors?.cancellation_policy_file}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
@@ -15,7 +15,7 @@ export class CancellationPolicy {
 
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documents: { cancellation_policy_file: DisputeEvidenceDocument[] } = { cancellation_policy_file: [] };
+  @State() documents: { cancellation_policy: DisputeEvidenceDocument[] } = { cancellation_policy: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
@@ -68,9 +68,9 @@ export class CancellationPolicy {
           <div class="col-12">
             <form-control-file-v2
               label="Upload Cancellation Policy"
-              name="cancellation_policy_file"
+              name="cancellation_policy"
               onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
-              errorText={this.documentErrors?.cancellation_policy_file}
+              errorText={this.documentErrors?.cancellation_policy}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/cancellation-policy.tsx
@@ -1,29 +1,26 @@
 import { Component, h, State, Method, Prop } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import CancellationPolicySchema from "./schemas/cancellation-policy-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-cancellation-policy',
 })
 export class CancellationPolicy {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documentList: DisputeEvidenceDocument[] = [];
-  @State() documentErrors: any = {};
+  @State() documents: { cancellation_policy_file: DisputeEvidenceDocument[] } = { cancellation_policy_file: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.cancellationPolicy));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.cancellationPolicy));
   };
 
   componentWillLoad() {
@@ -41,15 +38,6 @@ export class CancellationPolicy {
       ...this.form.values.getValue(),
       [name]: value
     });
-  }
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   render() {
@@ -81,7 +69,7 @@ export class CancellationPolicy {
             <form-control-file-v2
               label="Upload Cancellation Policy"
               name="cancellation_policy_file"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.cancellation_policy_file}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/customer-details.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/customer-details.tsx
@@ -10,14 +10,20 @@ import { heading5 } from "../../../styles/parts";
 })
 export class CustomerDetails {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList = [];
+  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.customerDetails));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -86,7 +92,7 @@ export class CustomerDetails {
               label="Customer Signature"
               name="customer_signature"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.customer_signature}
+              errorText={this.documentErrors?.customer_signature}
             />
           </div>
           <div class="col-12">
@@ -94,7 +100,7 @@ export class CustomerDetails {
               label="Customer Communication"
               name="customer_communication"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.customer_communication}
+              errorText={this.documentErrors?.customer_communication}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/customer-details.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/customer-details.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class CustomerDetails {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList = [];
@@ -85,6 +86,7 @@ export class CustomerDetails {
               label="Customer Signature"
               name="customer_signature"
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.customer_signature}
             />
           </div>
           <div class="col-12">
@@ -92,6 +94,7 @@ export class CustomerDetails {
               label="Customer Communication"
               name="customer_communication"
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.customer_communication}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/customer-details.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/customer-details.tsx
@@ -1,29 +1,29 @@
 import { Component, h, Method, Prop, State } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import CustomerDetailsSchema from "./schemas/customer-details-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-customer-details',
 })
 export class CustomerDetails {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documentList = [];
-  @State() documentErrors: any = {};
+  @State() documents: {
+    customer_signature: DisputeEvidenceDocument[],
+    customer_communication: DisputeEvidenceDocument[]
+  } = { customer_signature: [], customer_communication: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.customerDetails));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.customerDetails));
   };
 
   componentWillLoad() {
@@ -41,15 +41,6 @@ export class CustomerDetails {
       ...this.form.values.getValue(),
       [name]: value
     });
-  }
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   render() {
@@ -91,7 +82,7 @@ export class CustomerDetails {
             <form-control-file-v2
               label="Customer Signature"
               name="customer_signature"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.customer_signature}
             />
           </div>
@@ -99,7 +90,7 @@ export class CustomerDetails {
             <form-control-file-v2
               label="Customer Communication"
               name="customer_communication"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.customer_communication}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/dispute-response-core.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/dispute-response-core.tsx
@@ -35,6 +35,7 @@ export class DisputeResponseCore {
 
   @State() isLoading: boolean = false;
   @State() documentList = [];
+  @State() documentServerErrors = {};
   @State() currentStep = 0;
   @State() currentStepComponentRef: any;
 
@@ -44,15 +45,27 @@ export class DisputeResponseCore {
   @Event({ eventName: 'submit-event', bubbles: true }) submitEvent: EventEmitter<ComponentSubmitEvent>;
 
   componentStepMapping = [
-    () => <justifi-product-or-service ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-customer-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-cancellation-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-refund-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-duplicate-charge ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-electronic-evidence ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-shipping-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-additional-statement ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
+    () => <justifi-product-or-service ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
+    () => <justifi-customer-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
+    () => <justifi-cancellation-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
+    () => <justifi-refund-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
+    () => <justifi-duplicate-charge ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
+    () => <justifi-electronic-evidence ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
+    () => <justifi-shipping-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
+    () => <justifi-additional-statement ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentServerErrors={this.documentServerErrors} />,
   ];
+
+  get currentStepComponent() {
+    return this.componentStepMapping[this.currentStep]();
+  }
+
+  get isLastStep() {
+    return this.currentStep === this.componentStepMapping.length - 1;
+  }
+
+  get isFirstStep() {
+    return this.currentStep === 0;
+  }
 
   saveData = async (formData: any, formStep): Promise<IApiResponse<IDispute>> => {
     const hasFormData = Object.keys(formData).length;
@@ -121,6 +134,8 @@ export class DisputeResponseCore {
         this.isLoading = false;
       },
       onError: ({ error, code, severity }) => {
+        const errors = { [document.dispute_evidence_type]: error };
+        this.documentServerErrors = { ...this.documentServerErrors, ...errors };
         this.errorEvent.emit({
           errorCode: code,
           message: error,
@@ -146,22 +161,6 @@ export class DisputeResponseCore {
     return response;
   }
 
-  get currentStepComponent() {
-    return this.componentStepMapping[this.currentStep]();
-  }
-
-  get isLastStep() {
-    return this.currentStep === this.componentStepMapping.length - 1;
-  }
-
-  get isFirstStep() {
-    return this.currentStep === 0;
-  }
-
-  private onCancel = () => {
-    this.clickEvent.emit({ name: DisputeManagementClickActions.cancelDispute });
-  }
-
   private handleSubmit = async (formData, documentList, formStep: DisputeResponseFormStep) => {
     this.isLoading = true;
 
@@ -174,6 +173,10 @@ export class DisputeResponseCore {
     await this.saveData(formData, formStep);
 
     this.isLoading = false;
+  }
+
+  private onCancel = () => {
+    this.clickEvent.emit({ name: DisputeManagementClickActions.cancelDispute });
   }
 
   // after each of these steps where validateAndSubmit is called, reload the dispute

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/dispute-response-core.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/dispute-response-core.tsx
@@ -35,7 +35,7 @@ export class DisputeResponseCore {
 
   @State() isLoading: boolean = false;
   @State() documentList = [];
-  @State() documentServerErrors = {};
+  @State() documentErrors = {};
   @State() currentStep = 0;
   @State() currentStepComponentRef: any;
 
@@ -45,14 +45,14 @@ export class DisputeResponseCore {
   @Event({ eventName: 'submit-event', bubbles: true }) submitEvent: EventEmitter<ComponentSubmitEvent>;
 
   componentStepMapping = [
-    () => <justifi-product-or-service ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-customer-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-cancellation-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-refund-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-duplicate-charge ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-electronic-evidence ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-shipping-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
-    () => <justifi-additional-statement ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} />,
+    () => <justifi-product-or-service ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
+    () => <justifi-customer-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
+    () => <justifi-cancellation-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
+    () => <justifi-refund-policy ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
+    () => <justifi-duplicate-charge ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
+    () => <justifi-electronic-evidence ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
+    () => <justifi-shipping-details ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
+    () => <justifi-additional-statement ref={(el) => this.currentStepComponentRef = el} disputeResponse={this.disputeResponse} documentErrors={this.documentErrors} />,
   ];
 
   get currentStepComponent() {
@@ -134,7 +134,7 @@ export class DisputeResponseCore {
       },
       onError: ({ error, code, severity }) => {
         const errors = { [document.dispute_evidence_type]: error };
-        this.documentServerErrors = { ...this.documentServerErrors, ...errors };
+        this.documentErrors = { ...this.documentErrors, ...errors };
         this.errorEvent.emit({
           errorCode: code,
           message: error,
@@ -163,14 +163,13 @@ export class DisputeResponseCore {
     this.isLoading = true;
 
     if (documentList.length) {
-      this.documentServerErrors = {};
+      this.documentErrors = {};
       this.documentList = documentList;
 
       await this.initializeMakePresignedURLs();
-      const hasPresigningErrors = Object.keys(this.documentServerErrors).length;
+      const hasPresigningErrors = Object.keys(this.documentErrors).length;
 
       if (hasPresigningErrors) {
-        this.currentStepComponentRef.resetDocumentListWithErrors(this.documentServerErrors);
         this.isLoading = false;
         throw new Error('Could not presign all documents');
       }

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/duplicate-charge.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/duplicate-charge.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class DuplicateCharge {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
@@ -76,6 +77,7 @@ export class DuplicateCharge {
               label="Duplicate Charge Documentation"
               name="duplicate_charge_documentation"
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.duplicate_charge_documentation}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/duplicate-charge.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/duplicate-charge.tsx
@@ -1,29 +1,26 @@
 import { Component, h, State, Method, Prop } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import DuplicateChargeSchema from "./schemas/duplicate-charge-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-duplicate-charge',
 })
 export class DuplicateCharge {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documentList: DisputeEvidenceDocument[] = [];
-  @State() documentErrors: any = {};
+  @State() documents: { duplicate_charge_documentation: DisputeEvidenceDocument[] } = { duplicate_charge_documentation: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.duplicateCharge));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.duplicateCharge));
   };
 
   componentWillLoad() {
@@ -41,16 +38,6 @@ export class DuplicateCharge {
       ...this.form.values.getValue(),
       [name]: value
     });
-  }
-
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   render() {
@@ -82,7 +69,7 @@ export class DuplicateCharge {
             <form-control-file-v2
               label="Duplicate Charge Documentation"
               name="duplicate_charge_documentation"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.duplicate_charge_documentation}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/duplicate-charge.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/duplicate-charge.tsx
@@ -10,14 +10,20 @@ import { heading5 } from "../../../styles/parts";
 })
 export class DuplicateCharge {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
+  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.duplicateCharge));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -77,7 +83,7 @@ export class DuplicateCharge {
               label="Duplicate Charge Documentation"
               name="duplicate_charge_documentation"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.duplicate_charge_documentation}
+              errorText={this.documentErrors?.duplicate_charge_documentation}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/electronic-evidence.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/electronic-evidence.tsx
@@ -1,29 +1,26 @@
 import { Component, h, State, Method, Prop } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import ElectronicEvidenceSchema from "./schemas/electronic-evidence-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-electronic-evidence',
 })
 export class ElectronicEvidence {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documentList = [];
-  @State() documentErrors: any = {};
+  @State() documents: { activity_log: DisputeEvidenceDocument[] } = { activity_log: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.electronicEvidence));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.electronicEvidence));
   };
 
   componentWillLoad() {
@@ -34,15 +31,6 @@ export class ElectronicEvidence {
     this.form.errors.subscribe(errors => {
       this.errors = { ...errors };
     });
-  }
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   private inputHandler = (name: string, value: string) => {
@@ -74,7 +62,7 @@ export class ElectronicEvidence {
               label="Activity Logs"
               name="activity_log"
               helpText="Any server or activity logs that provide evidence of the customer's access to or download of the purchased digital product. This information should encompass IP addresses, relevant timestamps, and any detailed records of activity."
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.activity_log}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/electronic-evidence.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/electronic-evidence.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class ElectronicEvidence {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList = [];
@@ -68,7 +69,7 @@ export class ElectronicEvidence {
               name="activity_log"
               helpText="Any server or activity logs that provide evidence of the customer's access to or download of the purchased digital product. This information should encompass IP addresses, relevant timestamps, and any detailed records of activity."
               onChange={this.handleFileSelection}
-              errorText={this.errors.activity_log}
+              errorText={this.documentServerErrors?.activity_log}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/electronic-evidence.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/electronic-evidence.tsx
@@ -10,14 +10,20 @@ import { heading5 } from "../../../styles/parts";
 })
 export class ElectronicEvidence {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList = [];
+  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.electronicEvidence));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -69,7 +75,7 @@ export class ElectronicEvidence {
               name="activity_log"
               helpText="Any server or activity logs that provide evidence of the customer's access to or download of the purchased digital product. This information should encompass IP addresses, relevant timestamps, and any detailed records of activity."
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.activity_log}
+              errorText={this.documentErrors?.activity_log}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/file-input-handler.ts
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/file-input-handler.ts
@@ -1,0 +1,14 @@
+import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+
+const fileInputHandler = (e: InputEvent, documentState) => {
+  const target = e.target as HTMLInputElement;
+  const name = target.name as DisputeEvidenceDocumentType;
+  const files = target.files as unknown as File[];
+  documentState[name] = [];
+
+  for (const file of files) {
+    documentState[name].push(new DisputeEvidenceDocument(file, name));
+  }
+}
+
+export default fileInputHandler;

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/product-or-service.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/product-or-service.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class ProductOrService {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList = [];
@@ -62,7 +63,7 @@ export class ProductOrService {
             />
           </div>
           <div class="col-12">
-            <form-control-text
+            <form-control-date
               label="Service Date"
               name="service_date"
               defaultValue={this.disputeResponse?.service_date}
@@ -75,7 +76,7 @@ export class ProductOrService {
               label="Service Documentation"
               name="service_documentation"
               onChange={this.handleFileSelection}
-              errorText={this.errors.service_documentation}
+              errorText={this.documentServerErrors?.service_documentation}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/product-or-service.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/product-or-service.tsx
@@ -10,14 +10,20 @@ import { heading5 } from "../../../styles/parts";
 })
 export class ProductOrService {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList = [];
+  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.productOrService));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -76,7 +82,7 @@ export class ProductOrService {
               label="Service Documentation"
               name="service_documentation"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.service_documentation}
+              errorText={this.documentErrors?.service_documentation}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/product-or-service.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/product-or-service.tsx
@@ -1,29 +1,26 @@
 import { Component, h, Method, State, Prop } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import ProductOrServiceSchema from "./schemas/product-or-service-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-product-or-service',
 })
 export class ProductOrService {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documentList = [];
-  @State() documentErrors: any = {};
+  @State() documents: { service_documentation: DisputeEvidenceDocument[] } = { service_documentation: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.productOrService));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.productOrService));
   };
 
   componentWillLoad() {
@@ -34,15 +31,6 @@ export class ProductOrService {
     this.form.errors.subscribe(errors => {
       this.errors = { ...errors };
     });
-  }
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   private inputHandler = (name: string, value: string) => {
@@ -81,7 +69,7 @@ export class ProductOrService {
             <form-control-file-v2
               label="Service Documentation"
               name="service_documentation"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.service_documentation}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/refund-policy.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/refund-policy.tsx
@@ -1,29 +1,29 @@
 import { Component, h, State, Method, Prop } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import RefundPolicySchema from "./schemas/refund-policy-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-refund-policy',
 })
 export class RefundPolicy {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
-  @State() documentList: DisputeEvidenceDocument[] = [];
-  @State() documentErrors: any = {};
+  @State() documents: {
+    refund_policy: DisputeEvidenceDocument[],
+    receipt: DisputeEvidenceDocument[],
+  } = { refund_policy: [], receipt: [] };
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.refundPolicy));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.refundPolicy));
   };
 
   componentWillLoad() {
@@ -41,16 +41,6 @@ export class RefundPolicy {
       ...this.form.values.getValue(),
       [name]: value
     });
-  }
-
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   render() {
@@ -80,7 +70,7 @@ export class RefundPolicy {
             <form-control-file-v2
               label="Upload Refund Policy"
               name="refund_policy"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.refund_policy}
             />
           </div>
@@ -88,7 +78,7 @@ export class RefundPolicy {
             <form-control-file-v2
               label="Upload Receipt"
               name="receipt"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.receipt}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/refund-policy.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/refund-policy.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class RefundPolicy {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
@@ -74,6 +75,7 @@ export class RefundPolicy {
               label="Upload Refund Policy"
               name="refund_policy"
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.refund_policy}
             />
           </div>
           <div class="col-12">
@@ -81,6 +83,7 @@ export class RefundPolicy {
               label="Upload Receipt"
               name="receipt"
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.receipt}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/refund-policy.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/refund-policy.tsx
@@ -10,14 +10,20 @@ import { heading5 } from "../../../styles/parts";
 })
 export class RefundPolicy {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
+  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.refundPolicy));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -75,7 +81,7 @@ export class RefundPolicy {
               label="Upload Refund Policy"
               name="refund_policy"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.refund_policy}
+              errorText={this.documentErrors?.refund_policy}
             />
           </div>
           <div class="col-12">
@@ -83,7 +89,7 @@ export class RefundPolicy {
               label="Upload Receipt"
               name="receipt"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.receipt}
+              errorText={this.documentErrors?.receipt}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/shipping-details.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/shipping-details.tsx
@@ -1,29 +1,27 @@
 import { Component, h, State, Method, Prop } from "@stencil/core";
 import { FormController } from "../../../ui-components/form/form";
 import ShippingDetailsSchema from "./schemas/shipping-details-schema";
-import { DisputeEvidenceDocument, DisputeEvidenceDocumentType } from "../../../api/DisputeEvidenceDocument";
+import { DisputeEvidenceDocument } from "../../../api/DisputeEvidenceDocument";
 import { DisputeResponseFormStep } from "./dispute-response-form-types";
 import { heading5 } from "../../../styles/parts";
+import fileInputHandler from "./file-input-handler";
 
 @Component({
   tag: 'justifi-shipping-details',
 })
 export class ShippingDetails {
   @Prop() disputeResponse: any;
+  @Prop() documentErrors: any = {};
+
   @State() form: FormController;
   @State() errors: any = {};
+  @State() documents: { shipping_documentation: DisputeEvidenceDocument[] } = { shipping_documentation: [] };
   @State() documentList: DisputeEvidenceDocument[] = [];
-  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
-    this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.shippingDetails));
-  };
-
-  @Method()
-  resetDocumentListWithErrors(errors: any) {
-    this.documentErrors = errors;
-    this.documentList = [];
+    const documentList = Object.values(this.documents).flat();
+    this.form.validateAndSubmit((formData) => onSuccess(formData, documentList, DisputeResponseFormStep.shippingDetails));
   };
 
   componentWillLoad() {
@@ -41,15 +39,6 @@ export class ShippingDetails {
       ...this.form.values.getValue(),
       [name]: value
     });
-  }
-
-  private handleFileSelection = (e: InputEvent) => {
-    const target = e.target as HTMLInputElement;
-    const name = target.name as DisputeEvidenceDocumentType;
-    const files = target.files as unknown as File[];
-    for (const file of files) {
-      this.documentList.push(new DisputeEvidenceDocument(file, name));
-    }
   }
 
   render() {
@@ -99,7 +88,7 @@ export class ShippingDetails {
             <form-control-file-v2
               label="Shipping Documentation"
               name="shipping_documentation"
-              onChange={this.handleFileSelection}
+              onChange={(e) => fileInputHandler(e as InputEvent, this.documents)}
               errorText={this.documentErrors?.shipping_documentation}
             />
           </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/shipping-details.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/shipping-details.tsx
@@ -10,14 +10,20 @@ import { heading5 } from "../../../styles/parts";
 })
 export class ShippingDetails {
   @Prop() disputeResponse: any;
-  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
+  @State() documentErrors: any = {};
 
   @Method()
   async validateAndSubmit(onSuccess: (formData: any, documentList: DisputeEvidenceDocument[], formStep: DisputeResponseFormStep) => void) {
     this.form.validateAndSubmit((formData) => onSuccess(formData, this.documentList, DisputeResponseFormStep.shippingDetails));
+  };
+
+  @Method()
+  resetDocumentListWithErrors(errors: any) {
+    this.documentErrors = errors;
+    this.documentList = [];
   };
 
   componentWillLoad() {
@@ -94,7 +100,7 @@ export class ShippingDetails {
               label="Shipping Documentation"
               name="shipping_documentation"
               onChange={this.handleFileSelection}
-              errorText={this.documentServerErrors?.shipping_documentation}
+              errorText={this.documentErrors?.shipping_documentation}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/shipping-details.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/shipping-details.tsx
@@ -10,6 +10,7 @@ import { heading5 } from "../../../styles/parts";
 })
 export class ShippingDetails {
   @Prop() disputeResponse: any;
+  @Prop() documentServerErrors: any;
   @State() form: FormController;
   @State() errors: any = {};
   @State() documentList: DisputeEvidenceDocument[] = [];
@@ -93,6 +94,7 @@ export class ShippingDetails {
               label="Shipping Documentation"
               name="shipping_documentation"
               onChange={this.handleFileSelection}
+              errorText={this.documentServerErrors?.shipping_documentation}
             />
           </div>
         </div>

--- a/packages/webcomponents/src/ui-components/form/form-control-file-v2.tsx
+++ b/packages/webcomponents/src/ui-components/form/form-control-file-v2.tsx
@@ -47,6 +47,7 @@ export class FileInput {
             multiple={this.multiple}
             disabled={this.disabled}
             onBlur={() => this.formControlBlur.emit()}
+            onChange={() => this.errorText = ""}
           />
           <FormControlErrorText errorText={this.errorText} name={this.name} />
         </div>

--- a/packages/webcomponents/src/ui-components/form/form-control-file-v2.tsx
+++ b/packages/webcomponents/src/ui-components/form/form-control-file-v2.tsx
@@ -8,6 +8,7 @@ import {
   State,
   Element,
 } from '@stencil/core';
+import { FormControlErrorText } from './form-helpers/form-control-error-text';
 
 @Component({
   tag: 'form-control-file-v2',
@@ -47,7 +48,7 @@ export class FileInput {
             disabled={this.disabled}
             onBlur={() => this.formControlBlur.emit()}
           />
-          <form-control-error-text errorText={this.errorText} name={this.name} />
+          <FormControlErrorText errorText={this.errorText} name={this.name} />
         </div>
       </Host>
     );

--- a/packages/webcomponents/src/ui-components/form/form-helpers/form-control-tooltip/readme.md
+++ b/packages/webcomponents/src/ui-components/form/form-helpers/form-control-tooltip/readme.md
@@ -27,6 +27,7 @@
  - [justifi-business-owners-form-step-core](../../../../components/business-forms/payment-provisioning/business-owners)
  - [justifi-business-representative-form-inputs](../../../../components/business-forms/payment-provisioning/business-representative)
  - [justifi-legal-address-form-step-core](../../../../components/business-forms/payment-provisioning/legal-address-form)
+ - [terminal-quantity-selector](../../../../components/terminal-quantity-selector)
 
 ### Depends on
 
@@ -47,6 +48,7 @@ graph TD;
   justifi-business-owners-form-step-core --> form-control-tooltip
   justifi-business-representative-form-inputs --> form-control-tooltip
   justifi-legal-address-form-step-core --> form-control-tooltip
+  terminal-quantity-selector --> form-control-tooltip
   style form-control-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
- Surface file upload pre-signing issues (such as file types that are not accepted) in the UI
- Change "Service Date" to a date selector
- Fix evidence type name: "cancellation_policy_file" -> "cancellation_policy"
- Fix typos in completion notification messages
- Abstract file handlers for consistent behavior
- Clear out / "replace" file uploads when a new file is selected

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- Pull this branch
- Edit your `.env` file (in the root of the project) to include a fresh dispute ID
- Run it using `npm install` then `pnpm dev:dispute`
- Go through the steps filling out the fields. For files, try making each one fail by selecting an unsupported file type such as `.gif`
- An error should be displayed stating that it is not a supported file type. Select a supported file type such as `.jpg` and the error should clear.
- You should now be able to proceed to the next step. Confirm that the file was uploaded using the Network tab in the dev tools

