### PR TITLE
Fetch Terminal Orders Data in `terminal-orders-list` component and emit events

### DIFF
--- a/apps/component-examples/examples/terminal-orders-list.js
+++ b/apps/component-examples/examples/terminal-orders-list.js
@@ -3,12 +3,11 @@ require('dotenv').config({ path: '../../.env' });
 const express = require('express');
 const app = express();
 const port = process.env.PORT || 3000;
-// const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
-// const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
-// const subAccountId = process.env.SUB_ACCOUNT_ID;
-const businessId = process.env.BUSINESS_ID;
-// const clientId = process.env.CLIENT_ID;
-// const clientSecret = process.env.CLIENT_SECRET;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const subAccountId = process.env.SUB_ACCOUNT_ID;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
 
 app.use(
   '/scripts',
@@ -16,50 +15,52 @@ app.use(
 );
 app.use('/styles', express.static(__dirname + '/../css/'));
 
-// async function getToken() {
-//   const requestBody = JSON.stringify({
-//     client_id: clientId,
-//     client_secret: clientSecret
-//   });
+async function getToken() {
+  const requestBody = JSON.stringify({
+    client_id: clientId,
+    client_secret: clientSecret
+  });
 
-//   let response;
-//   try {
-//     response = await fetch(authTokenEndpoint, {
-//       method: 'POST',
-//       headers: {
-//         'Content-Type': 'application/json',
-//       },
-//       body: requestBody,
-//     });
-//   } catch (error) {
-//     console.log('ERROR:', error);
-//   }
+  let response;
+  try {
+    response = await fetch(authTokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
 
-//   const { access_token } = await response.json();
-//   return access_token;
-// }
+  const { access_token } = await response.json();
+  console.log('Token:', access_token);
+  return access_token;
+}
 
-// async function getWebComponentToken(token) {
-//   const response = await fetch(webComponentTokenEndpoint,
-//     {
-//       method: 'POST',
-//       headers: {
-//         'Content-Type': 'application/json',
-//         Authorization: `Bearer ${token}`,
-//       },
-//       body: JSON.stringify({
-//         resources: [`read:account:${subAccountId}`],
-//       }),
-//     }
-//   );
+async function getWebComponentToken(token) {
+  const response = await fetch(webComponentTokenEndpoint,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        resources: [`write:account:${subAccountId}`],
+      }),
+    }
+  );
 
-//   const { access_token } = await response.json();
-//   return access_token;
-// }
+  const { access_token } = await response.json();
+  console.log('Web Component Token:', access_token);
+  return access_token;
+}
 
 app.get('/', async (req, res) => {
-  // const token = await getToken();
-  // const webComponentToken = await getWebComponentToken(token);
+  const token = await getToken();
+  const webComponentToken = await getWebComponentToken(token);
 
   res.send(`
     <!DOCTYPE html>
@@ -73,8 +74,8 @@ app.get('/', async (req, res) => {
       <body>
         <div class="list-component-wrapper">
           <justifi-terminal-orders-list 
-            business-id="${businessId}"
-            auth-token="authToken123"
+            account-id="${subAccountId}"
+            auth-token="${webComponentToken}"
           />
         </div>
         <script>

--- a/apps/component-examples/examples/terminal-orders-list.js
+++ b/apps/component-examples/examples/terminal-orders-list.js
@@ -77,6 +77,15 @@ app.get('/', async (req, res) => {
           />
         </div>
         <script>
+          const justifiTerminalOrdersList = document.querySelector('justifi-terminal-orders-list');
+
+          justifiTerminalOrdersList.addEventListener('error-event', (event) => {
+            console.log(event);
+          });
+
+          justifiTerminalOrdersList.addEventListener('click-event', (event) => {
+            console.log(event);
+          });
         </script>
       </body>
     </html>

--- a/apps/component-examples/examples/terminal-orders-list.js
+++ b/apps/component-examples/examples/terminal-orders-list.js
@@ -35,7 +35,6 @@ async function getToken() {
   }
 
   const { access_token } = await response.json();
-  console.log('Token:', access_token);
   return access_token;
 }
 
@@ -54,7 +53,6 @@ async function getWebComponentToken(token) {
   );
 
   const { access_token } = await response.json();
-  console.log('Web Component Token:', access_token);
   return access_token;
 }
 

--- a/packages/webcomponents/src/actions/terminal/get-terminal-orders.ts
+++ b/packages/webcomponents/src/actions/terminal/get-terminal-orders.ts
@@ -1,0 +1,39 @@
+import { TerminalOrder } from '../../api';
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
+
+export const makeGetTerminalOrders = 
+  ({ id, authToken, service, apiOrigin }) =>
+  async ({ params, onSuccess, onError, final }) => {
+    try {
+      const response = await service.fetchTerminalOrders(id, authToken, params, apiOrigin);
+
+      if (!response.error) {
+        const pagingInfo = {
+          ...response.page_info,
+        };
+
+        const terminalOrders =
+          response.data?.map((dataItem) => new TerminalOrder(dataItem)) || [];
+
+        onSuccess({ terminalOrders, pagingInfo });
+      } else {
+        const responseError = getErrorMessage(response.error);
+        const code = getErrorCode(response.error?.code);
+        return onError({
+          error: responseError,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
+      }
+    } catch (error) {
+      const code = getErrorCode(error?.code);
+      return onError({
+        error: error.message || error,
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
+    } finally {
+      return final();
+    }
+  };

--- a/packages/webcomponents/src/api/TerminalOrder.ts
+++ b/packages/webcomponents/src/api/TerminalOrder.ts
@@ -7,6 +7,7 @@ enum TerminalOrderType {
 }
 
 export enum TerminalOrderStatus {
+  created = 'created',
   submitted = 'submitted',
   completed = 'completed',
 }

--- a/packages/webcomponents/src/api/services/terminal_orders.service.ts
+++ b/packages/webcomponents/src/api/services/terminal_orders.service.ts
@@ -1,0 +1,25 @@
+import { Api, IApiResponseCollection, ITerminalOrder } from '..';
+
+export interface ITerminalOrderService {
+  fetchTerminalOrders(
+    accountId: string,
+    authToken: string,
+    params: any,
+    apiOrigin?: string
+  ): Promise<IApiResponseCollection<ITerminalOrder[]>>;
+}
+
+export class TerminalOrderService implements ITerminalOrderService {
+  async fetchTerminalOrders(
+    accountId: string,
+    authToken: string,
+    params: any,
+    apiOrigin: string = PROXY_API_ORIGIN
+  ): Promise<IApiResponseCollection<ITerminalOrder[]>> {
+    const headers = { account: accountId };
+
+    const api = Api({ authToken, apiOrigin });
+    const endpoint = 'terminals/orders';
+    return api.get(endpoint, params, null, headers);
+  }
+}

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
@@ -13,7 +13,12 @@ export const MapTerminalOrderStatusToBadge = (status: TerminalOrderStatus) => {
       variant: BadgeVariant.SUCCESS,
       title: 'This order has been completed',
       text: 'Completed',
-    }
+    },
+    created: {
+      variant: BadgeVariant.SECONDARY,
+      title: 'This order is created',
+      text: 'Created',
+    },
   };
 
   const badgeProps = statusToBadgeProps[status];

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
@@ -40,8 +40,20 @@ export class TerminalOrdersListCore {
 
   fetchData(): void {
     this.loading = true;
-    console.log('fetching terminal orders');
-    this.loading = false;
+    
+    this.getTerminalOrders({
+      params: {},
+      onSuccess: async ({ terminalOrders, pagingInfo }) => {
+        this.terminalOrders = terminalOrders;
+        this.paging = pagingInfo;
+        this.terminalOrdersTable.collectionData = this.terminalOrders;
+      },
+      onError: ({ error, code, severity }) => {
+        this.errorMessage = error;
+        this.errorEvent.emit({ error, code, severity });
+      },
+      final: () => { this.loading = false },
+    });
   }
 
   handleClickPrevious = (beforeCursor: string) => {

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
@@ -2,10 +2,11 @@ import { Component, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/
 import { Table } from '../../utils/table';
 import { table, tableCell } from '../../styles/parts';
 import { TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
-import { pagingDefaults, PagingInfo } from '../../api';
+import { ComponentClickEvent, ComponentErrorEvent, pagingDefaults, PagingInfo } from '../../api';
 import { terminalOrdersTableCells, terminalOrdersTableColumns } from './terminal-orders-table';
 import { TerminalOrder } from '../../api';
 import mockTerminalOrders from '../../../../../mockData/mockTerminalOrdersListSuccess.json';
+import { TableClickActions } from '../../ui-components/table/event-types';
 
 @Component({
   tag: 'terminal-orders-list-core',
@@ -29,8 +30,9 @@ export class TerminalOrdersListCore {
     this.fetchData();
   }
 
-  @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<any>;
-
+  @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<ComponentClickEvent>;
+  @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
+  
   componentWillLoad() {
     this.terminalOrdersTable = new Table<TerminalOrder>(this.terminalOrders, this.columns, terminalOrdersTableColumns, terminalOrdersTableCells);
     if (this.getTerminalOrders) {
@@ -50,7 +52,11 @@ export class TerminalOrdersListCore {
       },
       onError: ({ error, code, severity }) => {
         this.errorMessage = error;
-        this.errorEvent.emit({ error, code, severity });
+        this.errorEvent.emit({
+          errorCode: code,
+          message: error,
+          severity,
+        });
       },
       final: () => { this.loading = false },
     });
@@ -58,16 +64,20 @@ export class TerminalOrdersListCore {
 
   handleClickPrevious = (beforeCursor: string) => {
     this.pagingParams = { before_cursor: beforeCursor };
+    this.clickEvent.emit({ name: TableClickActions.previous });
   };
 
   handleClickNext = (afterCursor: string) => {
     this.pagingParams = { after_cursor: afterCursor };
+    this.clickEvent.emit({ name: TableClickActions.next });
   };
 
   rowClickHandler = (e) => {
     const clickedOrderId = e.target.closest('tr').dataset.rowEntityId;
     if (!clickedOrderId) return;
-    console.log('clickedOrderId', clickedOrderId);
+
+    const orderData = this.terminalOrders.find((order) => order.id === clickedOrderId);
+    this.clickEvent.emit({ name: TableClickActions.row, data: orderData });
   };
 
   get entityId() {

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
@@ -5,7 +5,6 @@ import { TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-co
 import { ComponentClickEvent, ComponentErrorEvent, pagingDefaults, PagingInfo } from '../../api';
 import { terminalOrdersTableCells, terminalOrdersTableColumns } from './terminal-orders-table';
 import { TerminalOrder } from '../../api';
-import mockTerminalOrders from '../../../../../mockData/mockTerminalOrdersListSuccess.json';
 import { TableClickActions } from '../../ui-components/table/event-types';
 
 @Component({
@@ -16,7 +15,7 @@ export class TerminalOrdersListCore {
   @Prop() getTerminalOrders: Function;
   @Prop() columns: string;
 
-  @State() terminalOrders: TerminalOrder[] = mockTerminalOrders.data as TerminalOrder[];
+  @State() terminalOrders: TerminalOrder[] = [];
   @State() terminalOrdersTable: Table<TerminalOrder>;
   @State() loading: boolean = true;
   @State() errorMessage: string;

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
@@ -2,6 +2,8 @@ import { Component, h, Prop, State } from '@stencil/core';
 import { StyledHost } from '../../ui-components';
 import { checkPkgVersion } from '../../utils/check-pkg-version';
 import { defaultColumnsKeys } from './terminal-orders-table';
+import { makeGetTerminalOrders } from '../../actions/terminal/get-terminal-orders';
+import { TerminalOrderService } from '../../api/services/terminal_orders.service';
 
 @Component({
   tag: 'justifi-terminal-orders-list',
@@ -12,7 +14,7 @@ export class TerminalOrdersList {
   @State() getTerminalOrders: Function;
   @State() errorMessage: string = null;
 
-  @Prop() businessId: string;
+  @Prop() accountId: string;
   @Prop() authToken: string;
   @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys
@@ -23,10 +25,13 @@ export class TerminalOrdersList {
   }
 
   private initializeGetTerminalOrders() {
-    if (this.businessId && this.authToken) {
-      this.getTerminalOrders = () => {
-        console.log('getTerminalOrders');
-      }
+    if (this.accountId && this.authToken) {
+      this.getTerminalOrders = makeGetTerminalOrders({
+        id: this.accountId,
+        authToken: this.authToken,
+        service: new TerminalOrderService(),
+        apiOrigin: this.apiOrigin
+      });
     } else {
       this.errorMessage = 'Business ID and Auth Token are required';
     }

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
@@ -25,7 +25,6 @@ export class TerminalOrdersList {
 
   analytics: JustifiAnalytics;
 
-  
   componentWillLoad() {
     checkPkgVersion();
     this.analytics = new JustifiAnalytics(this);
@@ -58,7 +57,7 @@ export class TerminalOrdersList {
   render() {
     return (
       <StyledHost>
-        <terminal-orders-list-core 
+        <terminal-orders-list-core
           getTerminalOrders={this.getTerminalOrders}
           onError-event={this.handleErrorEvent}
           columns={this.columns}

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
@@ -1,9 +1,11 @@
-import { Component, h, Prop, State } from '@stencil/core';
+import { Component, h, Prop, State, Event, EventEmitter } from '@stencil/core';
 import { StyledHost } from '../../ui-components';
 import { checkPkgVersion } from '../../utils/check-pkg-version';
 import { defaultColumnsKeys } from './terminal-orders-table';
 import { makeGetTerminalOrders } from '../../actions/terminal/get-terminal-orders';
 import { TerminalOrderService } from '../../api/services/terminal_orders.service';
+import { ComponentErrorCodes, ComponentErrorEvent, ComponentErrorSeverity } from '../../api';
+import JustifiAnalytics from '../../api/Analytics';
 
 @Component({
   tag: 'justifi-terminal-orders-list',
@@ -18,13 +20,19 @@ export class TerminalOrdersList {
   @Prop() authToken: string;
   @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys
+
+  @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
+
+  analytics: JustifiAnalytics;
+
   
   componentWillLoad() {
     checkPkgVersion();
-    this.initializeGetTerminalOrders();
+    this.analytics = new JustifiAnalytics(this);
+    this.initializeGetData();
   }
 
-  private initializeGetTerminalOrders() {
+  private initializeGetData() {
     if (this.accountId && this.authToken) {
       this.getTerminalOrders = makeGetTerminalOrders({
         id: this.accountId,
@@ -33,15 +41,26 @@ export class TerminalOrdersList {
         apiOrigin: this.apiOrigin
       });
     } else {
-      this.errorMessage = 'Business ID and Auth Token are required';
+      this.errorMessage = 'Account ID and Auth Token are required';
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.MISSING_PROPS,
+        message: this.errorMessage,
+        severity: ComponentErrorSeverity.ERROR,
+      });
     }
   }
+
+  handleErrorEvent = (event) => {
+    this.errorMessage = event.detail.message;
+    this.errorEvent.emit(event.detail);
+  };
 
   render() {
     return (
       <StyledHost>
         <terminal-orders-list-core 
-          getTerminalOrders={this.getTerminalOrders} 
+          getTerminalOrders={this.getTerminalOrders}
+          onError-event={this.handleErrorEvent}
           columns={this.columns}
         />
       </StyledHost>


### PR DESCRIPTION
### Fetch Terminal Orders Data in `terminal-orders-list` component

This PR commits the following changes:

- `terminal-orders-list` component requests orders data from `terminals/orders` and displays it in the table
- adds new `TerminalOrderStatus`: `created`
- Edits example file for this component to make real requests for auth token, WCT and load actual data in component.
- Component now emits `click-event` on table row click or pagination button click
- Component now emits `error-event` on fetch error, or props error (no account ID or auth token provided)


Links
-----

Closes #888
Closes #891 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

- [x] Component library builds and runs
- [x] Test suites pass
- [x] `terminal-orders-list` component fetches data with valid account credentials and displays in table
- [x] Component emits error event if valid credentials are not provided
- [x] Component emits click event when clicking on table row.
  - [x] terminal order data is contained in `data` property

