### PR TITLE
`terminal-orders-list` Documentation and Example

### DIFF
--- a/apps/docs/stories/components/TerminalOrdersList/Docs.mdx
+++ b/apps/docs/stories/components/TerminalOrdersList/Docs.mdx
@@ -1,0 +1,75 @@
+import {
+  Meta,
+  Title,
+  Subtitle,
+  Description,
+  ArgTypes,
+  Source,
+} from '@storybook/blocks';
+import { filterDocsByTag, ExportedParts } from '../../utils';
+import { codeExampleFull, codeExampleEventHandling } from './example';
+import {
+  Authorization,
+  ComponentBox,
+} from '../../utils/documentation-components';
+import * as JustifiTerminalOrdersList from './index.stories.tsx';
+import { setUpMocks } from '../../utils/mockAllServices';
+
+{setUpMocks()}
+
+<Meta
+  title="Merchant Tools/Terminal Orders List"
+  Components="justifi-terminal-orders-list"
+  of={JustifiTerminalOrdersList}
+/>
+
+<Title />
+
+---
+
+Component to render a formated list of terminal device orders for the requested account.
+
+# Index
+
+---
+
+- [Props, events and methods](#props-events-and-methods)
+- [Authorization](#authorization)
+- [Events usage](#events-usage)
+- [Example usage](#example-usage)
+
+# Props, events and methods
+
+---
+
+<ArgTypes exclude={['Theme']} />
+
+# Authorization
+
+---
+
+<Authorization
+  actions={['write']}
+  entity="account"
+  identification="account_id"
+/>
+
+# Events usage
+
+---
+
+All table components emit an event when a row is clicked with the necessary information to call the appropriate `Details` component for that entity.
+
+<Source dark language="html" code={codeExampleEventHandling} />
+
+# Example Usage
+
+---
+
+<ComponentBox>
+  <justifi-terminal-orders-list account-id="123" auth-token="123abc" />
+</ComponentBox>
+
+---
+
+<Source dark language="html" code={codeExampleFull} />

--- a/apps/docs/stories/components/TerminalOrdersList/Docs.mdx
+++ b/apps/docs/stories/components/TerminalOrdersList/Docs.mdx
@@ -58,7 +58,30 @@ Component to render a formated list of terminal device orders for the requested 
 
 ---
 
-All table components emit an event when a row is clicked with the necessary information to call the appropriate `Details` component for that entity.
+All table components emit an event when a row is clicked. Below is an example event payload showing the contents of `event.detail`, and a brief code example showing usage in your own implementation. 
+
+```
+{
+  "name": "tableRow",
+  "data": {
+    "id": "tord_ABCD1234",
+    "business_id": "biz_0987",
+    "sub_account_id": "acc_5678",
+    "provider": "verifone",
+    "order_type": "boarding_only",
+    "order_status": "submitted",
+    "terminals": [
+        {
+          "terminal_id": "tmn_QWER",
+          "terminal_did": "11112222",
+          "model_name": "v400"
+        }
+    ],
+    "created_at": "2025-01-02T10:30:00Z",
+    "updated_at": "2025-01-02T10:45:00Z"
+  }
+}
+```
 
 <Source dark language="html" code={codeExampleEventHandling} />
 

--- a/apps/docs/stories/components/TerminalOrdersList/example.ts
+++ b/apps/docs/stories/components/TerminalOrdersList/example.ts
@@ -1,0 +1,74 @@
+import { codeExampleHead } from '../../utils';
+
+export const codeExampleFull = `
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+${codeExampleHead(
+  'justifi-terminal-orders-list',
+  `<style>
+      ::part(font-family) {
+        font-family: georgia;   
+      }
+        
+      ::part(color) {
+        color: darkslategray;
+      }
+
+      ::part(background-color) {
+        background-color: transparent;
+      }
+
+      ::part(background-color) {
+        background-color: transparent;
+      }
+
+      ::part(button) {
+        padding: 0.375rem 0.75rem;
+        font-size: 16px;
+        box-shadow: none;
+        border-radius: 0px;
+        line-height: 1.5;
+        text-transform: none;
+      }
+
+      ::part(button-disabled) {
+        opacity: 0.5;
+      }
+    </style>`
+)}
+
+<body>
+  <!-- Optional: add the filters component -->
+  <justifi-terminals-list-filters></justifi-terminals-list-filters>
+  <justifi-terminals-list></justifi-terminals-list>
+</body>
+
+</html>
+`;
+
+export const codeExampleEventHandling = `
+<justifi-terminal-orders-list />
+
+<script>
+  (function() {
+    const ordersList = document.querySelector('justifi-terminal-orders-list');
+    
+    ordersList.addEventListener('click-event', (event) => {
+      // 'click-event' is emitted when a user clicks on a table row, or clicks on the next or previous page buttons
+      // event.detail.name describes the action that was clicked - it could be 'nextPage', 'previousPage', or 'tableRow'
+      // event.detail.data will be included if the action was 'tableRow', and will contain the data for the row that was clicked
+      
+      if (event.detail.name === 'tableRow') {
+        // Here is where you would handle the click event
+        console.log('data from click-event', event.detail.data);
+      }
+    })
+  
+    ordersList.addEventListener('error-event', (event) => {
+      // here is where you would handle the error
+      console.error('error-event', event.detail);
+    });
+  })();
+</script>
+`;

--- a/apps/docs/stories/components/TerminalOrdersList/example.ts
+++ b/apps/docs/stories/components/TerminalOrdersList/example.ts
@@ -39,9 +39,7 @@ ${codeExampleHead(
 )}
 
 <body>
-  <!-- Optional: add the filters component -->
-  <justifi-terminals-list-filters></justifi-terminals-list-filters>
-  <justifi-terminals-list></justifi-terminals-list>
+  <justifi-terminal-orders-list></justifi-terminal-orders-list>
 </body>
 
 </html>

--- a/apps/docs/stories/components/TerminalOrdersList/index.stories.tsx
+++ b/apps/docs/stories/components/TerminalOrdersList/index.stories.tsx
@@ -1,0 +1,75 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { withActions } from "@storybook/addon-actions/decorator";
+import { StoryBaseArgs, customStoryDecorator } from "../../utils";
+import { ThemeNames } from "../../themes";
+
+import "@justifi/webcomponents/dist/module/justifi-terminal-orders-list";
+
+type Story = StoryObj;
+
+const storyBaseArgs = new StoryBaseArgs(["account-id", "auth-token"]);
+
+const meta: Meta = {
+  title: "Merchant Tools/Terminal Orders List",
+  component: "justifi-terminal-orders-list",
+  args: {
+    ...storyBaseArgs.args,
+    Theme: ThemeNames.Light
+  },
+  argTypes: {
+    ...storyBaseArgs.argTypes,
+    Theme: {
+      description:
+        "Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling)",
+      options: Object.values(ThemeNames),
+      control: {
+        type: "select",
+      },
+    },
+    "click-event": {
+      description:
+        "Emitted when controls or table rows are clicked.  Control name is defined in `event.detail.name`.",
+      table: {
+        category: "events",
+      },
+      action: true
+    },
+    "error-event": {
+      description: "`ComponentError` - emitted when a network error occurs in the component.",
+      table: {
+        category: "events",
+      },
+      action: true
+    },
+    "columns": {
+      description: "Columns to display in the table <br> Pass a comma separated list of columns to display in the table.",
+      type: "string",
+      table: {
+        category: "props",
+        defaultValue: {
+          summary: "created_at,updated_at,order_status,quantity",
+          detail: "The following values are available to pass to the columns prop as a comma separated string: `created_at`, `updated_at`, `order_status` and `quantity`"
+        }
+      },
+      control: {
+        type: "text",
+      },
+    }
+  },
+  parameters: {
+    actions: {
+      handles: ["click-event", "error-event"],
+    },
+    chromatic: {
+      delay: 2000,
+    },
+  },
+  decorators: [
+    customStoryDecorator,
+    withActions
+  ]
+};
+
+export const Example: Story = {};
+
+export default meta;

--- a/apps/docs/stories/components/TerminalOrdersList/index.stories.tsx
+++ b/apps/docs/stories/components/TerminalOrdersList/index.stories.tsx
@@ -4,6 +4,7 @@ import { StoryBaseArgs, customStoryDecorator } from "../../utils";
 import { ThemeNames } from "../../themes";
 
 import "@justifi/webcomponents/dist/module/justifi-terminal-orders-list";
+import "@justifi/webcomponents/dist/module/justifi-terminal-orders-list-filters";
 
 type Story = StoryObj;
 
@@ -71,5 +72,18 @@ const meta: Meta = {
 };
 
 export const Example: Story = {};
+
+export const ExampleWithFilters: Story = {
+  args: {},
+  render: (args) => `
+  <div>
+    <justifi-terminal-orders-list-filters></justifi-terminal-orders-list-filters>
+    <justifi-terminal-orders-list
+      account-id="${args["account-id"]}"
+      auth-token="${args["auth-token"]}"
+    ></justifi-terminal-orders-list>
+  </div>
+  `
+};
 
 export default meta;

--- a/apps/docs/stories/utils/mockAllServices.ts
+++ b/apps/docs/stories/utils/mockAllServices.ts
@@ -15,6 +15,7 @@ import mockPayout from '../../../../mockData/mockPayoutDetailsSuccess.json';
 import mockPayouts from '../../../../mockData/mockPayoutsSuccess.json';
 import mockSeasonInterruptionInsurance from '../../../../mockData/mockSeasonInterruptionInsurance.json';
 import mockTerminals from '../../../../mockData/mockTerminalsListSuccess.json';
+import mockTerminalOrders from '../../../../mockData/mockTerminalOrdersListSuccess.json';
 import mockSubAccounts from '../../../../mockData/mockSubAccountsListSuccess.json';
 import mockDispute from '../../../../mockData/mockDisputeResponse.json';
 import mockNPMVersion from '../../../../mockData/mockNPMVersion.json';
@@ -62,6 +63,7 @@ export const API_PATHS = {
   PAYOUTS_LIST: '/account/:id/payouts',
   INSURANCE_QUOTES: '/insurance/quotes',
   TERMINALS_LIST: 'terminals',
+  TERMINAL_ORDERS_LIST: 'terminals/orders',
   SUB_ACCOUNTS_LIST: 'sub_accounts',
   PKG_VERSION: '/@justifi/webcomponents/latest',
   DISPUTE: '/disputes/:id',
@@ -140,6 +142,9 @@ export const setUpMocks = () => {
 
       // TerminalsList
       this.get(API_PATHS.TERMINALS_LIST, () => mockTerminals);
+
+      // TerminalOrdersList
+      this.get(API_PATHS.TERMINAL_ORDERS_LIST, () => mockTerminalOrders);
 
       // SubAccountsList
       this.get(API_PATHS.SUB_ACCOUNTS_LIST, () => mockSubAccounts);

--- a/mockData/mockTerminalOrdersListSuccess.json
+++ b/mockData/mockTerminalOrdersListSuccess.json
@@ -12,7 +12,7 @@
     {
       "id": "tord_ABCD1234",
       "business_id": "biz_0987",
-      "account_id": "acc_5678",
+      "sub_account_id": "acc_5678",
       "provider": "verifone",
       "order_type": "boarding_only",
       "order_status": "submitted",
@@ -29,7 +29,7 @@
     {
       "id": "tord_WXYZ5678",
       "business_id": "biz_1234",
-      "account_id": "acc_4321",
+      "sub_account_id": "acc_4321",
       "provider": "verifone",
       "order_type": "boarding_shipping",
       "order_status": "completed",
@@ -46,7 +46,7 @@
     {
       "id": "tord_DEF55468789",
       "business_id": "biz_5678",
-      "account_id": "acc_7890",
+      "sub_account_id": "acc_7890",
       "provider": "verifone",
       "order_type": "boarding_shipping",
       "order_status": "created",
@@ -63,7 +63,7 @@
     {
       "id": "tord_GHI22168225",
       "business_id": "biz_7777",
-      "account_id": "acc_6666",
+      "sub_account_id": "acc_6666",
       "provider": "verifone",
       "order_type": "boarding_only",
       "order_status": "completed",

--- a/mockData/mockTerminalOrdersListSuccess.json
+++ b/mockData/mockTerminalOrdersListSuccess.json
@@ -6,89 +6,76 @@
     "has_next": false,
     "start_cursor": "mockCursorPage1",
     "end_cursor": "mockCursorPage2",
-    "amount": 2
+    "amount": 4
   },
   "data": [
     {
-      "id": null,
-      "type": "array",
-      "page_info": {
-        "has_previous": false,
-        "has_next": false,
-        "start_cursor": "mockCursorPage1",
-        "end_cursor": "mockCursorPage2",
-        "amount": 4
-      },
-      "data": [
+      "id": "tord_ABCD1234",
+      "business_id": "biz_0987",
+      "account_id": "acc_5678",
+      "provider": "verifone",
+      "order_type": "boarding_only",
+      "order_status": "submitted",
+      "terminals": [
         {
-          "id": "tord_ABCD1234",
-          "business_id": "biz_0987",
-          "account_id": "acc_5678",
-          "provider": "verifone",
-          "order_type": "boarding_only",
-          "order_status": "submitted",
-          "terminals": [
-            {
-              "terminal_id": "tmn_QWER",
-              "terminal_did": "11112222",
-              "model_name": "v400"
-            }
-          ],
-          "created_at": "2025-01-02T10:30:00Z",
-          "updated_at": "2025-01-02T10:45:00Z"
-        },
-        {
-          "id": "tord_WXYZ5678",
-          "business_id": "biz_1234",
-          "account_id": "acc_4321",
-          "provider": "verifone",
-          "order_type": "boarding_shipping",
-          "order_status": "completed",
-          "terminals": [
-            {
-              "terminal_id": "tmn_ASDF",
-              "terminal_did": "33334444",
-              "model_name": "e355"
-            }
-          ],
-          "created_at": "2025-02-10T09:20:00Z",
-          "updated_at": "2025-02-10T09:25:00Z"
-        },
-        {
-          "id": "tord_DEF55468789",
-          "business_id": "biz_5678",
-          "account_id": "acc_7890",
-          "provider": "verifone",
-          "order_type": "boarding_shipping",
-          "order_status": "created",
-          "terminals": [
-            {
-              "terminal_id": "tmn_TT99",
-              "terminal_did": "99887766",
-              "model_name": "v400"
-            }
-          ],
-          "created_at": "2025-03-11T17:00:00Z",
-          "updated_at": "2025-03-11T17:05:00Z"
-        },
-        {
-          "id": "tord_GHI22168225",
-          "business_id": "biz_7777",
-          "account_id": "acc_6666",
-          "provider": "verifone",
-          "order_type": "boarding_only",
-          "order_status": "completed",
-          "terminals": [
-            {
-              "terminal_id": "tmn_XXYY",
-              "terminal_did": "55667788",
-              "model_name": "e355"
-            }
-          ],
-          "created_at": "2025-04-05T11:50:00Z",
-          "updated_at": "2025-04-05T12:10:00Z"
+          "terminal_id": "tmn_QWER",
+          "terminal_did": "11112222",
+          "model_name": "v400"
         }
-      ]
+      ],
+      "created_at": "2025-01-02T10:30:00Z",
+      "updated_at": "2025-01-02T10:45:00Z"
+    },
+    {
+      "id": "tord_WXYZ5678",
+      "business_id": "biz_1234",
+      "account_id": "acc_4321",
+      "provider": "verifone",
+      "order_type": "boarding_shipping",
+      "order_status": "completed",
+      "terminals": [
+        {
+          "terminal_id": "tmn_ASDF",
+          "terminal_did": "33334444",
+          "model_name": "e355"
+        }
+      ],
+      "created_at": "2025-02-10T09:20:00Z",
+      "updated_at": "2025-02-10T09:25:00Z"
+    },
+    {
+      "id": "tord_DEF55468789",
+      "business_id": "biz_5678",
+      "account_id": "acc_7890",
+      "provider": "verifone",
+      "order_type": "boarding_shipping",
+      "order_status": "created",
+      "terminals": [
+        {
+          "terminal_id": "tmn_TT99",
+          "terminal_did": "99887766",
+          "model_name": "v400"
+        }
+      ],
+      "created_at": "2025-03-11T17:00:00Z",
+      "updated_at": "2025-03-11T17:05:00Z"
+    },
+    {
+      "id": "tord_GHI22168225",
+      "business_id": "biz_7777",
+      "account_id": "acc_6666",
+      "provider": "verifone",
+      "order_type": "boarding_only",
+      "order_status": "completed",
+      "terminals": [
+        {
+          "terminal_id": "tmn_XXYY",
+          "terminal_did": "55667788",
+          "model_name": "e355"
+        }
+      ],
+      "created_at": "2025-04-05T11:50:00Z",
+      "updated_at": "2025-04-05T12:10:00Z"
     }
   ]
 }

--- a/mockData/mockTerminalOrdersListSuccess.json
+++ b/mockData/mockTerminalOrdersListSuccess.json
@@ -10,38 +10,85 @@
   },
   "data": [
     {
-      "id": "tord_ABCD1234",
-      "business_id": "biz_0987",
-      "account_id": "acc_5678",
-      "provider": "verifone",
-      "order_type": "boarding_only",
-      "order_status": "submitted",
-      "terminals": [
+      "id": null,
+      "type": "array",
+      "page_info": {
+        "has_previous": false,
+        "has_next": false,
+        "start_cursor": "mockCursorPage1",
+        "end_cursor": "mockCursorPage2",
+        "amount": 4
+      },
+      "data": [
         {
-          "terminal_id": "tmn_QWER",
-          "terminal_did": "11112222",
-          "model_name": "v400"
-        }
-      ],
-      "created_at": "2025-01-02T10:30:00Z",
-      "updated_at": "2025-01-02T10:45:00Z"
-    },
-    {
-      "id": "tord_WXYZ5678",
-      "business_id": "biz_1234",
-      "account_id": "acc_4321",
-      "provider": "verifone",
-      "order_type": "boarding_shipping",
-      "order_status": "completed",
-      "terminals": [
+          "id": "tord_ABCD1234",
+          "business_id": "biz_0987",
+          "account_id": "acc_5678",
+          "provider": "verifone",
+          "order_type": "boarding_only",
+          "order_status": "submitted",
+          "terminals": [
+            {
+              "terminal_id": "tmn_QWER",
+              "terminal_did": "11112222",
+              "model_name": "v400"
+            }
+          ],
+          "created_at": "2025-01-02T10:30:00Z",
+          "updated_at": "2025-01-02T10:45:00Z"
+        },
         {
-          "terminal_id": "tmn_ASDF",
-          "terminal_did": "33334444",
-          "model_name": "e355"
+          "id": "tord_WXYZ5678",
+          "business_id": "biz_1234",
+          "account_id": "acc_4321",
+          "provider": "verifone",
+          "order_type": "boarding_shipping",
+          "order_status": "completed",
+          "terminals": [
+            {
+              "terminal_id": "tmn_ASDF",
+              "terminal_did": "33334444",
+              "model_name": "e355"
+            }
+          ],
+          "created_at": "2025-02-10T09:20:00Z",
+          "updated_at": "2025-02-10T09:25:00Z"
+        },
+        {
+          "id": "tord_DEF55468789",
+          "business_id": "biz_5678",
+          "account_id": "acc_7890",
+          "provider": "verifone",
+          "order_type": "boarding_shipping",
+          "order_status": "created",
+          "terminals": [
+            {
+              "terminal_id": "tmn_TT99",
+              "terminal_did": "99887766",
+              "model_name": "v400"
+            }
+          ],
+          "created_at": "2025-03-11T17:00:00Z",
+          "updated_at": "2025-03-11T17:05:00Z"
+        },
+        {
+          "id": "tord_GHI22168225",
+          "business_id": "biz_7777",
+          "account_id": "acc_6666",
+          "provider": "verifone",
+          "order_type": "boarding_only",
+          "order_status": "completed",
+          "terminals": [
+            {
+              "terminal_id": "tmn_XXYY",
+              "terminal_did": "55667788",
+              "model_name": "e355"
+            }
+          ],
+          "created_at": "2025-04-05T11:50:00Z",
+          "updated_at": "2025-04-05T12:10:00Z"
         }
-      ],
-      "created_at": "2025-02-10T09:20:00Z",
-      "updated_at": "2025-02-10T09:25:00Z"
+      ]
     }
   ]
 }

--- a/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
@@ -140,6 +140,58 @@ exports[`terminal-orders-list-core renders properly with fetched data 1`] = `
               1
             </td>
           </tr>
+          <tr data-row-entity-id="tord_DEF55468789" data-test-id="table-row">
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Mar 11, 2025
+              </div>
+              <div class="fw-bold">
+                5:00pm
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Mar 11, 2025
+              </div>
+              <div class="fw-bold">
+                5:05pm
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <span class="badge bg-secondary" part="badge font-family badge-secondary" title="This order is created">
+                Created
+              </span>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              1
+            </td>
+          </tr>
+          <tr data-row-entity-id="tord_GHI22168225" data-test-id="table-row">
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Apr 5, 2025
+              </div>
+              <div class="fw-bold">
+                11:50am
+              </div>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Apr 5, 2025
+              </div>
+              <div class="fw-bold">
+                12:10pm
+              </div>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <span class="badge bg-success" part="badge font-family badge-success" title="This order has been completed">
+                Completed
+              </span>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              1
+            </td>
+          </tr>
         </tbody>
         <tfoot class="sticky-bottom">
           <tr class="align-middle table-light">

--- a/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-core.spec.tsx
@@ -36,7 +36,7 @@ describe('terminal-orders-list-core', () => {
 
     await page.waitForChanges();
 
-    expect(page.rootInstance.terminalOrders[0]).toEqual(expect.objectContaining({ account_id: mockOrdersResponse.data[0].account_id }));
+    expect(page.rootInstance.terminalOrders[0]).toEqual(expect.objectContaining({ sub_account_id: mockOrdersResponse.data[0].sub_account_id }));
     const rows = page.root.querySelectorAll('[data-test-id="table-row"]');
     expect(rows.length).toBe(mockOrdersResponse.data.length);
     expect(mockTerminalsService.fetchTerminalOrders).toHaveBeenCalled();


### PR DESCRIPTION
### `terminal-orders-list` Documentation and Example

This PR commits the following:

- Adds page to Storybook showing documentation and example for `terminal-orders-list`

Links
-----

Closes #893 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [ ] Component example loads properly with mock data in storybook example
- [ ] Component documentation is in line with other list / table components, explains props, shows example with event listener usage

