### PR TITLE
Add `terminal-orders-list-filters` component

### DIFF
--- a/apps/component-examples/examples/terminal-orders-list-with-filters.js
+++ b/apps/component-examples/examples/terminal-orders-list-with-filters.js
@@ -1,0 +1,102 @@
+require('dotenv').config({ path: '../../.env' });
+
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const subAccountId = process.env.SUB_ACCOUNT_ID;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
+
+app.use(
+  '/scripts',
+  express.static(__dirname + '/../node_modules/@justifi/webcomponents/dist/')
+);
+app.use('/styles', express.static(__dirname + '/../css/'));
+
+async function getToken() {
+  const requestBody = JSON.stringify({
+    client_id: clientId,
+    client_secret: clientSecret
+  });
+
+  let response;
+  try {
+    response = await fetch(authTokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
+
+  const { access_token } = await response.json();
+  return access_token;
+}
+
+async function getWebComponentToken(token) {
+  const response = await fetch(webComponentTokenEndpoint,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        resources: [`write:account:${subAccountId}`],
+      }),
+    }
+  );
+
+  const { access_token } = await response.json();
+  return access_token;
+}
+
+app.get('/', async (req, res) => {
+  const token = await getToken();
+  const webComponentToken = await getWebComponentToken(token);
+
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>JustiFi Terminal Orders List Component</title>
+        <script type="module" src="/scripts/webcomponents/webcomponents.esm.js"></script>
+        <link rel="stylesheet" href="/styles/theme.css">
+        <link rel="stylesheet" href="/styles/example.css">
+      </head>
+      <body>
+        <div class="list-component-wrapper">
+        <div>
+          <justifi-terminal-orders-list-filters />
+        </div>
+        <div>
+          <justifi-terminal-orders-list 
+            account-id="${subAccountId}"
+            auth-token="${webComponentToken}"
+          />
+        </div>
+        </div>
+        <script>
+          const justifiTerminalOrdersList = document.querySelector('justifi-terminal-orders-list');
+
+          justifiTerminalOrdersList.addEventListener('error-event', (event) => {
+            console.log(event);
+          });
+
+          justifiTerminalOrdersList.addEventListener('click-event', (event) => {
+            console.log(event);
+          });
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -21,7 +21,8 @@
     "start:payouts-list": "npx nodemon ./examples/payouts-list.js",
     "start:payouts-list-with-filters": "npx nodemon ./examples/payouts-list-with-filters.js",
     "start:order-terminals": "npx nodemon ./examples/order-terminals.js",
-    "start:terminal-orders-list": "npx nodemon ./examples/terminal-orders-list.js"
+    "start:terminal-orders-list": "npx nodemon ./examples/terminal-orders-list.js",
+    "start:terminal-orders-list-with-filters": "npx nodemon ./examples/terminal-orders-list-with-filters.js"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dev:payouts-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payouts-list-with-filters'",
     "dev:order-terminals": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:order-terminals'",
     "dev:terminal-orders-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:terminal-orders-list'",
+    "dev:terminal-orders-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:terminal-orders-list-with-filters'",
     "preview-storybook": "turbo run preview-storybook",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/packages/webcomponents/src/api/TerminalOrder.ts
+++ b/packages/webcomponents/src/api/TerminalOrder.ts
@@ -1,7 +1,12 @@
 import { TerminalProviders } from './Terminal';
 import { TerminalModelName } from './TerminalModel';
 
-enum TerminalOrderType {
+export interface TerminalOrderQueryParams {
+  order_status?: TerminalOrderStatus;
+  order_type?: TerminalOrderType;
+}
+
+export enum TerminalOrderType {
   boardingOnly = 'boarding_only',
   boardingShipping = 'boarding_shipping',
 }

--- a/packages/webcomponents/src/api/TerminalOrder.ts
+++ b/packages/webcomponents/src/api/TerminalOrder.ts
@@ -4,6 +4,8 @@ import { TerminalModelName } from './TerminalModel';
 export interface TerminalOrderQueryParams {
   order_status?: TerminalOrderStatus;
   order_type?: TerminalOrderType;
+  created_after?: string;
+  created_before?: string;
 }
 
 export enum TerminalOrderType {

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-core.tsx
@@ -6,6 +6,7 @@ import { ComponentClickEvent, ComponentErrorEvent, pagingDefaults, PagingInfo } 
 import { terminalOrdersTableCells, terminalOrdersTableColumns } from './terminal-orders-table';
 import { TerminalOrder } from '../../api';
 import { TableClickActions } from '../../ui-components/table/event-types';
+import { getRequestParams, onQueryParamsChange } from './terminal-orders-list-params-state';
 
 @Component({
   tag: 'terminal-orders-list-core',
@@ -37,13 +38,22 @@ export class TerminalOrdersListCore {
     if (this.getTerminalOrders) {
       this.fetchData();
     }
+
+    onQueryParamsChange('set', () => {
+      this.pagingParams = {};
+    });
+
+    onQueryParamsChange('reset', () => {
+      this.pagingParams = {};
+      this.errorMessage = '';
+    });
   }
 
   fetchData(): void {
     this.loading = true;
     
     this.getTerminalOrders({
-      params: {},
+      params: this.terminalOrderParams,
       onSuccess: async ({ terminalOrders, pagingInfo }) => {
         this.terminalOrders = terminalOrders;
         this.paging = pagingInfo;
@@ -78,6 +88,12 @@ export class TerminalOrdersListCore {
     const orderData = this.terminalOrders.find((order) => order.id === clickedOrderId);
     this.clickEvent.emit({ name: TableClickActions.row, data: orderData });
   };
+
+  get terminalOrderParams() {
+    const requestParams = getRequestParams();
+    const params = { ...requestParams, ...this.pagingParams };
+    return params;
+  }
 
   get entityId() {
     return this.terminalOrders.map((terminalOrder) => terminalOrder.id);

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
@@ -1,0 +1,82 @@
+import { Component, h, Prop } from '@stencil/core';
+import { filterParams, propsParams, clearParams } from './terminal-orders-list-params-state';
+import { StyledHost } from '../../ui-components';
+import { TerminalOrderStatus, TerminalOrderType } from '../../api';
+
+@Component({
+  tag: 'justifi-terminal-orders-list-filters',
+  shadow: true
+})
+export class TerminalOrdersListFilters {
+  @Prop() orderStatus?: TerminalOrderStatus;
+  @Prop() orderType?: TerminalOrderType;
+
+  componentWillLoad() {
+    const propsToSet = {
+      status: this.orderStatus,
+      type: this.orderType,
+    };
+
+    Object.entries(propsToSet).forEach(([key, value]) => {
+      if (value) {
+        propsParams[key] = value;
+      }
+    });
+  }
+
+  setParamsOnChange = (name: string, value: string) => {
+    filterParams[name] = value;
+  };
+
+  get terminalOrderStatusOptions(): { label: string, value: TerminalOrderStatus | '' }[] {
+    return [
+      { label: 'All', value: '' },
+      { label: 'Created', value: TerminalOrderStatus.created },
+      { label: 'Completed', value: TerminalOrderStatus.completed },
+      { label: 'Submitted', value: TerminalOrderStatus.submitted },
+    ]
+  }
+
+  get terminalOrderTypeOptions(): { label: string, value: TerminalOrderType | '' }[] {
+    return [
+      { label: 'All', value: '' },
+      { label: 'Boarding Only', value: TerminalOrderType.boardingOnly },
+      { label: 'Boarding Shipping', value: TerminalOrderType.boardingShipping },
+    ]
+  }
+
+  render() {
+    const filterMenuParams = { ...filterParams }
+
+    return (
+      <StyledHost>
+        <table-filters-menu params={filterMenuParams} clearParams={clearParams}>
+          <div class="grid-cols-2 gap-3 p-1">
+            <div class="p-2">
+              <form-control-select
+                name="status"
+                label="Status"
+                options={this.terminalOrderStatusOptions}
+                inputHandler={this.setParamsOnChange}
+                defaultValue={this.orderStatus || filterParams.order_status}
+                disabled={!!this.orderStatus}
+
+              />
+            </div>
+            <div class="p-2">
+              <form-control-select
+                name="type"
+                label="Type"
+                options={this.terminalOrderTypeOptions}
+                inputHandler={this.setParamsOnChange}
+                defaultValue={this.orderType || filterParams.order_type}
+                disabled={!!this.orderType}
+
+              />
+            </div>
+          </div>
+        </table-filters-menu>
+      </StyledHost>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
@@ -2,6 +2,11 @@ import { Component, h, Prop } from '@stencil/core';
 import { filterParams, propsParams, clearParams } from './terminal-orders-list-params-state';
 import { StyledHost } from '../../ui-components';
 import { TerminalOrderStatus, TerminalOrderType } from '../../api';
+import {
+  terminalOrdersListFilterMenu,
+  orderStatusTerminalOrdersListFilterParam,
+  orderTypeTerminalOrdersListFilterParam
+} from '../../styles/parts';
 
 @Component({
   tag: 'justifi-terminal-orders-list-filters',
@@ -50,7 +55,7 @@ export class TerminalOrdersListFilters {
 
     return (
       <StyledHost>
-        <table-filters-menu params={filterMenuParams} clearParams={clearParams}>
+        <table-filters-menu params={filterMenuParams} clearParams={clearParams} part={terminalOrdersListFilterMenu}>
           <div class="grid-cols-2 gap-3 p-1">
             <div class="p-2">
               <form-control-select
@@ -60,7 +65,7 @@ export class TerminalOrdersListFilters {
                 inputHandler={this.setParamsOnChange}
                 defaultValue={this.orderStatus || filterParams.order_status}
                 disabled={!!this.orderStatus}
-
+                part={orderStatusTerminalOrdersListFilterParam}
               />
             </div>
             <div class="p-2">
@@ -71,7 +76,7 @@ export class TerminalOrdersListFilters {
                 inputHandler={this.setParamsOnChange}
                 defaultValue={this.orderType || filterParams.order_type}
                 disabled={!!this.orderType}
-
+                part={orderTypeTerminalOrdersListFilterParam}
               />
             </div>
           </div>

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
@@ -13,8 +13,8 @@ export class TerminalOrdersListFilters {
 
   componentWillLoad() {
     const propsToSet = {
-      status: this.orderStatus,
-      type: this.orderType,
+      order_status: this.orderStatus,
+      order_type: this.orderType,
     };
 
     Object.entries(propsToSet).forEach(([key, value]) => {
@@ -54,8 +54,8 @@ export class TerminalOrdersListFilters {
           <div class="grid-cols-2 gap-3 p-1">
             <div class="p-2">
               <form-control-select
-                name="status"
-                label="Status"
+                name="order_status"
+                label="Order Status"
                 options={this.terminalOrderStatusOptions}
                 inputHandler={this.setParamsOnChange}
                 defaultValue={this.orderStatus || filterParams.order_status}
@@ -65,8 +65,8 @@ export class TerminalOrdersListFilters {
             </div>
             <div class="p-2">
               <form-control-select
-                name="type"
-                label="Type"
+                name="order_type"
+                label="Order Type"
                 options={this.terminalOrderTypeOptions}
                 inputHandler={this.setParamsOnChange}
                 defaultValue={this.orderType || filterParams.order_type}

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
@@ -2,10 +2,13 @@ import { Component, h, Prop } from '@stencil/core';
 import { filterParams, propsParams, clearParams } from './terminal-orders-list-params-state';
 import { StyledHost } from '../../ui-components';
 import { TerminalOrderStatus, TerminalOrderType } from '../../api';
+import { convertToLocal, convertToUTC } from '../../utils/utils';
 import {
   terminalOrdersListFilterMenu,
   orderStatusTerminalOrdersListFilterParam,
-  orderTypeTerminalOrdersListFilterParam
+  orderTypeTerminalOrdersListFilterParam,
+  createdAfterTerminalOrdersListFilterParam,
+  createdBeforeTerminalOrdersListFilterParam
 } from '../../styles/parts';
 
 @Component({
@@ -15,11 +18,15 @@ import {
 export class TerminalOrdersListFilters {
   @Prop() orderStatus?: TerminalOrderStatus;
   @Prop() orderType?: TerminalOrderType;
+  @Prop() createdAfter?: string;
+  @Prop() createdBefore?: string;
 
   componentWillLoad() {
     const propsToSet = {
       order_status: this.orderStatus,
       order_type: this.orderType,
+      created_after: this.createdAfter,
+      created_before: this.createdBefore
     };
 
     Object.entries(propsToSet).forEach(([key, value]) => {
@@ -32,6 +39,11 @@ export class TerminalOrdersListFilters {
   setParamsOnChange = (name: string, value: string) => {
     filterParams[name] = value;
   };
+
+  handleDateInput = (name: string, value: string) => {
+    const utcDate = convertToUTC(value, { setExactTime: true });
+    this.setParamsOnChange(name, utcDate);
+  }
 
   get terminalOrderStatusOptions(): { label: string, value: TerminalOrderStatus | '' }[] {
     return [
@@ -77,6 +89,34 @@ export class TerminalOrdersListFilters {
                 defaultValue={this.orderType || filterParams.order_type}
                 disabled={!!this.orderType}
                 part={orderTypeTerminalOrdersListFilterParam}
+              />
+            </div>
+            <div class="p-2">
+              <form-control-date
+                name="created_after"
+                label="Created After"
+                inputHandler={this.handleDateInput}
+                defaultValue={
+                  convertToLocal(this.createdAfter, { showInputDateTime: true }) ||
+                  convertToLocal(filterParams.created_after, { showInputDateTime: true })
+                }
+                showTime
+                disabled={!!this.createdAfter}
+                part={createdAfterTerminalOrdersListFilterParam}
+              />
+            </div>
+            <div class="p-2">
+              <form-control-date
+                name="created_before"
+                label="Created Before"
+                inputHandler={this.handleDateInput}
+                defaultValue={
+                  convertToLocal(this.createdBefore, { showInputDateTime: true }) ||
+                  convertToLocal(filterParams.created_before, { showInputDateTime: true })
+                }
+                showTime
+                disabled={!!this.createdBefore}
+                part={createdBeforeTerminalOrdersListFilterParam}
               />
             </div>
           </div>

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-params-state.ts
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-params-state.ts
@@ -1,0 +1,30 @@
+import { createStore } from '@stencil/store';
+import { TerminalOrderQueryParams } from '../../api';
+
+const filterParamsInitialState = {};
+const propsParamsInitialState = {};
+
+const filterParamsStore = createStore<TerminalOrderQueryParams>(() => filterParamsInitialState);
+const { state: filterParams, on: onQueryParamsChange } = filterParamsStore;
+
+const propsParamsStore = createStore<TerminalOrderQueryParams>(() => propsParamsInitialState);
+const { state: propsParams } = propsParamsStore;
+
+const getRequestParams = (): TerminalOrderQueryParams => {
+  return {
+    ...filterParams,
+    ...propsParams
+  };
+};
+
+const clearParams = () => {
+  filterParamsStore.reset();
+}
+
+export {
+  filterParams,
+  propsParams,
+  onQueryParamsChange,
+  clearParams,
+  getRequestParams
+};

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -142,3 +142,5 @@ export const terminalOrdersListFilterMenu = `${filterMenu} terminal-orders-list-
 export const terminalOrdersListFilterParam = `terminal-orders-list-filter-param`;
 export const orderStatusTerminalOrdersListFilterParam = `${terminalOrdersListFilterParam} order-status-terminal-orders-list-filter-param`;
 export const orderTypeTerminalOrdersListFilterParam = `${terminalOrdersListFilterParam} order-type-terminal-orders-list-filter-param`;
+export const createdAfterTerminalOrdersListFilterParam = `${terminalOrdersListFilterParam} created-after-terminal-orders-list-filter-param`;
+export const createdBeforeTerminalOrdersListFilterParam = `${terminalOrdersListFilterParam} created-before-terminal-orders-list-filter-param`;

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -136,3 +136,9 @@ export const terminalsListFilterMenu = `${filterMenu} terminals-list-filter-menu
 export const terminalsListFilterParam = `terminals-list-filter-param`;
 export const terminalIdTerminalsListFilterParam = `${terminalsListFilterParam} terminal-id-terminals-list-filter-param`;
 export const terminalStatusTerminalsListFilterParam = `${terminalsListFilterParam} terminal-status-terminals-list-filter-param`;
+
+// Terminal Orders List Filters
+export const terminalOrdersListFilterMenu = `${filterMenu} terminal-orders-list-filter-menu`;
+export const terminalOrdersListFilterParam = `terminal-orders-list-filter-param`;
+export const orderStatusTerminalOrdersListFilterParam = `${terminalOrdersListFilterParam} order-status-terminal-orders-list-filter-param`;
+export const orderTypeTerminalOrdersListFilterParam = `${terminalOrdersListFilterParam} order-type-terminal-orders-list-filter-param`;

--- a/packages/webcomponents/src/ui-components/filters/readme.md
+++ b/packages/webcomponents/src/ui-components/filters/readme.md
@@ -20,6 +20,7 @@
  - [justifi-checkouts-list-filters](../../components/checkouts-list)
  - [justifi-payments-list-filters](../../components/payments-list)
  - [justifi-payouts-list-filters](../../components/payouts-list)
+ - [justifi-terminal-orders-list-filters](../../components/terminal-orders-list)
  - [justifi-terminals-list-filters](../../components/terminals-list)
 
 ### Depends on
@@ -33,6 +34,7 @@ graph TD;
   justifi-checkouts-list-filters --> table-filters-menu
   justifi-payments-list-filters --> table-filters-menu
   justifi-payouts-list-filters --> table-filters-menu
+  justifi-terminal-orders-list-filters --> table-filters-menu
   justifi-terminals-list-filters --> table-filters-menu
   style table-filters-menu fill:#f9f,stroke:#333,stroke-width:4px
 ```


### PR DESCRIPTION
### Add `terminal-orders-list-filters` component

This PR commits the following changes:

- Adds `terminal-orders-list-filters` component which can be optionally rendered alongside `terminal-orders-list` to filter via status or order type
  - includes CSS parts for the menu and its corresponding inputs
  - query params can be passed to the filter menu as props
- Adds new example file rendering the list and the filters together: `pnpm dev:terminal-orders-list-with-filters`


Links
-----

Closes #890 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

To test, please run `pnpm dev:terminal-orders-list-with-filters`


- [x] Component library builds and runs normally
- [x] test suites pass
- [x] Filter menu can be used to apply `order_status` filter / param
- [x] Filter menu can be used to apply `order_type` filter / param
- [x] Filter menu can be used to apply `created_before` filter / param
- [x] Filter menu can be used to apply `created_after` filter / param
- [x] Filter inputs work in conjunction with each other - IE multiple filters can be successfully applied


Passing in props to filter component:
- [x] Passing in props to `terminal-orders-list-filters` applies corresponding query param to component's API request
- [x] Passing in props to `terminal-orders-list-filters` disables corresponding input in filter menu UI
- [x] Other filter UI inputs can be used in conjunction with params passed as prop. 
- [x] Clear filters button should NOT render until user manually interacts with filters UI, IE you won't see the Clear Filters button just for passing in a param as a prop
- [x] Clear filters clears out filters that were applied by the UI, but retains the ones set by props. 
- [x] CSS parts can be used to successfully hide the menu, or any corresponding inputs

