### PR TITLE
`terminal-orders-list` Unit Tests

### DIFF
--- a/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
@@ -1,0 +1,180 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`terminal-orders-list-core displays an error state on failed data fetch 1`] = `
+<terminal-orders-list-core>
+  <div>
+    <div class="table-wrapper">
+      <table class="table table-hover" part="table text color font-family background-color">
+        <thead class="sticky-top table-head">
+          <tr class="table-light text-nowrap">
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The date and time the order was created">
+              Created At
+            </th>
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The date and time the order was last updated">
+              Updated At
+            </th>
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The current status of the order">
+              Order Status
+            </th>
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The number of terminals associated with the order">
+              Order Quantity
+            </th>
+          </tr>
+        </thead>
+        <tbody class="table-body">
+          <tr>
+            <td class="error-state" colspan="4" data-test-id="table-error-state" part="table-error text color font-family background-color" style="text-align: center;">
+              An unexpected error occurred: Fetch error
+            </td>
+          </tr>
+        </tbody>
+        <tfoot class="sticky-bottom">
+          <tr class="align-middle table-light">
+            <td colspan="4" part="table-cell text color font-family background-color">
+              <pagination-menu>
+                <nav aria-label="Table pagination" class="d-flex gap-3 justify-content-end">
+                  <ul class="m-0 pagination">
+                    <li class="disabled page-item">
+                      <a class="page-link" href="#" part="button-disabled button text color font-family">
+                        <span class="me-1">
+                          «
+                        </span>
+                        <span>
+                          Previous
+                        </span>
+                      </a>
+                    </li>
+                    <li class="disabled page-item">
+                      <a class="page-link" href="#" part="button-disabled button text color font-family">
+                        <span>
+                          Next
+                        </span>
+                        <span class="ms-1">
+                          »
+                        </span>
+                      </a>
+                    </li>
+                  </ul>
+                </nav>
+              </pagination-menu>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+</terminal-orders-list-core>
+`;
+
+exports[`terminal-orders-list-core renders properly with fetched data 1`] = `
+<terminal-orders-list-core>
+  <div>
+    <div class="table-wrapper">
+      <table class="table table-hover" part="table text color font-family background-color">
+        <thead class="sticky-top table-head">
+          <tr class="table-light text-nowrap">
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The date and time the order was created">
+              Created At
+            </th>
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The date and time the order was last updated">
+              Updated At
+            </th>
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The current status of the order">
+              Order Status
+            </th>
+            <th part="table-head-cell table-cell text color font-family background-color text color font-family background-color" scope="col" title="The number of terminals associated with the order">
+              Order Quantity
+            </th>
+          </tr>
+        </thead>
+        <tbody class="table-body">
+          <tr data-row-entity-id="tord_ABCD1234" data-test-id="table-row">
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Jan 2, 2025
+              </div>
+              <div class="fw-bold">
+                10:30am
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Jan 2, 2025
+              </div>
+              <div class="fw-bold">
+                10:45am
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <span class="badge bg-primary" part="badge font-family badge-primary" title="This order is submitted">
+                Submitted
+              </span>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              1
+            </td>
+          </tr>
+          <tr data-row-entity-id="tord_WXYZ5678" data-test-id="table-row">
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Feb 10, 2025
+              </div>
+              <div class="fw-bold">
+                9:20am
+              </div>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Feb 10, 2025
+              </div>
+              <div class="fw-bold">
+                9:25am
+              </div>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <span class="badge bg-success" part="badge font-family badge-success" title="This order has been completed">
+                Completed
+              </span>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              1
+            </td>
+          </tr>
+        </tbody>
+        <tfoot class="sticky-bottom">
+          <tr class="align-middle table-light">
+            <td colspan="4" part="table-cell text color font-family background-color">
+              <pagination-menu>
+                <nav aria-label="Table pagination" class="d-flex gap-3 justify-content-end">
+                  <ul class="m-0 pagination">
+                    <li class="disabled page-item">
+                      <a class="page-link" href="#" part="button-disabled button text color font-family">
+                        <span class="me-1">
+                          «
+                        </span>
+                        <span>
+                          Previous
+                        </span>
+                      </a>
+                    </li>
+                    <li class="disabled page-item">
+                      <a class="page-link" href="#" part="button-disabled button text color font-family">
+                        <span>
+                          Next
+                        </span>
+                        <span class="ms-1">
+                          »
+                        </span>
+                      </a>
+                    </li>
+                  </ul>
+                </nav>
+              </pagination-menu>
+            </td>
+          </tr>
+        </tfoot>
+      </table>
+    </div>
+  </div>
+</terminal-orders-list-core>
+`;

--- a/packages/webcomponents/src/components/terminal-orders-list/test/get-terminal-orders.spec.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/get-terminal-orders.spec.tsx
@@ -1,0 +1,105 @@
+import { TerminalOrderService } from '../../../api/services/terminal_orders.service';
+import { makeGetTerminalOrders } from '../../../actions/terminal/get-terminal-orders';
+import mockResponse from '../../../../../../mockData/mockTerminalOrdersListSuccess.json';
+import { IApiResponseCollection, ITerminalOrder, TerminalOrder } from '../../../api';
+
+// Mock the TerminalOrderService class
+jest.mock('../../../api/services/terminal_orders.service');
+
+describe('makeGetTerminalOrders', () => {
+  const mockId = '123';
+  const mockAuthToken = 'fake_token_789';
+  const mockParams = { limit: 10, page: 1 };
+  const mockApiOrigin = 'http://localhost:3000';
+
+  const onSuccess = jest.fn();
+  const onError = jest.fn();
+  const final = jest.fn();
+
+  let mockServiceInstance: jest.Mocked<TerminalOrderService>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Create a new instance of the mocked TerminalOrderService
+    mockServiceInstance = new TerminalOrderService() as jest.Mocked<TerminalOrderService>;
+
+    // Explicitly mock fetchTerminalOrders as a jest mock function
+    mockServiceInstance.fetchTerminalOrders = jest.fn();
+  });
+
+  it('should call onSuccess with terminals and pagingInfo on successful fetch', async () => {
+    
+    // Mock fetchTerminalOrders to resolve with mockResponse
+    mockServiceInstance.fetchTerminalOrders.mockResolvedValue(
+      mockResponse as IApiResponseCollection<ITerminalOrder[]>
+    );
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: mockId,
+      authToken: mockAuthToken,
+      service: mockServiceInstance,
+      apiOrigin: mockApiOrigin
+    });
+    await getTerminalOrders({ params: mockParams, onSuccess, onError, final });
+
+    expect(onSuccess).toHaveBeenCalledWith({
+      terminalOrders: expect.arrayContaining([
+        expect.any(TerminalOrder),
+        expect.any(TerminalOrder),
+      ]),
+      pagingInfo: mockResponse.page_info,
+    });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('should call onError with an error message on API failure', async () => {
+    const mockError = new Error('Error fetching terminals');
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    // Mock fetchTerminalOrders to reject with mockError
+    mockServiceInstance.fetchTerminalOrders.mockRejectedValue(mockError);
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: mockId,
+      authToken: mockAuthToken,
+      service: mockServiceInstance,
+      apiOrigin: mockApiOrigin
+    });
+    await getTerminalOrders({ params: mockParams, onSuccess, onError, final });
+
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Error fetching terminals',
+      severity: 'error',
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should call onError with an exception message on fetch exception', async () => {
+    const mockError = new Error('Network error');
+    const onSuccess = jest.fn();
+    const onError = jest.fn();
+
+    // Mock fetchTerminalOrders to reject with mockError
+    mockServiceInstance.fetchTerminalOrders.mockRejectedValue(mockError);
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: mockId,
+      authToken: mockAuthToken,
+      service: mockServiceInstance,
+      apiOrigin: mockApiOrigin
+    });
+    await getTerminalOrders({ params: mockParams, onSuccess, onError, final });
+
+    expect(onError).toHaveBeenCalledWith({
+      code: 'fetch-error',
+      error: 'Network error',
+      severity: 'error',
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // Add more tests as needed for edge cases and different scenarios
+});

--- a/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-core.spec.tsx
@@ -1,0 +1,161 @@
+jest.mock('../../../ui-components/styled-host/styled-host.css', () => '');
+
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+import { TerminalOrdersListCore } from '../terminal-orders-list-core';
+import { PaginationMenu } from '../../pagination-menu/pagination-menu';
+import mockSuccessResponse from '../../../../../../mockData/mockTerminalOrdersListSuccess.json';
+import { IApiResponseCollection, ITerminalOrder } from '../../../api';
+import { makeGetTerminalOrders } from '../../../actions/terminal/get-terminal-orders';
+import { TerminalOrdersListFilters } from '../terminal-orders-list-filters';
+import { TableFiltersMenu } from '../../../ui-components/filters/table-filters-menu';
+import { SelectInput } from '../../../ui-components/form/form-control-select';
+import { defaultColumnsKeys } from '../terminal-orders-table';
+
+const mockOrdersResponse = mockSuccessResponse as IApiResponseCollection<ITerminalOrder[]>;
+const components = [TerminalOrdersListCore, PaginationMenu, TableFiltersMenu, TerminalOrdersListFilters, SelectInput];
+
+describe('terminal-orders-list-core', () => {
+
+  it('renders properly with fetched data', async () => {
+    const mockTerminalsService = {
+      fetchTerminalOrders: jest.fn().mockResolvedValue(mockOrdersResponse),
+    };
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: '123',
+      authToken: '123',
+      service: mockTerminalsService,
+      apiOrigin: 'http://localhost:3000'
+    });
+
+    const page = await newSpecPage({
+      components: components,
+      template: () => <terminal-orders-list-core getTerminalOrders={getTerminalOrders} columns={defaultColumnsKeys} />,
+    });
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.terminalOrders[0]).toEqual(expect.objectContaining({ account_id: mockOrdersResponse.data[0].account_id }));
+    const rows = page.root.querySelectorAll('[data-test-id="table-row"]');
+    expect(rows.length).toBe(mockOrdersResponse.data.length);
+    expect(mockTerminalsService.fetchTerminalOrders).toHaveBeenCalled();
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('displays an error state on failed data fetch', async () => {
+    const mockService = {
+      fetchTerminalOrders: jest.fn().mockRejectedValue(new Error('Fetch error'))
+    };
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: 'some-id',
+      authToken: 'some-auth-token',
+      service: mockService,
+      apiOrigin: 'http://localhost:3000'
+    });
+
+    const page = await newSpecPage({
+      components: components,
+      template: () => <terminal-orders-list-core getTerminalOrders={getTerminalOrders} columns={defaultColumnsKeys} />,
+    });
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.errorMessage).toBe('Fetch error');
+    expect(page.root).toMatchSnapshot();
+  });
+
+  it('emits click-event event on row click', async () => {
+    const mockTerminalsService = {
+      fetchTerminalOrders: jest.fn().mockResolvedValue(mockOrdersResponse),
+    };
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: '123',
+      authToken: '123',
+      service: mockTerminalsService,
+      apiOrigin: 'http://localhost:3000'
+    });
+
+    const page = await newSpecPage({
+      components: components,
+      template: () => <terminal-orders-list-core getTerminalOrders={getTerminalOrders} columns={defaultColumnsKeys} />,
+    });
+
+    await page.waitForChanges();
+
+    const firstRow = page.root.querySelector('[data-test-id="table-row"]') as HTMLElement;
+    expect(firstRow).not.toBeNull();
+
+    const spyEvent = jest.fn();
+    page.win.addEventListener('click-event', spyEvent);
+
+    firstRow.click();
+    expect(spyEvent).toHaveBeenCalled();
+  });
+
+  it('emits error event on fetch error', async () => {
+    const mockService = {
+      fetchTerminalOrders: jest.fn().mockRejectedValue(new Error('Fetch error'))
+    };
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: 'some-id',
+      authToken: 'some-auth',
+      service: mockService,
+      apiOrigin: 'http://localhost:3000'
+    });
+
+    const errorEvent = jest.fn();
+
+    const page = await newSpecPage({
+      components: components,
+      template: () => <terminal-orders-list-core getTerminalOrders={getTerminalOrders} columns={defaultColumnsKeys} onError-event={errorEvent} />,
+    });
+
+    await page.waitForChanges();
+
+    expect(errorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          errorCode: 'fetch-error',
+          message: 'Fetch error',
+          severity: 'error',
+        }
+      })
+    );
+  });
+});
+
+describe('terminal-orders-list-core pagination', () => {
+
+  it('updates params and refetches data on pagination interaction', async () => {
+    const mockTerminalsService = {
+      fetchTerminalOrders: jest.fn().mockResolvedValue(mockOrdersResponse),
+    };
+
+    const getTerminalOrders = makeGetTerminalOrders({
+      id: '123',
+      authToken: '123',
+      service: mockTerminalsService,
+      apiOrigin: 'http://localhost:3000'
+    });
+
+    const page = await newSpecPage({
+      components: components,
+      template: () => <terminal-orders-list-core getTerminalOrders={getTerminalOrders} columns={defaultColumnsKeys} />,
+    });
+
+    await page.waitForChanges();
+
+    // Assuming handleClickNext is accessible and modifies `params` which triggers a re-fetch
+    page.rootInstance.handleClickNext('nextCursor');
+    await page.waitForChanges();
+
+    // The mock function should be called 2 times: once for the initial load and later after the pagination interaction
+    expect(mockTerminalsService.fetchTerminalOrders).toHaveBeenCalledTimes(2);
+    const updatedParams = page.rootInstance.pagingParams;
+    expect(updatedParams.after_cursor).toBe('nextCursor');
+  });
+});

--- a/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-with-filters.spec.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-with-filters.spec.tsx
@@ -1,0 +1,145 @@
+jest.mock('../../../ui-components/styled-host/styled-host.css', () => '');
+
+import { h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+import { TerminalOrdersList } from '../terminal-orders-list';
+import { defaultColumnsKeys } from '../terminal-orders-table';
+import { TableFiltersMenu } from '../../../ui-components/filters/table-filters-menu';
+import { TerminalOrdersListFilters } from '../terminal-orders-list-filters';
+import { SelectInput } from '../../../ui-components/form/form-control-select';
+import { filterParams } from '../terminal-orders-list-params-state';
+import { TerminalOrdersListCore } from '../terminal-orders-list-core';
+
+const components = [TerminalOrdersList, TerminalOrdersListCore, TableFiltersMenu, TerminalOrdersListFilters, SelectInput];
+
+describe('justifi-terminal-orders-list with filters', () => {
+  const fetchDataSpy = jest.spyOn(TerminalOrdersListCore.prototype, 'fetchData');
+  let page;
+
+  afterEach(() => {
+    page = null;
+    jest.resetAllMocks();
+  });
+
+  it('shows table filter menu on filter button click', async () => {
+
+    page = await newSpecPage({
+      components: components,
+      autoApplyChanges: true,
+      flushQueue: true,
+      template: () => 
+      <div>
+        <justifi-terminal-orders-list-filters />
+        <justifi-terminal-orders-list 
+          account-id="abc"
+          auth-token="abc" 
+          columns={defaultColumnsKeys} 
+        />,
+      </div>
+    });
+
+    const filterButton = page.root.shadowRoot.querySelector('[data-test-id="open-filters-button"]') as HTMLElement;
+    expect(filterButton).not.toBeNull();
+
+    filterButton.click();
+
+    const filterMenu = page.root.shadowRoot.querySelector('[data-test-id="filter-menu"]') as HTMLElement;
+    expect(filterMenu).not.toBeNull();
+  });
+
+  it('updates params and refetches data on filter interaction', async () => {
+
+    page = await newSpecPage({
+      components: components,
+      autoApplyChanges: true,
+      template: () => 
+      <div>
+        <justifi-terminal-orders-list-filters />
+        <justifi-terminal-orders-list 
+          account-id="abc"
+          auth-token="abc" 
+          columns={defaultColumnsKeys}
+        />,
+      </div>
+    });
+
+    expect(fetchDataSpy).toHaveBeenCalled();
+
+    const filterButton = page.root.shadowRoot.querySelector('[data-test-id="open-filters-button"]') as HTMLElement;
+    filterButton.click();
+
+    const filterMenu = page.root.shadowRoot.querySelector('[data-test-id="filter-menu"]') as HTMLElement;
+    expect(filterMenu).not.toBeNull();
+
+    const selectFilter = filterMenu.querySelector('form-control-select') as HTMLFormControlSelectElement;
+    expect(selectFilter).not.toBeNull();
+
+    const selectFilterInput = selectFilter.querySelector('select') as HTMLSelectElement;
+    expect(selectFilterInput).not.toBeNull();
+
+    selectFilterInput.click();
+    
+    const selectOptions = selectFilterInput.querySelectorAll('option');
+    expect(selectOptions).not.toBeNull();
+    
+    const succeededOption = selectOptions[3] as HTMLOptionElement;
+    succeededOption.click();
+    selectFilterInput.value = 'completed';
+    selectFilterInput.dispatchEvent(new Event('input'));
+
+    expect(fetchDataSpy).toHaveBeenCalled();
+    const updatedParams = filterParams;
+    expect(updatedParams).toEqual({"order_status": "completed"});
+  });
+
+  it('clears filters and refetches data on clear filters interaction', async () => {
+
+    page = await newSpecPage({
+      components: components,
+      autoApplyChanges: true,
+      flushQueue: true,
+      template: () => 
+      <div>
+        <justifi-terminal-orders-list-filters />
+        <justifi-terminal-orders-list 
+          account-id="abc"
+          auth-token="abc" 
+          columns={defaultColumnsKeys} 
+        />,
+      </div>
+    });
+
+    expect(fetchDataSpy).toHaveBeenCalled();
+
+    const filterButton = page.root.shadowRoot.querySelector('[data-test-id="open-filters-button"]') as HTMLElement;
+    filterButton.click();
+
+    const filterMenu = page.root.shadowRoot.querySelector('[data-test-id="filter-menu"]') as HTMLElement;
+    expect(filterMenu).not.toBeNull();
+
+    const selectFilter = page.root.shadowRoot.querySelector('form-control-select') as HTMLFormControlSelectElement;
+    expect(selectFilter).not.toBeNull();
+
+    const selectFilterInput = selectFilter.querySelector('select') as HTMLSelectElement;
+    expect(selectFilterInput).not.toBeNull();
+
+    selectFilterInput.click();
+    
+    const selectOptions = selectFilterInput.querySelectorAll('option');
+    expect(selectOptions).not.toBeNull();
+    
+    const succeededOption = selectOptions[3] as HTMLOptionElement;
+    succeededOption.click();
+    selectFilterInput.value = 'succeeded';
+    selectFilterInput.dispatchEvent(new Event('input'));
+
+    const clearButton = page.root.shadowRoot.querySelector('[data-test-id="clear-filters-button"]') as HTMLElement;
+    expect(clearButton).not.toBeNull();
+
+    clearButton.click();
+
+    expect(fetchDataSpy).toHaveBeenCalled();
+    const updatedParams = page.rootInstance.params;
+    expect(updatedParams).toEqual(undefined);
+  });
+});

--- a/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list.spec.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list.spec.tsx
@@ -1,0 +1,52 @@
+import { h } from "@stencil/core";
+import { newSpecPage } from "@stencil/core/testing";
+import { TerminalOrdersList } from "../terminal-orders-list";
+import { TerminalOrdersListCore } from "../terminal-orders-list-core";
+import { TerminalOrderService } from '../../../api/services/terminal_orders.service';
+import JustifiAnalytics from "../../../api/Analytics";
+jest.mock('../../../api/services/terminal_orders.service');
+
+beforeEach(() => {
+  // Bypass Analytics to avoid errors. Analytics attaches events listeners to HTML elements
+  // which are not available in Jest/node environment
+  // @ts-ignore
+  JustifiAnalytics.prototype.trackCustomEvents = jest.fn();
+});
+
+describe('terminals-list', () => {
+  it('emit an error event when accountId and authToken are not provided', async () => {
+    const errorEvent = jest.fn();
+    const page = await newSpecPage({
+      components: [TerminalOrdersList, TerminalOrdersListCore],
+      template: () => <justifi-terminal-orders-list onError-event={errorEvent} />,
+    });
+    await page.waitForChanges();
+    expect(errorEvent).toHaveBeenCalled();
+  });
+
+  it('emit an error event when fetch fails', async () => {
+    TerminalOrderService.prototype.fetchTerminalOrders = jest.fn().mockRejectedValue(new Error('Fetch error'));
+
+    const errorEvent = jest.fn();
+    const page = await newSpecPage({
+      components: [TerminalOrdersList, TerminalOrdersListCore],
+      template: () => (
+        <justifi-terminal-orders-list
+          account-id="abc"
+          auth-token="abc"
+          onError-event={errorEvent}
+        />
+      ),
+    });
+    await page.waitForChanges();
+    expect(errorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          errorCode: 'fetch-error',
+          message: 'Fetch error',
+          severity: 'error',
+        }
+      })
+    );
+  });
+});


### PR DESCRIPTION
### terminal-orders-list Unit Tests

This PR commits the following:

- Adds unit test coverage for terminal-orders-list and filters

Links
-----

Closes #935 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

- [x] Component library builds and runs as expected
- [x] test suites pass

