### PR TITLE
Add headers support to API requests and rename account_id to sub_account_id in TerminalOrder

### DIFF
--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -77,9 +77,17 @@ const Api = ({ authToken, apiOrigin }: IApiProps) => {
     endpoint: string,
     body?: any,
     params?: any,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    headers?: HeadersInit
   ) {
-    return makeRequest(endpoint, 'POST', params, JSON.stringify(body), signal);
+    return makeRequest(
+      endpoint,
+      'POST',
+      params,
+      JSON.stringify(body),
+      signal,
+      headers
+    );
   }
 
   async function put(endpoint: string, body?: any, params?: any, signal?: AbortSignal) {

--- a/packages/webcomponents/src/api/TerminalOrder.ts
+++ b/packages/webcomponents/src/api/TerminalOrder.ts
@@ -28,7 +28,7 @@ interface TerminalOrderItem {
 export interface ITerminalOrder {
   id?: string;
   business_id?: string;
-  account_id?: string;
+  sub_account_id?: string;
   provider?: TerminalProviders;
   order_type?: TerminalOrderType;
   order_status?: TerminalOrderStatus;
@@ -40,7 +40,7 @@ export interface ITerminalOrder {
 export class TerminalOrder {
   public id: string;
   public business_id: string;
-  public account_id: string;
+  public sub_account_id: string;
   public provider: TerminalProviders;
   public order_type: TerminalOrderType;
   public order_status: TerminalOrderStatus;
@@ -52,7 +52,7 @@ export class TerminalOrder {
   constructor(data: ITerminalOrder) {
     this.id = data.id;
     this.business_id = data.business_id;
-    this.account_id = data.account_id;
+    this.sub_account_id = data.sub_account_id;
     this.provider = data.provider || TerminalProviders.verifone;
     this.order_items = [];
     this.order_type = data.order_type;
@@ -65,7 +65,7 @@ export class TerminalOrder {
   public get payload() {
     return {
       business_id: this.business_id,
-      account_id: this.account_id,
+      sub_account_id: this.sub_account_id,
       order_type: this.order_type,
       order_items: this.order_items,
     };

--- a/packages/webcomponents/src/api/services/terminal.service.ts
+++ b/packages/webcomponents/src/api/services/terminal.service.ts
@@ -65,8 +65,9 @@ export class TerminalService implements ITerminalService {
     terminalOrder: any,
     apiOrigin: string = API_ORIGIN
   ): Promise<IApiResponse<ITerminal>> {
+    const headers = { 'sub-account': terminalOrder.sub_account_id };
     const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals/orders';
-    return api.post(endpoint, terminalOrder);
+    return api.post(endpoint, terminalOrder, null, null, headers);
   }
 }

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -49,7 +49,7 @@ export class OrderTerminals {
   componentWillLoad() {
     this.order = new TerminalOrder({
       business_id: this.businessId,
-      account_id: this.accountId,
+      sub_account_id: this.accountId,
       order_type: this.shipping ? TerminalOrderType.boardingShipping : TerminalOrderType.boardingOnly,
     });
     checkPkgVersion();


### PR DESCRIPTION
This PR commits the following: 

- Rename `account_id` to `sub_account_id` on the Order Terminals payload post request to match recent API changes.
- Refactor the API.post method to accept an additional `headers` argument.
- Send `sub-account` header in the Order Terminal post request to address an authorization issue. 

Links
-----
#937 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

Setup: Run `pnpm dev:order-terminals`.

- [x] - It should build and tests should pass.
- [x] - Orders can be successful created.
