### PR TITLE
Update analytics tracking to exclude staging environment

### DIFF
--- a/.changeset/lovely-pets-dream.md
+++ b/.changeset/lovely-pets-dream.md
@@ -1,5 +1,0 @@
----
-"@justifi/webcomponents": patch
----
-
-Prevent Analytics data to be tracked from staging environments

--- a/.changeset/lovely-pets-dream.md
+++ b/.changeset/lovely-pets-dream.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Prevent Analytics data to be tracked from staging environments

--- a/packages/webcomponents/src/api/Analytics.ts
+++ b/packages/webcomponents/src/api/Analytics.ts
@@ -25,10 +25,11 @@ class JustifiAnalytics {
   basicData: iBasicData;
 
   constructor(component: ComponentInterface) {
-    // dont track analytics in local or storybook
+    // dont track analytics in local, storybook or staging
     if (
       window.location.origin.includes('localhost') ||
-      window.location.origin.includes('storybook')
+      window.location.origin.includes('storybook') ||
+      window.location.origin.includes('staging')
     ) {
       return;
     }


### PR DESCRIPTION
Prevent Analytics data to be tracked from staging environment.


Links
-----
#939 


Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

This can be only tested after published and updated the version used in the dashboard, no Analytics call should happen.
