### PR TITLE
Add new optional columns for `justifi-terminals-list`

### DIFF
--- a/.changeset/witty-coins-grow.md
+++ b/.changeset/witty-coins-grow.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Added new optional columns to render in `justifi-terminals-list`: `id`, `model_name`, and `provider`.

--- a/apps/component-examples/examples/terminals-list.js
+++ b/apps/component-examples/examples/terminals-list.js
@@ -74,6 +74,7 @@ app.get('/', async (req, res) => {
           <justifi-terminals-list 
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"
+            columns="nickname,provider,provider_serial_number,model_name,id,status"
           />
         </div>
         <script>

--- a/apps/component-examples/examples/terminals-list.js
+++ b/apps/component-examples/examples/terminals-list.js
@@ -74,7 +74,6 @@ app.get('/', async (req, res) => {
           <justifi-terminals-list 
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"
-            columns="nickname,provider,provider_serial_number,model_name,id,status"
           />
         </div>
         <script>

--- a/packages/webcomponents/src/api/Terminal.ts
+++ b/packages/webcomponents/src/api/Terminal.ts
@@ -1,3 +1,4 @@
+import { TerminalModelName } from "./TerminalModel";
 
 export interface TerminalsQueryParams {
   terminal_id?: string;
@@ -16,13 +17,14 @@ export interface ITerminal {
   account_id?: string | null;
   platform_account_id?: string | null;
   gateway_ref_id?: string | null;
-  provider?: string | null;
+  provider?: TerminalProviders | null;
   provider_id?: string | null;
   provider_serial_number?: string | null;
   created_at?: string | null;
   updated_at?: string | null;
   verified_at?: string | null;
   nickname?: string | null;
+  model_name?: TerminalModelName | null;
 }
 
 export enum TerminalProviders {
@@ -34,7 +36,7 @@ export class Terminal implements ITerminal {
   public status: ITerminalStatus;
   public account_id: string;
   public platform_account_id: string;
-  public provider: string;
+  public provider: TerminalProviders;
   public provider_id: string;
   public provider_serial_number: string;
   public created_at: string;
@@ -42,18 +44,20 @@ export class Terminal implements ITerminal {
   public verified_at: string;
   public nickname: string;
   public sub_account_name: string;
+  public model_name: TerminalModelName;
 
   constructor(data: ITerminal) {
     this.id = data.id || '';
     this.status = data.status;
     this.account_id = data.account_id || '';
     this.platform_account_id = data.platform_account_id || '';
-    this.provider = data.provider || '';
+    this.provider = data.provider || null;
     this.provider_id = data.provider_id || '';
     this.provider_serial_number = data.provider_serial_number || '';
     this.created_at = data.created_at || '';
     this.updated_at = data.updated_at || '';
     this.verified_at = data.verified_at || '';
     this.nickname = data.nickname || '';
+    this.model_name = data.model_name || null;
   }
 };

--- a/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
@@ -2,6 +2,7 @@ import { h } from '@stencil/core';
 import { MapTerminalStatusToBadge } from './terminals-status';
 import { getAlternateTableCellPart, tableHeadCell } from '../../styles/parts';
 import { Terminal } from '../../api/Terminal';
+import { capitalFirstLetter } from '../../utils/utils';
 
 export const defaultColumnsKeys = 'nickname,provider_serial_number,status';
 
@@ -9,6 +10,21 @@ export const terminalTableColumns = {
   nickname: () => (
     <th part={tableHeadCell} scope="col" title="The nickname associated with the terminal">
       Nickname
+    </th>
+  ),
+  model_name: () => (
+    <th part={tableHeadCell} scope="col" title="The model name of the terminal">
+      Model Name
+    </th>
+  ),
+  id: () => (
+    <th part={tableHeadCell} scope="col" title="The ID of the terminal">
+      ID
+    </th>
+  ),
+  provider: () => (
+    <th part={tableHeadCell} scope="col" title="The provider of the terminal">
+      Provider
     </th>
   ),
   provider_serial_number: () => (
@@ -36,6 +52,15 @@ export const terminalTableColumns = {
 export const terminalTableCells = {
   nickname: (terminal: Terminal, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminal.nickname}</td>
+  ),
+  model_name: (terminal: Terminal, index: number) => (
+    <td part={getAlternateTableCellPart(index)}>{terminal.model_name}</td>
+  ),
+  id: (terminal: Terminal, index: number) => (
+    <td part={getAlternateTableCellPart(index)}>{terminal.id}</td>
+  ),
+  provider: (terminal: Terminal, index: number) => (
+    <td part={getAlternateTableCellPart(index)}>{capitalFirstLetter(terminal.provider)}</td>
   ),
   provider_serial_number: (terminal: Terminal, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminal.provider_serial_number}</td>

--- a/packages/webcomponents/src/utils/utils.ts
+++ b/packages/webcomponents/src/utils/utils.ts
@@ -143,6 +143,11 @@ export function formatAddress(address: Address): string {
 
 // String Manipulation
 
+export function capitalFirstLetter(str: string): string {
+  if (!str) return '';
+  return str.charAt(0).toUpperCase() + str.slice(1);
+};
+
 export function snakeCaseToHumanReadable(snakeCaseStr: string): string {
   if (!snakeCaseStr) return '';
   return snakeCaseStr


### PR DESCRIPTION
### Add new optional columns for `justifi-terminals-list`

This PR commits the following:

- Uses `TerminalModels` enum in `Terminal` class and captures new property `model_name` in class instantiation
- Uses `TerminalProviders` enum in `Terminal` class for `provider` property
- Adds new optional columns to `terminals-list`: 
  - `model_name` - shows `model_name` property in new column
  - `id` shows `id` property in new column
  - `provider` shows `provider` property in new column


Links
-----

Closes #954 

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] Component library builds and runs normally
- [x] Test suites pass
- [x] New column `model_name` can be enabled using the `columns` prop
- [x] New column `id` can be enabled using the `columns` prop
- [x] New column `provider` can be enabled using the `columns` prop

