### PR TITLE
Add apiOrigin parameter to business and terminal service methods

### DIFF
--- a/packages/webcomponents/src/actions/business/get-business.ts
+++ b/packages/webcomponents/src/actions/business/get-business.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetBusiness =
-  ({ id, authToken, service }) =>
+  ({ id, authToken, service, apiOrigin = PROXY_API_ORIGIN }) =>
   async ({ onSuccess, onError }) => {
     try {
-      const response = await service.fetchBusiness(id, authToken);
+      const response = await service.fetchBusiness(id, authToken, apiOrigin);
 
       if (!response.error) {
         onSuccess({ business: new Business(response.data) });

--- a/packages/webcomponents/src/actions/terminal/get-terminal-models.ts
+++ b/packages/webcomponents/src/actions/terminal/get-terminal-models.ts
@@ -2,10 +2,14 @@ import { ComponentErrorSeverity, TerminalModel } from '../../api';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetTerminalModels =
-  ({ id, authToken, service }) =>
+  ({ id, authToken, service, apiOrigin }) =>
   async ({ onSuccess, onError }) => {
     try {
-      const response = await service.fetchTerminalModels(id, authToken);
+      const response = await service.fetchTerminalModels(
+        id,
+        authToken,
+        apiOrigin
+      );
 
       if (!response.error) {
         const terminals =

--- a/packages/webcomponents/src/actions/terminal/order-terminals.ts
+++ b/packages/webcomponents/src/actions/terminal/order-terminals.ts
@@ -2,10 +2,14 @@ import { ComponentErrorSeverity } from '../../api';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeOrderTerminals =
-  ({ authToken, service }) =>
+  ({ authToken, service, apiOrigin = PROXY_API_ORIGIN }) =>
   async ({ terminalOrder, onSuccess, onError }) => {
     try {
-      const response = await service.orderTerminals(authToken, terminalOrder);
+      const response = await service.orderTerminals(
+        authToken,
+        terminalOrder,
+        apiOrigin
+      );
 
       if (!response.error) {
         const { data } = response;

--- a/packages/webcomponents/src/api/services/business.service.ts
+++ b/packages/webcomponents/src/api/services/business.service.ts
@@ -19,10 +19,11 @@ export interface IBusinessService {
 export class BusinessService implements IBusinessService {
   async fetchBusiness(
     businessId: string,
-    authToken: string
+    authToken: string,
+    apiOrigin: string = PROXY_API_ORIGIN
   ): Promise<IApiResponse<IBusiness>> {
     const endpoint = `entities/business/${businessId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get(endpoint);
+    return Api({ authToken, apiOrigin }).get(endpoint);
   }
 
   async patchBusiness(

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -25,6 +25,7 @@ export class OrderTerminals {
   @Prop() authToken: string;
   @Prop() accountId: string;
   @Prop() shipping: boolean = false;
+  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
 
   @State() loading = {
     business: true,
@@ -77,6 +78,7 @@ export class OrderTerminals {
       id: this.businessId,
       authToken: this.authToken,
       service: new BusinessService(),
+      apiOrigin: this.apiOrigin,
     })({
       onSuccess: ({ business }) => {
         this.business = new Business(business);
@@ -94,6 +96,7 @@ export class OrderTerminals {
       id: this.accountId,
       authToken: this.authToken,
       service: new TerminalService(),
+      apiOrigin: this.apiOrigin,
     })({
       onSuccess: ({ terminals, orderLimit }) => {
         this.terminalModels = terminals;
@@ -111,6 +114,7 @@ export class OrderTerminals {
     const orderTerminals = makeOrderTerminals({
       authToken: this.authToken,
       service: new TerminalService(),
+      apiOrigin: this.apiOrigin,
     });
 
     this.submitting = true;


### PR DESCRIPTION
Likewise other components, the optional `apiOrigin` prop is needed so we can use a different API on the dashboard.

Links
-----
#956 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
Setup: 
- `pnpm dev:order-terminals`.
- Add `api-origin` prop in the component `apps/component-examples/examples/order-terminals.js`.

- [x] - All requests should use the `apiOrigin` set on the prop.
- [x] - Remove the prop. All requests should use whatever is on `PROXY_API_ORIGIN` on the `.env` file.

