### PR TITLE
Remove unused error rendering logic from OrderTerminals component

### DIFF
--- a/.changeset/strange-lobsters-roll.md
+++ b/.changeset/strange-lobsters-roll.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Update the `justifi-order-terminals` component to not show an error state, but only emit the `error-event`.

--- a/apps/component-examples/examples/order-terminals.js
+++ b/apps/component-examples/examples/order-terminals.js
@@ -95,6 +95,13 @@ app.get('/', async (req, res) => {
             document.body.appendChild(message);
           });
 
+          document.addEventListener('error-event', (event) => {
+            const message = document.createElement('div');
+            console.log('error-event', event.detail);
+            message.textContent = 'Error: ' + event.detail.message;
+            document.body.appendChild(message);
+          });
+
         </script>
       </body>
     </html>

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -4,7 +4,6 @@ import { checkPkgVersion } from "../../utils/check-pkg-version";
 import JustifiAnalytics from "../../api/Analytics";
 import { ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
 import { BusinessService } from "../../api/services/business.service";
-import { ErrorState } from "../../ui-components/details/utils";
 import { TerminalModel, ComponentErrorEvent } from "../../api";
 import { Business } from "../../api/Business";
 import { makeGetBusiness } from "../../actions/business/get-business";
@@ -42,7 +41,7 @@ export class OrderTerminals {
   analytics: JustifiAnalytics;
 
   @Event({
-    eventName: 'error-event'
+    eventName: 'error-event',
   }) errorEvent: EventEmitter<ComponentErrorEvent>;
 
   @Event({ eventName: 'submit-event' }) submitted: EventEmitter<any>;
@@ -152,12 +151,6 @@ export class OrderTerminals {
     );
   }
 
-  private renderError() {
-    if (!this.loading.business && this.error) {
-      return ErrorState(this.error.message);
-    }
-  }
-
   private renderBusinessDetails() {
     if (!this.loading.business && this.business) {
       return (
@@ -224,7 +217,6 @@ export class OrderTerminals {
       <StyledHost>
         <div part={text}>
           {this.renderLoading()}
-          {this.renderError()}
           {this.renderBusinessDetails()}
           {this.renderTerminals()}
           {this.renderOrderSection()}

--- a/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
+++ b/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
@@ -28509,11 +28509,6 @@ fieldset:disabled .btn {
           </div>
         </div>
       </div>
-      <main class="d-flex justify-content-center p-4 text-center" style="font-size: 1.2rem;">
-        <p part="text color font-family">
-          Resource Not Found
-        </p>
-      </main>
       <div class="mt-3">
         <div class="text-end">
           Order limit:
@@ -42687,11 +42682,6 @@ fieldset:disabled .btn {
     </style>
     <div part="text color font-family">
       <div></div>
-      <main class="d-flex justify-content-center p-4 text-center" style="font-size: 1.2rem;">
-        <p part="text color font-family">
-          Resource Not Found
-        </p>
-      </main>
       <div class="gap-5 mb-5 pt-5">
         <div class="row">
           <div class="col-12">


### PR DESCRIPTION
Remove the error state in favor of using the error-event.

Links
-----

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
`pnpm dev:order-terminals`

- [x] - Should build and tests pass
- [x] - If forced and error, it should only emit the `error-event` but the component shouldn't show an error message

