### PR TITLE
960 justifi order terminals add shipping address mistakenly removed

### DIFF
--- a/.changeset/smooth-boats-obey.md
+++ b/.changeset/smooth-boats-obey.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Added the shipping address information to the justifi-order-terminals component and format phone number.

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -14,6 +14,7 @@ import { makeGetTerminalModels } from "../../actions/terminal/get-terminal-model
 import { TerminalService } from "../../api/services/terminal.service";
 import { TerminalOrder, TerminalOrderType } from "../../api/TerminalOrder";
 import { makeOrderTerminals } from "../../actions/terminal/order-terminals";
+import { formatPhoneNumber } from "../../utils/utils";
 
 @Component({
   tag: 'justifi-order-terminals',
@@ -154,22 +155,36 @@ export class OrderTerminals {
   private renderBusinessDetails() {
     if (!this.loading.business && this.business) {
       return (
-        <div class="gap-5 pt-5 mb-5">
+        <div class="d-flex flex-column gap-4 mb-5 pt-5">
           <div class="row">
             <div class="col-12">
               <h2 part={heading4}>{this.business.legal_name}</h2>
             </div>
           </div>
           <div class="row">
-            <h5 part={heading5}>Representative:</h5>
-            <div>
-              <div>{this.business?.representative?.name}</div>
-              <div>{this.business?.representative?.title}</div>
-              <div>{this.business?.representative?.email}</div>
-              <div>{this.business?.representative?.phone}</div>
+            <div class="col-6">
+              <h5 part={heading5}>Representative:</h5>
+              <div>
+                <div>{this.business?.representative?.name}</div>
+                <div>{this.business?.representative?.title}</div>
+                <div>{this.business?.representative?.email}</div>
+                <div>{formatPhoneNumber(this.business?.representative?.phone)}</div>
+              </div>
             </div>
+            {this.shipping && (
+              <div class="col-6">
+                <h5 part={heading5}>Shipping Address:</h5>
+                <div>
+                  <div>Street: {this.business.legal_address?.line1}</div>
+                  <div>{this.business.legal_address?.line2}</div>
+                  <div>Postal Code: {this.business.legal_address?.postal_code}</div>
+                  <div>City: {this.business.legal_address?.city}</div>
+                  <div>State: {this.business.legal_address?.state}</div>
+                </div>
+              </div>
+            )}
           </div>
-        </div>
+        </div >
       );
     }
   }

--- a/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
+++ b/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
@@ -14233,7 +14233,7 @@ fieldset:disabled .btn {
           </div>
         </div>
       </div>
-      <div class="gap-5 mb-5 pt-5">
+      <div class="d-flex flex-column gap-4 mb-5 pt-5">
         <div class="row">
           <div class="col-12">
             <h2 part="heading-4 heading text color font-family">
@@ -14242,21 +14242,23 @@ fieldset:disabled .btn {
           </div>
         </div>
         <div class="row">
-          <h5 part="heading-5 heading text color font-family">
-            Representative:
-          </h5>
-          <div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Representative:
+            </h5>
             <div>
-              Person Name
-            </div>
-            <div>
-              President
-            </div>
-            <div>
-              person.name@justifi.ai
-            </div>
-            <div>
-              6124011111
+              <div>
+                Person Name
+              </div>
+              <div>
+                President
+              </div>
+              <div>
+                person.name@justifi.ai
+              </div>
+              <div>
+                (612) 401-1111
+              </div>
             </div>
           </div>
         </div>
@@ -42682,7 +42684,7 @@ fieldset:disabled .btn {
     </style>
     <div part="text color font-family">
       <div></div>
-      <div class="gap-5 mb-5 pt-5">
+      <div class="d-flex flex-column gap-4 mb-5 pt-5">
         <div class="row">
           <div class="col-12">
             <h2 part="heading-4 heading text color font-family">
@@ -42691,21 +42693,23 @@ fieldset:disabled .btn {
           </div>
         </div>
         <div class="row">
-          <h5 part="heading-5 heading text color font-family">
-            Representative:
-          </h5>
-          <div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Representative:
+            </h5>
             <div>
-              Person Name
-            </div>
-            <div>
-              President
-            </div>
-            <div>
-              person.name@justifi.ai
-            </div>
-            <div>
-              6124011111
+              <div>
+                Person Name
+              </div>
+              <div>
+                President
+              </div>
+              <div>
+                person.name@justifi.ai
+              </div>
+              <div>
+                (612) 401-1111
+              </div>
             </div>
           </div>
         </div>
@@ -71227,7 +71231,7 @@ fieldset:disabled .btn {
           </div>
         </div>
       </div>
-      <div class="gap-5 mb-5 pt-5">
+      <div class="d-flex flex-column gap-4 mb-5 pt-5">
         <div class="row">
           <div class="col-12">
             <h2 part="heading-4 heading text color font-family">
@@ -71236,21 +71240,23 @@ fieldset:disabled .btn {
           </div>
         </div>
         <div class="row">
-          <h5 part="heading-5 heading text color font-family">
-            Representative:
-          </h5>
-          <div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Representative:
+            </h5>
             <div>
-              Person Name
-            </div>
-            <div>
-              President
-            </div>
-            <div>
-              person.name@justifi.ai
-            </div>
-            <div>
-              6124011111
+              <div>
+                Person Name
+              </div>
+              <div>
+                President
+              </div>
+              <div>
+                person.name@justifi.ai
+              </div>
+              <div>
+                (612) 401-1111
+              </div>
             </div>
           </div>
         </div>
@@ -85428,7 +85434,7 @@ fieldset:disabled .btn {
     </style>
     <div part="text color font-family">
       <div></div>
-      <div class="gap-5 mb-5 pt-5">
+      <div class="d-flex flex-column gap-4 mb-5 pt-5">
         <div class="row">
           <div class="col-12">
             <h2 part="heading-4 heading text color font-family">
@@ -85437,21 +85443,23 @@ fieldset:disabled .btn {
           </div>
         </div>
         <div class="row">
-          <h5 part="heading-5 heading text color font-family">
-            Representative:
-          </h5>
-          <div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Representative:
+            </h5>
             <div>
-              Person Name
-            </div>
-            <div>
-              President
-            </div>
-            <div>
-              person.name@justifi.ai
-            </div>
-            <div>
-              6124011111
+              <div>
+                Person Name
+              </div>
+              <div>
+                President
+              </div>
+              <div>
+                person.name@justifi.ai
+              </div>
+              <div>
+                (612) 401-1111
+              </div>
             </div>
           </div>
         </div>

--- a/packages/webcomponents/src/utils/utils.ts
+++ b/packages/webcomponents/src/utils/utils.ts
@@ -5,15 +5,19 @@ import { CurrencyTypes } from '../api/Payment';
 
 // Currency Formatting
 
-export const formatCurrency = (amount: number, currency?: CurrencyTypes, omitSymbols = false): string => {
+export const formatCurrency = (
+  amount: number,
+  currency?: CurrencyTypes,
+  omitSymbols = false
+): string => {
   if (!amount) amount = 0;
 
-  const formattedString = (omitSymbols) ? '0,0.00' : '$0,0.00';
+  const formattedString = omitSymbols ? '0,0.00' : '$0,0.00';
   const formattedCurrency = currency?.toUpperCase();
   const formattedAmount = Dinero({ amount: amount }).toFormat(formattedString);
 
   return currency ? `${formattedAmount} ${formattedCurrency}` : formattedAmount;
-}
+};
 
 // Number Formatting
 
@@ -146,7 +150,7 @@ export function formatAddress(address: Address): string {
 export function capitalFirstLetter(str: string): string {
   if (!str) return '';
   return str.charAt(0).toUpperCase() + str.slice(1);
-};
+}
 
 export function snakeCaseToHumanReadable(snakeCaseStr: string): string {
   if (!snakeCaseStr) return '';
@@ -198,4 +202,19 @@ export function processHTML(htmlString, functions) {
     processedHTML = func(processedHTML);
   });
   return processedHTML;
+}
+
+export function formatPhoneNumber(number) {
+  // Remove all non-numeric characters
+  let cleaned = ('' + number).replace(/\D/g, '');
+
+  // Check if the number has the correct length
+  if (cleaned.length !== 10) {
+    return 'Invalid number';
+  }
+
+  // Format the number (XXX) XXX-XXXX
+  let formatted = cleaned.replace(/(\d{3})(\d{3})(\d{4})/, '($1) $2-$3');
+
+  return formatted;
 }


### PR DESCRIPTION
**Description**

This PR commits the following changes: 
- Add back the "Shipping Address" information in case `shipping={true}`.
- Adds a helper function to format phone numbers and use it to format the "Representative Details" phone number on the order terminals component.

<img width="669" alt="image" src="https://github.com/user-attachments/assets/435ac343-2cce-48db-9951-a94c3b902827" />


Type of Change
--------------

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update
* [ ] This change is in scope for PCI
* [ ] This requires approval from UX
* [ ] This requires approval from Marketing


Links
-----
#536

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->


UX Review
---------

If your changes impact the user experience, check these considerations and send to UX for review, prior to QA.

- [ ] Responsive styling works as expected for all breakpoints
- [ ] Copy is free of typos
- [ ] Loading and error states are addressed (if part of this story)
- [ ] If form inputs are involved, ensure they are keyboard-accessible (check tab-through order, toggle checkboxes with spacebar, change radio button selections with cursor keys, etc.)
- [ ] ARIA labels are applied for screen reader accessibility


Steps for Testing/QA
--------------------
Run`pnpm dev:order-terminals`.

- [x] - The phone number should be formatted correctly on the "Representative" section.
- [x] - If `shipping=true`, a "Shipping Address" section should be visible beside the "Representative" details.
- [x] - If `shipping=false`, only the "Representative" should be displayed. 
