### PR TITLE
Add customizable submit button text and improve address header display in OrderTerminals component

### DIFF
--- a/.changeset/twelve-cobras-eat.md
+++ b/.changeset/twelve-cobras-eat.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Add the `submitButtonText` prop to `justifi-order-terminals` component and change the Address header text when `shipping` is set to false.

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -40,7 +40,7 @@ export class OrderTerminals {
   @State() order: TerminalOrder;
   @State() totalQuantity: number = 0;
 
-  addressHeader = this.shipping ? 'Shipping Address: ' : "Business Address: ";
+  addressHeader = this.shipping ? "Shipping Address:" : "Business Address:";
 
   analytics: JustifiAnalytics;
 

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -26,6 +26,7 @@ export class OrderTerminals {
   @Prop() accountId: string;
   @Prop() shipping: boolean = false;
   @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
+  @Prop() submitButtonText: string = 'Submit Order';
 
   @State() loading = {
     business: true,
@@ -38,6 +39,8 @@ export class OrderTerminals {
   @State() orderLimit: number;
   @State() order: TerminalOrder;
   @State() totalQuantity: number = 0;
+
+  addressHeader = this.shipping ? 'Shipping Address: ' : "Business Address: ";
 
   analytics: JustifiAnalytics;
 
@@ -171,17 +174,15 @@ export class OrderTerminals {
                 <div>{formatPhoneNumber(this.business?.representative?.phone)}</div>
               </div>
             </div>
-            {this.shipping && (
-              <div class="col-6">
-                <h5 part={heading5}>Shipping Address:</h5>
-                <div>
-                  {this.business.legal_address.line1}
-                  {this.business.legal_address.line2 ? `, ${this.business.legal_address.line2}` : ""}
-                  <br />
-                  {this.business.legal_address.city}, {this.business.legal_address.state} {this.business.legal_address.postal_code}
-                </div>
+            <div class="col-6">
+              <h5 part={heading5}>{this.addressHeader}</h5>
+              <div>
+                {this.business.legal_address.line1}
+                {this.business.legal_address.line2 ? `, ${this.business.legal_address.line2}` : ""}
+                <br />
+                {this.business.legal_address.city}, {this.business.legal_address.state} {this.business.legal_address.postal_code}
               </div>
-            )}
+            </div>
           </div>
         </div >
       );
@@ -219,7 +220,7 @@ export class OrderTerminals {
             disabled={this.order.totalQuantity === 0 || this.submitting}
             part={buttonPrimary}
           >
-            {this.submitting ? 'Submitting...' : 'Submit Order'}
+            {this.submitting ? 'Submitting...' : this.submitButtonText}
           </button>
         </div>
       </div>

--- a/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
+++ b/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
@@ -14261,6 +14261,16 @@ fieldset:disabled .btn {
               </div>
             </div>
           </div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Business Address:
+            </h5>
+            <div>
+              123 Example St, Suite 101
+              <br>
+              Minneapolis, MN 55555
+            </div>
+          </div>
         </div>
       </div>
       <div class="mt-3">
@@ -42710,6 +42720,16 @@ fieldset:disabled .btn {
               <div>
                 (612) 401-1111
               </div>
+            </div>
+          </div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Business Address:
+            </h5>
+            <div>
+              123 Example St, Suite 101
+              <br>
+              Minneapolis, MN 55555
             </div>
           </div>
         </div>
@@ -71259,6 +71279,16 @@ fieldset:disabled .btn {
               </div>
             </div>
           </div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Business Address:
+            </h5>
+            <div>
+              123 Example St, Suite 101
+              <br>
+              Minneapolis, MN 55555
+            </div>
+          </div>
         </div>
       </div>
       <div class="mt-3">
@@ -85460,6 +85490,16 @@ fieldset:disabled .btn {
               <div>
                 (612) 401-1111
               </div>
+            </div>
+          </div>
+          <div class="col-6">
+            <h5 part="heading-5 heading text color font-family">
+              Business Address:
+            </h5>
+            <div>
+              123 Example St, Suite 101
+              <br>
+              Minneapolis, MN 55555
             </div>
           </div>
         </div>


### PR DESCRIPTION
**This PR commits the following**

- [ ] - Add the `submitButtonText` prop.
- [ ] - Change the Address info header text based on the `shipping` prop value. 


Links
-----
#968 

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
Run `pnpm dev:order-terminals`.

- [x] - If `submitButtonText` is not passed, the submit button text should be "Submit Order".
- [x] - If `submitButtontext` is preset, it should change the button text.
- [x] - `shipping="true"`: Address info header should be "Shipping Address".
- [x] - `shipping="false"`: Address info header should be "Business Address".