### PR TITLE
Add `company_name` column terminal orders list

### DIFF
--- a/.changeset/lemon-students-unite.md
+++ b/.changeset/lemon-students-unite.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Add new optional column to `justifi-terminal-orders-list`: `company_name` - which will show the name of the business associated with a given terminal order.

--- a/packages/webcomponents/src/api/TerminalOrder.ts
+++ b/packages/webcomponents/src/api/TerminalOrder.ts
@@ -35,6 +35,7 @@ interface TerminalOrderItem {
 export interface ITerminalOrder {
   id?: string;
   business_id?: string;
+  company_name?: string;
   sub_account_id?: string;
   provider?: TerminalProviders;
   order_type?: TerminalOrderType;
@@ -47,6 +48,7 @@ export interface ITerminalOrder {
 export class TerminalOrder {
   public id: string;
   public business_id: string;
+  public company_name: string;
   public sub_account_id: string;
   public provider: TerminalProviders;
   public order_type: TerminalOrderType;
@@ -59,6 +61,7 @@ export class TerminalOrder {
   constructor(data: ITerminalOrder) {
     this.id = data.id;
     this.business_id = data.business_id;
+    this.company_name = data.company_name;
     this.sub_account_id = data.sub_account_id;
     this.provider = data.provider || TerminalProviders.verifone;
     this.order_items = [];

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
@@ -4,7 +4,7 @@ import { convertToLocal } from '../../utils/utils';
 import { TerminalOrder } from '../../api';
 import { MapTerminalOrderStatusToBadge } from './terminal-order-status';
 
-export const defaultColumnsKeys = 'created_at,updated_at,order_status,quantity';
+export const defaultColumnsKeys = 'company_name,created_at,updated_at,order_status,quantity';
 
 export const terminalOrdersTableColumns = {
   created_at: () => (
@@ -25,6 +25,11 @@ export const terminalOrdersTableColumns = {
   business_id: () => (
     <th part={tableHeadCell} scope="col" title="The business ID associated with the order">
       Business ID
+    </th>
+  ),
+  company_name: () => (
+    <th part={tableHeadCell} scope="col" title="The business name associated with the order">
+      Business Name
     </th>
   ),
   provider: () => (
@@ -62,6 +67,9 @@ export const terminalOrdersTableCells = {
   ),
   business_id: (terminalOrder: TerminalOrder, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminalOrder.business_id}</td>
+  ),
+  company_name: (terminalOrder: TerminalOrder, index: number) => (
+    <td part={getAlternateTableCellPart(index)}>{terminalOrder.company_name}</td>
   ),
   provider: (terminalOrder: TerminalOrder, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminalOrder.provider}</td>

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
@@ -4,7 +4,7 @@ import { convertToLocal } from '../../utils/utils';
 import { TerminalOrder } from '../../api';
 import { MapTerminalOrderStatusToBadge } from './terminal-order-status';
 
-export const defaultColumnsKeys = 'company_name,created_at,updated_at,order_status,quantity';
+export const defaultColumnsKeys = 'created_at,updated_at,order_status,quantity';
 
 export const terminalOrdersTableColumns = {
   created_at: () => (


### PR DESCRIPTION
### Add `company_name` column terminal orders list

This PR commits the following changes:

- Updates terminal order class with `company_name` - new property from backend
- Adds optional column: `company_name` to `terminal-orders-list`


Links
-----

Closes #970 




Developer QA steps
--------------------

To test this - run `pnpm dev:terminal-orders-list`

You will need to edit the columns prop for the component in the example file. You may copy and paste this as an example:
`columns="company_name,created_at,updated_at,order_status,quantity"`

- [x] Component library builds and runs
- [x] Test suites pass
- [x] You may use the optional `columns` prop on the list to show `company_name` in the table.
