### PR TITLE
Refactor address header logic in OrderTerminals component

### DIFF
--- a/.changeset/green-cows-tickle.md
+++ b/.changeset/green-cows-tickle.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": patch
+---
+
+- Updated name of column on `justifi-terminals-list` from `Provider ID` to `Device ID`
+- Fixed bug in `justifi-order-terminals` where header for address section was not rendered correctly.

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -40,8 +40,6 @@ export class OrderTerminals {
   @State() order: TerminalOrder;
   @State() totalQuantity: number = 0;
 
-  addressHeader = this.shipping ? "Shipping Address:" : "Business Address:";
-
   analytics: JustifiAnalytics;
 
   @Event({
@@ -175,7 +173,7 @@ export class OrderTerminals {
               </div>
             </div>
             <div class="col-6">
-              <h5 part={heading5}>{this.addressHeader}</h5>
+              <h5 part={heading5}>{this.shipping ? "Shipping Address:" : "Business Address:"}</h5>
               <div>
                 {this.business.legal_address.line1}
                 {this.business.legal_address.line2 ? `, ${this.business.legal_address.line2}` : ""}

--- a/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-table.tsx
@@ -32,9 +32,9 @@ export const terminalTableColumns = {
       Serial Number
     </th>
   ),
-  provider_id: () => (
-    <th part={tableHeadCell} scope="col" title="The provider ID of the terminal">
-      Provider ID
+  device_id: () => (
+    <th part={tableHeadCell} scope="col" title="The device/provider ID of the terminal">
+      Device ID
     </th>
   ),
   sub_account_name: () => (
@@ -65,7 +65,7 @@ export const terminalTableCells = {
   provider_serial_number: (terminal: Terminal, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminal.provider_serial_number}</td>
   ),
-  provider_id: (terminal: Terminal, index: number) => (
+  device_id: (terminal: Terminal, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminal.provider_id}</td>
   ),
   sub_account_name: (terminal: Terminal, index: number) => (


### PR DESCRIPTION
The way the Business Details header was being set was buggy, for some reason, passing shipping=true was being evaluated as false.
In the example files it was working though, this was maybe a re-render issue.

`addressHeader = this.shipping ? "Shipping Address:" : "Business Address:";`

Links
-----
Closes #977 
Closes #980 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

1 - Open the terminal in `web-component-library/packages/webcomponents` and run `pnpm link --global`.
2 - Go to the root folder and run `pnpm dev`.
3 - Open the terminal in `customer-admin-fe` and run `pnpm link --global @justifi/webcomponents`.
4 - Run ` pnpm build && pnpm start`.
5 - Put a console.log inside `componentWillLoad` on `packages/webcomponents/src/components/order-terminals/order-terminals.tsx` to confirm you have it linked correctly.

- [x] Click  "Provision Terminals", select a business. "Business Address" header should be visible.
- [x] Click "Order Terminals", select a business. "Shipping Addres" header should be visible.

6 - Open the terminal in `customer-admin-fe` and run `pnpm unlink --global @justifi/webcomponents`.

Additional QA for terminals-list:

 Running `terminals-list` example file `pnpm dev:terminals-list`
Go ahead and add the `columns` prop and pass in `nickname,provider_serial_number,status,device_id`

- [ ] You should see the column displaying the `provider_id` property, but the title of the column should be `Device ID`


