### PR TITLE
Refactor API service calls to use object for parameters

### DIFF
--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -42,14 +42,21 @@ const Api = ({ authToken, apiOrigin }: IApiProps) => {
     };
   }
 
-  async function makeRequest(
-    endpoint: string,
-    method: string,
-    params?: any,
-    body?: any,
-    signal?: AbortSignal,
-    headers?: HeadersInit
-  ) {
+  async function makeRequest({
+    endpoint,
+    method,
+    params,
+    body,
+    signal,
+    headers,
+  }: {
+    endpoint: string;
+    method: string;
+    params?: any;
+    body?: any;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  }) {
     const url = `${apiOrigin}/v1/${endpoint}`;
     const requestUrl = params ? `${url}?${new URLSearchParams(params)}` : url;
 
@@ -69,37 +76,93 @@ const Api = ({ authToken, apiOrigin }: IApiProps) => {
     handleError(requestUrl);
   }
 
-  async function get(endpoint: string, params?: any, signal?: AbortSignal, headers?: HeadersInit) {
-    return makeRequest(endpoint, 'GET', params, null, signal, headers);
+  async function get({
+    endpoint,
+    params,
+    signal,
+    headers,
+  }: {
+    endpoint: string;
+    params?: any;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  }) {
+    return makeRequest({ endpoint, method: 'GET', params, signal, headers });
   }
 
-  async function post(
-    endpoint: string,
-    body?: any,
-    params?: any,
-    signal?: AbortSignal,
-    headers?: HeadersInit
-  ) {
-    return makeRequest(
+  async function post({
+    endpoint,
+    body,
+    params,
+    signal,
+    headers,
+  }: {
+    endpoint: string;
+    body?: any;
+    params?: any;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  }) {
+    return makeRequest({
       endpoint,
-      'POST',
+      method: 'POST',
       params,
-      JSON.stringify(body),
+      body: JSON.stringify(body),
       signal,
-      headers
-    );
+      headers,
+    });
   }
 
-  async function put(endpoint: string, body?: any, params?: any, signal?: AbortSignal) {
-    return makeRequest(endpoint, 'PUT', params, JSON.stringify(body), signal);
+  async function put({
+    endpoint,
+    body,
+    params,
+    signal,
+  }: {
+    endpoint: string;
+    body?: any;
+    params?: any;
+    signal?: AbortSignal;
+  }) {
+    return makeRequest({
+      endpoint,
+      method: 'PUT',
+      params,
+      body: JSON.stringify(body),
+      signal,
+    });
   }
 
-  async function patch(endpoint: string, body?: any, params?: any, signal?: AbortSignal) {
-    return makeRequest(endpoint, 'PATCH', params, JSON.stringify(body), signal);
+  async function patch({
+    endpoint,
+    body,
+    params,
+    signal,
+  }: {
+    endpoint: string;
+    body?: any;
+    params?: any;
+    signal?: AbortSignal;
+  }) {
+    return makeRequest({
+      endpoint,
+      method: 'PATCH',
+      params,
+      body: JSON.stringify(body),
+      signal,
+    });
   }
 
-  async function destroy(endpoint: string, params?: any, signal?: AbortSignal) {
-    return makeRequest(endpoint, 'DELETE', params, null, signal);
+  async function destroy({
+    endpoint,
+    params,
+    signal,
+  }: {
+    endpoint: string;
+    params?: any;
+    signal?: AbortSignal;
+  }) {
+    return makeRequest({ endpoint, method: 'DELETE', params, signal });
   }
 
   return { get, post, put, patch, destroy };

--- a/packages/webcomponents/src/api/services/analytics.service.ts
+++ b/packages/webcomponents/src/api/services/analytics.service.ts
@@ -15,6 +15,6 @@ interface iAnayticsBody {
 export class AnalyticsService {
   async record(body: iAnayticsBody): Promise<void> {
     const endpoint = 'analytics';
-    return Api({ apiOrigin: PROXY_API_ORIGIN }).post(endpoint, body);
+    return Api({ apiOrigin: PROXY_API_ORIGIN }).post({ endpoint, body });
   }
 }

--- a/packages/webcomponents/src/api/services/business.service.ts
+++ b/packages/webcomponents/src/api/services/business.service.ts
@@ -23,7 +23,7 @@ export class BusinessService implements IBusinessService {
     apiOrigin: string = PROXY_API_ORIGIN
   ): Promise<IApiResponse<IBusiness>> {
     const endpoint = `entities/business/${businessId}`;
-    return Api({ authToken, apiOrigin }).get(endpoint);
+    return Api({ authToken, apiOrigin }).get({ endpoint });
   }
 
   async patchBusiness(
@@ -32,10 +32,10 @@ export class BusinessService implements IBusinessService {
     payload: Partial<IBusiness>
   ): Promise<IApiResponse<IBusiness>> {
     const endpoint = `entities/business/${businessId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }
 
@@ -65,7 +65,7 @@ export class IdentityService implements IdentityService {
     authToken: string
   ): Promise<IApiResponse<Identity>> {
     const endpoint = `entities/identity/${identityId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get(endpoint);
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get({ endpoint });
   }
 
   async patchIdentity(
@@ -74,10 +74,10 @@ export class IdentityService implements IdentityService {
     payload: Partial<Identity>
   ): Promise<IApiResponse<Identity>> {
     const endpoint = `entities/identity/${identityId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 
   async postIdentity(
@@ -85,10 +85,10 @@ export class IdentityService implements IdentityService {
     payload: Partial<Identity>
   ): Promise<IApiResponse<Identity>> {
     const endpoint = `entities/identity`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }
 
@@ -107,10 +107,10 @@ export class BusinessBankAccountService implements IBusinessBankAccountService {
     payload: Partial<IBankAccount>
   ): Promise<IApiResponse<IBankAccount>> {
     const endpoint = `entities/bank_accounts`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }
 
@@ -129,9 +129,9 @@ export class DocumentRecordService implements IDocumentRecordService {
     payload: DocumentRecordData
   ): Promise<IApiResponse<any>> {
     const endpoint = `entities/document`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }

--- a/packages/webcomponents/src/api/services/checkout.service.ts
+++ b/packages/webcomponents/src/api/services/checkout.service.ts
@@ -32,7 +32,7 @@ export class CheckoutService implements ICheckoutService {
     checkoutId: string
   ): Promise<IApiResponse<ICheckout>> {
     const endpoint = `checkouts/${checkoutId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get(endpoint);
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get({ endpoint });
   }
 
   async fetchCheckouts(
@@ -49,7 +49,7 @@ export class CheckoutService implements ICheckoutService {
 
     const api = Api({ authToken, apiOrigin: apiOrigin });
     const endpoint = 'checkouts';
-    return api.get(endpoint, params, null, headers);
+    return api.get({ endpoint, params, headers });
   }
 
   async complete(
@@ -64,9 +64,9 @@ export class CheckoutService implements ICheckoutService {
     if (payment.payment_token) {
       payload.payment_token = payment.payment_token;
     }
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }

--- a/packages/webcomponents/src/api/services/dispute.service.ts
+++ b/packages/webcomponents/src/api/services/dispute.service.ts
@@ -32,7 +32,7 @@ export class DisputeService implements IDisputeService {
     authToken: string
   ): Promise<IApiResponse<IDispute>> {
     const endpoint = `disputes/${disputeId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get(endpoint);
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get({ endpoint });
   }
 
   async updateDisputeResponse(
@@ -41,10 +41,10 @@ export class DisputeService implements IDisputeService {
     payload: any
   ): Promise<IApiResponse<IDispute>> {
     const endpoint = `disputes/${disputeId}/response`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 
   async submitDisputeResponse(
@@ -53,10 +53,10 @@ export class DisputeService implements IDisputeService {
     payload: any
   ): Promise<IApiResponse<IDispute>> {
     const endpoint = `disputes/${disputeId}/response`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 
   async createDisputeEvidence(
@@ -65,9 +65,9 @@ export class DisputeService implements IDisputeService {
     payload: any
   ): Promise<IApiResponse<any>> {
     const endpoint = `disputes/${disputeId}/evidence`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).put(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).put({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }

--- a/packages/webcomponents/src/api/services/insurance.service.ts
+++ b/packages/webcomponents/src/api/services/insurance.service.ts
@@ -15,10 +15,10 @@ export class InsuranceService implements IInsuranceService {
     payload: any
   ): Promise<IApiResponse<IQuote>> {
     const endpoint = 'insurance/quotes';
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
   async toggleCoverage(
     authToken: string,
@@ -26,9 +26,9 @@ export class InsuranceService implements IInsuranceService {
     payload: { accepted: boolean }
   ): Promise<IApiResponse<IQuote>> {
     const endpoint = `insurance/quotes/${quoteId}/toggle`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }

--- a/packages/webcomponents/src/api/services/payment.service.ts
+++ b/packages/webcomponents/src/api/services/payment.service.ts
@@ -22,7 +22,7 @@ export class PaymentService implements IPaymentService {
   ): Promise<IApiResponseCollection<IPayment[]>> {
     const api = Api({ authToken, apiOrigin: apiOrigin });
     const endpoint = `account/${accountId}/payments`;
-    return api.get(endpoint, params);
+    return api.get({ endpoint, params });
   }
 
   async fetchPayment(
@@ -30,6 +30,6 @@ export class PaymentService implements IPaymentService {
     authToken: string
   ): Promise<IApiResponse<IPayment>> {
     const endpoint = `payments/${paymentId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get(endpoint);
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get({ endpoint });
   }
 }

--- a/packages/webcomponents/src/api/services/payout.service.ts
+++ b/packages/webcomponents/src/api/services/payout.service.ts
@@ -13,9 +13,9 @@ export interface IPayoutService {
     apiOrigin?: string
   ): Promise<IApiResponse<IPayout>>;
   fetchCSV(
-    payoutId: string, 
+    payoutId: string,
     authToken: string,
-    apiOrigin?: string  
+    apiOrigin?: string
   ): Promise<IApiResponse<any>>;
 }
 
@@ -28,7 +28,7 @@ export class PayoutService implements IPayoutService {
   ): Promise<IApiResponseCollection<IPayout[]>> {
     const api = Api({ authToken, apiOrigin });
     const endpoint = `account/${accountId}/payouts`;
-    return api.get(endpoint, params);
+    return api.get({ endpoint, params });
   }
 
   async fetchPayout(
@@ -38,7 +38,7 @@ export class PayoutService implements IPayoutService {
   ): Promise<IApiResponse<IPayout>> {
     const api = Api({ authToken, apiOrigin });
     const endpoint = `payouts/${payoutId}`;
-    return api.get(endpoint);
+    return api.get({ endpoint });
   }
 
   async fetchCSV(
@@ -48,6 +48,6 @@ export class PayoutService implements IPayoutService {
   ): Promise<IApiResponse<any>> {
     const api = Api({ authToken, apiOrigin });
     const endpoint = `reports/payouts/${payoutId}`;
-    return api.get(endpoint);
+    return api.get({ endpoint });
   }
 }

--- a/packages/webcomponents/src/api/services/provision.service.ts
+++ b/packages/webcomponents/src/api/services/provision.service.ts
@@ -19,9 +19,9 @@ export class ProvisionService implements IProvisionService {
       business_id: businessId,
       product_category: product,
     };
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post(
+    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
       endpoint,
-      payload
-    );
+      body: payload,
+    });
   }
 }

--- a/packages/webcomponents/src/api/services/reports.service.ts
+++ b/packages/webcomponents/src/api/services/reports.service.ts
@@ -8,6 +8,6 @@ export class ReportsService {
   ): Promise<IApiResponse<GrossVolumeReport>> {
     const api = Api({ authToken: authToken, apiOrigin: PROXY_API_ORIGIN });
     const endpoint = `account/${accountId}/reports/gross_volume`;
-    return api.get(endpoint);
+    return api.get({ endpoint });
   }
 }

--- a/packages/webcomponents/src/api/services/subaccounts.service.ts
+++ b/packages/webcomponents/src/api/services/subaccounts.service.ts
@@ -20,6 +20,6 @@ export class SubAccountService implements ISubAccountService {
 
     const api = Api({ authToken, apiOrigin: apiOrigin });
     const endpoint = 'sub_accounts';
-    return api.get(endpoint, params, null, headers);
+    return api.get({ endpoint, params, headers });
   }
 }

--- a/packages/webcomponents/src/api/services/terminal.service.ts
+++ b/packages/webcomponents/src/api/services/terminal.service.ts
@@ -36,7 +36,7 @@ export class TerminalService implements ITerminalService {
 
     const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals';
-    return api.get(endpoint, params, null, headers);
+    return api.get({ endpoint, params, headers });
   }
 
   async fetchTerminal(
@@ -45,7 +45,7 @@ export class TerminalService implements ITerminalService {
     apiOrigin: string = PROXY_API_ORIGIN
   ): Promise<IApiResponse<ITerminal>> {
     const endpoint = `terminals/${terminalId}`;
-    return Api({ authToken, apiOrigin: apiOrigin }).get(endpoint);
+    return Api({ authToken, apiOrigin: apiOrigin }).get({ endpoint });
   }
 
   async fetchTerminalModels(
@@ -57,7 +57,7 @@ export class TerminalService implements ITerminalService {
 
     const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals/order_models';
-    return api.get(endpoint, null, null, headers);
+    return api.get({ endpoint, headers });
   }
 
   async orderTerminals(
@@ -68,6 +68,6 @@ export class TerminalService implements ITerminalService {
     const headers = { 'sub-account': terminalOrder.sub_account_id };
     const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals/orders';
-    return api.post(endpoint, terminalOrder, null, null, headers);
+    return api.post({ endpoint, body: terminalOrder, headers });
   }
 }

--- a/packages/webcomponents/src/api/services/terminal_orders.service.ts
+++ b/packages/webcomponents/src/api/services/terminal_orders.service.ts
@@ -20,6 +20,10 @@ export class TerminalOrderService implements ITerminalOrderService {
 
     const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals/orders';
-    return api.get(endpoint, params, null, headers);
+    return api.get({
+      endpoint,
+      params,
+      headers,
+    });
   }
 }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step.tsx
@@ -61,7 +61,7 @@ export class BusinessTermsConditionsFormStep {
   private fetchData = async () => {
     this.formLoading.emit(true);
     try {
-      const response: IApiResponse<IBusiness> = await this.api.get(this.businessEndpoint);
+      const response: IApiResponse<IBusiness> = await this.api.get({ endpoint: this.businessEndpoint });
       this.acceptedTermsBefore = response.data.terms_conditions_accepted;
     } catch (error) {
       this.errorEvent.emit({
@@ -79,7 +79,7 @@ export class BusinessTermsConditionsFormStep {
     this.formLoading.emit(true);
     try {
       const payload = this.termsPayload;
-      const response = await this.api.post(this.termsConditionsEndpoint, payload);
+      const response = await this.api.post({ endpoint: this.termsConditionsEndpoint, body: payload });
       this.handleResponse(response, onSuccess);
     } catch (error) {
       this.errorEvent.emit({


### PR DESCRIPTION
Like it was done in the `customer-admin-fe`, the `Api` class could be refactored to accept an object argument instead of each argument separated.

This improves clarity and maintenance.

Links
-----
#949 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
I couldn't run myself (even in main branch) the following examples: checkout, checkout-with-insurance and tokenize-payment-method. 

- [x] `pnpm dev:dispute` - Should get dispute correctly.
- [x] `pnpm dev:checkouts-list` - Should get checkouts.
- [x] `pnpm dev:checkouts-list-with-filters` - Should get checkouts and filter should work.
- [x] `pnpm dev:payment-provisioning` - Should load business initial data, and should save info inputted (no need to go all steps).
- [x] `pnpm dev:tokenize-payment-method` - Should tokenize payment method.
- [x] `pnpm dev:terminals-list` - Should get terminals list.
- [x] `pnpm dev:terminals-list-with-filters` - Should get terminals list and filters should work.
- [x] `pnpm dev:payouts-list` - Should get payouts list.
- [x] `pnpm dev:payouts-list-with-filters` - Should get payouts list and filters should work.
- [x] `pnpm dev:order-terminals` - Should load business info, terminal models, and should create order.
- [x] `pnpm dev:terminals-order-list` - Should get orders list.
- [x] `pnpm dev:terminals-order-list-with-filters` - Should get orders list and filters should work.