### PR TITLE
refactor: update checkout API endpoint and improve error handling

### DIFF
--- a/apps/component-examples/examples/checkout-with-insurance.js
+++ b/apps/component-examples/examples/checkout-with-insurance.js
@@ -3,7 +3,7 @@ require('dotenv').config({ path: '../../.env' });
 const express = require('express');
 const app = express();
 const port = process.env.PORT || 3000;
-const proxyApiOrigin = process.env.PROXY_API_ORIGIN;
+const checkoutEndpoint = process.env.CHECKOUT_ENDPOINT;
 const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
 const webcomponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
 const clientId = process.env.CLIENT_ID;
@@ -61,7 +61,7 @@ async function getToken() {
 }
 
 async function makeCheckout(token) {
-  const response = await fetch(`${proxyApiOrigin}/v1/checkouts`, {
+  const response = await fetch(checkoutEndpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -72,11 +72,10 @@ async function makeCheckout(token) {
       amount: 1799,
       description: 'One Chocolate Donut',
       payment_method_group_id: paymentMethodId,
-      origin_url: `http://localhost:${port}`,
+      origin_url: `localhost:${port}`,
     }),
   });
   const responseJson = await response.json();
-  console.log('responseJson:', responseJson);
   const { data } = responseJson;
   return data;
 }

--- a/apps/component-examples/examples/checkout.js
+++ b/apps/component-examples/examples/checkout.js
@@ -36,26 +36,34 @@ async function getToken() {
     console.log('ERROR:', error);
   }
 
-  const { access_token } = await response.json();
+  const responseJson = await response.json();
+  const { access_token } = responseJson;
   return access_token;
 }
 
 async function makeCheckout(token) {
-  const response = await fetch(checkoutEndpoint, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`,
-      'Sub-Account': subAccountId,
-    },
-    body: JSON.stringify({
-      amount: 1799,
-      description: 'One Chocolate Donut',
-      payment_method_group_id: paymentMethodGroupId,
-      origin_url: `http://localhost:${port}`,
-    }),
-  });
-  const { data } = await response.json();
+  let response;
+  try {
+    response = await fetch(checkoutEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        'Sub-Account': subAccountId,
+      },
+      body: JSON.stringify({
+        amount: 1799,
+        description: 'One Chocolate Donut',
+        payment_method_group_id: paymentMethodGroupId,
+        origin_url: `localhost:${port}`,
+      }),
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
+
+  const responseJson = await response.json();
+  const { data } = responseJson;
   return data;
 }
 
@@ -73,7 +81,9 @@ async function getWebComponentToken(token, checkoutId) {
       ],
     }),
   });
-  const { access_token } = await response.json();
+
+  const responseJson = await response.json();
+  const { access_token } = responseJson;
   return access_token;
 }
 


### PR DESCRIPTION
This PR commits the following fixes: 

- Checkout example: `http://` on the `origin_url` was breaking the request.
- Checkout with insurance example: Same `origin_url` issue and switched from the proxy API to the regular one.


Links
-----

#121 

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [ ] `pnpm dev:checkout` should work fine.
- [ ] `pnpm dev:checkout-with-insurance` should work fine. 

