### PR TITLE
137 storybooks docs stying example breaks checkbox

### DIFF
--- a/.changeset/whole-flies-deny.md
+++ b/.changeset/whole-flies-deny.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix background issue by removing background part from inputCheckbox part

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -41,7 +41,7 @@ export const inputRadioChecked = `input-radio-checked ${inputRadio}`;
 export const inputRadioCheckedFocused = `input-radio-checked-focused ${inputRadio}`;
 export const inputRadioInvalid = `input-radio-invalid ${inputRadio}`;
 
-export const inputCheckbox = `input-checkbox ${backgroundColor}`;
+export const inputCheckbox = `input-checkbox`;
 export const inputCheckboxInvalid = `input-checkbox-invalid ${inputCheckbox}`;
 export const inputCheckboxFocused = `input-checkbox-focused ${inputCheckbox}`;
 export const inputCheckboxChecked = `input-checkbox-checked ${inputCheckbox}`;

--- a/packages/webcomponents/src/ui-components/form/test/__snapshots__/form-control-checkbox.spec.tsx.snap
+++ b/packages/webcomponents/src/ui-components/form/test/__snapshots__/form-control-checkbox.spec.tsx.snap
@@ -4,7 +4,7 @@ exports[`form-control-checkbox Renders with all props provided 1`] = `
 <form-control-checkbox>
   <div class="d-flex flex-column form-group">
     <div class="form-check">
-      <input class="form-check-input is-invalid" disabled="" id="accept" name="accept" part="input-checkbox-invalid input-checkbox background-color" type="checkbox">
+      <input class="form-check-input is-invalid" disabled="" id="accept" name="accept" part="input-checkbox-invalid input-checkbox" type="checkbox">
       <label class="form-check-label" htmlfor="accept" part="label text color font-family">
         Accept Terms
       </label>
@@ -23,7 +23,7 @@ exports[`form-control-checkbox Renders with default props 1`] = `
 <form-control-checkbox>
   <div class="d-flex flex-column form-group">
     <div class="form-check">
-      <input class="form-check-input" id="accept" name="accept" part="input-checkbox background-color" type="checkbox">
+      <input class="form-check-input" id="accept" name="accept" part="input-checkbox" type="checkbox">
       <label class="form-check-label" htmlfor="accept" part="label text color font-family">
         Accept Terms
       </label>


### PR DESCRIPTION
**Description**

When setting `background: transparent` using the `background` part, the checkbox starts presenting a weird style not being possible to recognize it's current state. 

(checked)
![image](https://github.com/user-attachments/assets/3fa17e84-e1b6-4070-9327-449fad3ea890)

This only happens when the `inputCheckbox`, `inputCheckboxInvalid`, `inputCheckboxFocused`, `inputCheckboxChecked`, `inputCheckboxCheckedFocused` parts are not set. 

The checkbox, however, still works, only the styles are affected. 

**Solution**
Removing the `background` part from the `inputCheckbox` composition seems to solve the problem. 

Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/137

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
Setup: 
1 - On `apps/component-examples/css/theme.css`, remove from line 80 to 97 (input-checkbox parts).
2 - Run `pnpm build && pnpm dev:payment-provisioning` and fill the form until the "Terms and Conditions" step.

- [x] - Checkbox should present default bootstrap styles.
- [x] - When checked, checkbox should display satisfactory checked styles:  (blue background, white checkmark...)