### PR TITLE
Re-implement `terminal-orders-list` docs to storybook

### DIFF
--- a/apps/docs/stories/components/TerminalOrdersList/Docs.mdx
+++ b/apps/docs/stories/components/TerminalOrdersList/Docs.mdx
@@ -1,0 +1,98 @@
+import {
+  Meta,
+  Title,
+  Subtitle,
+  Description,
+  ArgTypes,
+  Source,
+} from '@storybook/blocks';
+import { filterDocsByTag, ExportedParts } from '../../utils';
+import { codeExampleFull, codeExampleEventHandling } from './example';
+import {
+  Authorization,
+  ComponentBox,
+} from '../../utils/documentation-components';
+import * as JustifiTerminalOrdersList from './index.stories.tsx';
+import { setUpMocks } from '../../utils/mockAllServices';
+
+{setUpMocks()}
+
+<Meta
+  title="Merchant Tools/Terminal Orders List"
+  Components="justifi-terminal-orders-list"
+  of={JustifiTerminalOrdersList}
+/>
+
+<Title />
+
+---
+
+Component to render a formated list of terminal device orders for the requested account.
+
+# Index
+
+---
+
+- [Props, events and methods](#props-events-and-methods)
+- [Authorization](#authorization)
+- [Events usage](#events-usage)
+- [Example usage](#example-usage)
+
+# Props, events and methods
+
+---
+
+<ArgTypes exclude={['Theme']} />
+
+# Authorization
+
+---
+
+<Authorization
+  actions={['write']}
+  entity="account"
+  identification="account_id"
+/>
+
+# Events usage
+
+---
+
+All table components emit an event when a row is clicked. Below is an example event payload showing the contents of `event.detail`, and a brief code example showing usage in your own implementation. 
+
+```
+{
+  "name": "tableRow",
+  "data": {
+    "id": "tord_ABCD1234",
+    "business_id": "biz_0987",
+    "sub_account_id": "acc_5678",
+    "provider": "verifone",
+    "order_type": "boarding_only",
+    "order_status": "submitted",
+    "terminals": [
+        {
+          "terminal_id": "tmn_QWER",
+          "terminal_did": "11112222",
+          "model_name": "v400"
+        }
+    ],
+    "created_at": "2025-01-02T10:30:00Z",
+    "updated_at": "2025-01-02T10:45:00Z"
+  }
+}
+```
+
+<Source dark language="html" code={codeExampleEventHandling} />
+
+# Example Usage
+
+---
+
+<ComponentBox>
+  <justifi-terminal-orders-list account-id="123" auth-token="123abc" />
+</ComponentBox>
+
+---
+
+<Source dark language="html" code={codeExampleFull} />

--- a/apps/docs/stories/components/TerminalOrdersList/example.ts
+++ b/apps/docs/stories/components/TerminalOrdersList/example.ts
@@ -1,0 +1,72 @@
+import { codeExampleHead } from '../../utils';
+
+export const codeExampleFull = `
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+${codeExampleHead(
+  'justifi-terminal-orders-list',
+  `<style>
+      ::part(font-family) {
+        font-family: georgia;   
+      }
+        
+      ::part(color) {
+        color: darkslategray;
+      }
+
+      ::part(background-color) {
+        background-color: transparent;
+      }
+
+      ::part(background-color) {
+        background-color: transparent;
+      }
+
+      ::part(button) {
+        padding: 0.375rem 0.75rem;
+        font-size: 16px;
+        box-shadow: none;
+        border-radius: 0px;
+        line-height: 1.5;
+        text-transform: none;
+      }
+
+      ::part(button-disabled) {
+        opacity: 0.5;
+      }
+    </style>`
+)}
+
+<body>
+  <justifi-terminal-orders-list></justifi-terminal-orders-list>
+</body>
+
+</html>
+`;
+
+export const codeExampleEventHandling = `
+<justifi-terminal-orders-list />
+
+<script>
+  (function() {
+    const ordersList = document.querySelector('justifi-terminal-orders-list');
+    
+    ordersList.addEventListener('click-event', (event) => {
+      // 'click-event' is emitted when a user clicks on a table row, or clicks on the next or previous page buttons
+      // event.detail.name describes the action that was clicked - it could be 'nextPage', 'previousPage', or 'tableRow'
+      // event.detail.data will be included if the action was 'tableRow', and will contain the data for the row that was clicked
+      
+      if (event.detail.name === 'tableRow') {
+        // Here is where you would handle the click event
+        console.log('data from click-event', event.detail.data);
+      }
+    })
+  
+    ordersList.addEventListener('error-event', (event) => {
+      // here is where you would handle the error
+      console.error('error-event', event.detail);
+    });
+  })();
+</script>
+`;

--- a/apps/docs/stories/components/TerminalOrdersList/example.ts
+++ b/apps/docs/stories/components/TerminalOrdersList/example.ts
@@ -39,6 +39,8 @@ ${codeExampleHead(
 )}
 
 <body>
+  <!-- Optional: add the filters component -->
+  <justifi-terminal-orders-list-filters></justifi-terminal-orders-list-filters>
   <justifi-terminal-orders-list></justifi-terminal-orders-list>
 </body>
 

--- a/apps/docs/stories/components/TerminalOrdersList/index.stories.tsx
+++ b/apps/docs/stories/components/TerminalOrdersList/index.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/web-components";
+import { withActions } from "@storybook/addon-actions/decorator";
+import { StoryBaseArgs, customStoryDecorator } from "../../utils";
+import { ThemeNames } from "../../themes";
+
+import "@justifi/webcomponents/dist/module/justifi-terminal-orders-list";
+import "@justifi/webcomponents/dist/module/justifi-terminal-orders-list-filters";
+
+type Story = StoryObj;
+
+const storyBaseArgs = new StoryBaseArgs(["account-id", "auth-token"]);
+
+const meta: Meta = {
+  title: "Merchant Tools/Terminal Orders List",
+  component: "justifi-terminal-orders-list",
+  args: {
+    ...storyBaseArgs.args,
+    Theme: ThemeNames.Light
+  },
+  argTypes: {
+    ...storyBaseArgs.argTypes,
+    Theme: {
+      description:
+        "Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling)",
+      options: Object.values(ThemeNames),
+      control: {
+        type: "select",
+      },
+    },
+    "click-event": {
+      description:
+        "Emitted when controls or table rows are clicked.  Control name is defined in `event.detail.name`.",
+      table: {
+        category: "events",
+      },
+      action: true
+    },
+    "error-event": {
+      description: "`ComponentError` - emitted when a network error occurs in the component.",
+      table: {
+        category: "events",
+      },
+      action: true
+    },
+    "columns": {
+      description: "Columns to display in the table <br> Pass a comma separated list of columns to display in the table.",
+      type: "string",
+      table: {
+        category: "props",
+        defaultValue: {
+          summary: "created_at,updated_at,order_status,quantity",
+          detail: "The following values are available to pass to the columns prop as a comma separated string: `created_at`, `updated_at`, `order_status` and `quantity`"
+        }
+      },
+      control: {
+        type: "text",
+      },
+    }
+  },
+  parameters: {
+    actions: {
+      handles: ["click-event", "error-event"],
+    },
+    chromatic: {
+      delay: 2000,
+    },
+  },
+  decorators: [
+    customStoryDecorator,
+    withActions
+  ]
+};
+
+export const Example: Story = {};
+
+export const ExampleWithFilters: Story = {
+  args: {},
+  render: (args) => `
+  <div>
+    <justifi-terminal-orders-list-filters></justifi-terminal-orders-list-filters>
+    <justifi-terminal-orders-list
+      account-id="${args["account-id"]}"
+      auth-token="${args["auth-token"]}"
+    ></justifi-terminal-orders-list>
+  </div>
+  `
+};
+
+export default meta;


### PR DESCRIPTION
### Re-implement `terminal-orders-list` docs to storybook

This PR adds back the docs for `terminal-orders-list`

This work had already been approved before - but was removed due to the API not being ready at the time. 


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/140



Developer QA steps
--------------------

- [x] Verify that doc pages for orders-list are present on storybook again
- [x] loading mock data when showing component

