### PR TITLE
`terminal-orders-list`: Show `order_type` in readable format

### DIFF
--- a/.changeset/deep-peaches-divide.md
+++ b/.changeset/deep-peaches-divide.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+If showing `order_type` column on `justifi-terminal-orders-list`, display value will now be converted from snake_case to a more readable format. `boarding_only` will now display as `Boarding Only`, and `boarding_shipping` will now display as `Boarding & Shipping`

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
@@ -1,6 +1,6 @@
 import { h } from '@stencil/core';
 import { getAlternateTableCellPart, tableHeadCell } from '../../styles/parts';
-import { convertToLocal } from '../../utils/utils';
+import { convertToLocal, snakeCaseToHumanReadable } from '../../utils/utils';
 import { TerminalOrder } from '../../api';
 import { MapTerminalOrderStatusToBadge } from './terminal-order-status';
 
@@ -75,7 +75,7 @@ export const terminalOrdersTableCells = {
     <td part={getAlternateTableCellPart(index)}>{terminalOrder.provider}</td>
   ),
   order_type: (terminalOrder: TerminalOrder, index: number) => (
-    <td part={getAlternateTableCellPart(index)}>{terminalOrder.order_type}</td>
+    <td part={getAlternateTableCellPart(index)}>{snakeCaseToHumanReadable(terminalOrder.order_type)}</td>
   ),
   quantity: (terminalOrder: TerminalOrder, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminalOrder.terminals.length}</td>

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-table.tsx
@@ -1,7 +1,7 @@
 import { h } from '@stencil/core';
 import { getAlternateTableCellPart, tableHeadCell } from '../../styles/parts';
-import { convertToLocal, snakeCaseToHumanReadable } from '../../utils/utils';
-import { TerminalOrder } from '../../api';
+import { convertToLocal } from '../../utils/utils';
+import { TerminalOrder, TerminalOrderType } from '../../api';
 import { MapTerminalOrderStatusToBadge } from './terminal-order-status';
 
 export const defaultColumnsKeys = 'created_at,updated_at,order_status,quantity';
@@ -74,9 +74,18 @@ export const terminalOrdersTableCells = {
   provider: (terminalOrder: TerminalOrder, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminalOrder.provider}</td>
   ),
-  order_type: (terminalOrder: TerminalOrder, index: number) => (
-    <td part={getAlternateTableCellPart(index)}>{snakeCaseToHumanReadable(terminalOrder.order_type)}</td>
-  ),
+  order_type: (terminalOrder: TerminalOrder, index: number) => {
+    let orderType;
+    if (terminalOrder.order_type === TerminalOrderType.boardingOnly) {
+      orderType = 'Boarding Only';
+    } else if (terminalOrder.order_type === TerminalOrderType.boardingShipping) {
+      orderType = 'Boarding & Shipping';
+    }
+    return (
+      <td part={getAlternateTableCellPart(index)}>{orderType}</td>
+    )
+  }
+  ,
   quantity: (terminalOrder: TerminalOrder, index: number) => (
     <td part={getAlternateTableCellPart(index)}>{terminalOrder.terminals.length}</td>
   ),


### PR DESCRIPTION
### `terminal-orders-list`: Show `order_type` in readable format

This PR commits the following:

- If showing `order_type` column in `terminal-orders-list`, value will be converted from snake_case to readable. `boarding_only` will now display as `Boarding Only`, and `boarding_shipping` will now display as `Boarding & Shipping`


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/141



Developer QA steps
--------------------

- [x] component library builds and runs
- [x] test suites pass

1. in `terminal-orders-list.js` use the `columns` prop on the component to show `order_type` Example: `columns='created_at,updated_at,order_status,order_type,quantity'`
2. Run `pnpm build && pnpm dev:terminal-orders-list`


- [x] If `order_type` column is showing, order_type value should be converted from snake_case


