### PR TITLE
Add CSS part for $ input adornment

### DIFF
--- a/.changeset/clever-ghosts-take.md
+++ b/.changeset/clever-ghosts-take.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Add new CSS part `input-group-text` used to target and style input adornment shown on inputs related to monetary amounts.

--- a/.changeset/clever-ghosts-take.md
+++ b/.changeset/clever-ghosts-take.md
@@ -2,4 +2,4 @@
 "@justifi/webcomponents": patch
 ---
 
-Add new CSS part `input-group-text` used to target and style input adornment shown on inputs related to monetary amounts.
+Add new CSS part `input-adornment` used to target and style input adornment shown on inputs related to monetary amounts.

--- a/apps/component-examples/css/theme.css
+++ b/apps/component-examples/css/theme.css
@@ -59,7 +59,7 @@ body {
   border-color: #333;
 }
 
-::part(input-group-text) {
+::part(input-adornment) {
   background-color: #fff;
   border-color: #333;
   border-radius: 0px;

--- a/apps/component-examples/css/theme.css
+++ b/apps/component-examples/css/theme.css
@@ -59,6 +59,12 @@ body {
   border-color: #333;
 }
 
+::part(input-group-text) {
+  background-color: #fff;
+  border-color: #333;
+  border-radius: 0px;
+}
+
 ::part(input-radio-checked) {
   background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="-5 -5 30 30" fill="white"><circle cx="10" cy="10" r="10"/></svg>');
   background-color: #000;

--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -35,11 +35,11 @@ const dark = `
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
   }
 
-  ::part(input-group-text) {
+  ::part(input-adornment) {
     background: transparent;
     color: #fdfdec;
     border-color: #fdfdec;
-    border-radius: 0px;
+    border-radius: 4px;
   }
 
   ::part(input-radio) {

--- a/apps/docs/stories/themes/dark.ts
+++ b/apps/docs/stories/themes/dark.ts
@@ -13,7 +13,7 @@ const dark = `
   }
 
   ::part(font-family) {
-    font-family: sans-serif;   
+    font-family: sans-serif;
   }
 
   ::part(color) {
@@ -33,6 +33,13 @@ const dark = `
     appearance: none;
     -webkit-appearance: none;
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.4);
+  }
+
+  ::part(input-group-text) {
+    background: transparent;
+    color: #fdfdec;
+    border-color: #fdfdec;
+    border-radius: 0px;
   }
 
   ::part(input-radio) {

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -97,6 +97,12 @@ const light = `
     box-shadow: 0 0 0 0.25rem rgba(0, 0, 0, 0.25);
   }
 
+  ::part(input-group-text) {
+    background-color: #fff;
+    border-color: #333;
+    border-radius: 0px;
+  }
+
   ::part(button) {
     padding: 0.375rem 0.75rem;
     font-size: 16px;

--- a/apps/docs/stories/themes/light.ts
+++ b/apps/docs/stories/themes/light.ts
@@ -97,7 +97,7 @@ const light = `
     box-shadow: 0 0 0 0.25rem rgba(0, 0, 0, 0.25);
   }
 
-  ::part(input-group-text) {
+  ::part(input-adornment) {
     background-color: #fff;
     border-color: #333;
     border-radius: 0px;

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/form-control-monetary-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/form-control-monetary-provisioning.tsx
@@ -11,7 +11,7 @@ import {
 import IMask, { InputMask } from 'imask';
 import { CURRENCY_MASK } from '../../../utils/form-input-masks';
 import { FormControlErrorText, FormControlHelpText } from '../../../ui-components';
-import { inputDisabled, inputFocused, inputGroup, inputInvalid, label, text } from '../../../styles/parts';
+import { inputAdornment, inputDisabled, inputFocused, inputGroup, inputInvalid, label } from '../../../styles/parts';
 
 @Component({
   tag: 'form-control-monetary-provisioning'
@@ -75,7 +75,7 @@ export class MonetaryInputProvisioning {
     }
   }
 
-  private get part() {
+  private get inputPart() {
     let part = inputGroup;
     if (this.errorText) {
       part = inputInvalid;
@@ -97,7 +97,7 @@ export class MonetaryInputProvisioning {
             {this.label}
           </label>
           <div class="input-group">
-            <span class="input-group-text" part={text}>$</span>
+            <span class="input-group-text" part={inputAdornment}>$</span>
             <input
               ref={el => (this.textInput = el as HTMLInputElement)}
               id={this.name}
@@ -108,7 +108,7 @@ export class MonetaryInputProvisioning {
                 this.formControlBlur.emit();
               }}
               onInput={this.handleFormControlInput}
-              part={this.part}
+              part={this.inputPart}
               class={this.errorText ? 'form-control monetary is-invalid' : 'form-control monetary'}
               type="text"
               disabled={this.disabled}

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/test/__snapshots__/form-control-monetary-provisioning.spec.tsx.snap
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/test/__snapshots__/form-control-monetary-provisioning.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`form-control-monetary-provisioning Renders with all props provided 1`] 
       Amount
     </label>
     <div class="input-group">
-      <span class="input-group-text" part="input-group-text">
+      <span class="input-group-text" part="input-adornment text color font-family">
         $
       </span>
       <input class="form-control is-invalid monetary" id="amount" name="amount" part="input-invalid input text color font-family background-color" type="text" value="1,500">
@@ -29,7 +29,7 @@ exports[`form-control-monetary-provisioning renders correctly with default props
       Amount
     </label>
     <div class="input-group">
-      <span class="input-group-text" part="input-group-text">
+      <span class="input-group-text" part="input-adornment text color font-family">
         $
       </span>
       <input class="form-control monetary" id="amount" name="amount" part="input-group input text color font-family background-color" type="text">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/test/__snapshots__/form-control-monetary-provisioning.spec.tsx.snap
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/test/__snapshots__/form-control-monetary-provisioning.spec.tsx.snap
@@ -7,7 +7,7 @@ exports[`form-control-monetary-provisioning Renders with all props provided 1`] 
       Amount
     </label>
     <div class="input-group">
-      <span class="input-group-text" part="text color font-family">
+      <span class="input-group-text" part="input-group-text">
         $
       </span>
       <input class="form-control is-invalid monetary" id="amount" name="amount" part="input-invalid input text color font-family background-color" type="text" value="1,500">
@@ -29,7 +29,7 @@ exports[`form-control-monetary-provisioning renders correctly with default props
       Amount
     </label>
     <div class="input-group">
-      <span class="input-group-text" part="text color font-family">
+      <span class="input-group-text" part="input-group-text">
         $
       </span>
       <input class="form-control monetary" id="amount" name="amount" part="input-group input text color font-family background-color" type="text">

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -35,12 +35,6 @@ export const inputDisabled = `input-disabled ${input}`;
 export const inputFocused = `input-focused ${input}`;
 export const inputInvalidAndFocused = `input-invalid-and-focused ${input}`;
 
-export const inputAdornment = `input-group-text ${text}`;
-export const inputAdornmentInvalid = `input-invalid ${inputAdornment}`;
-export const inputAdornmentDisabled = `input-disabled ${inputAdornment}`;
-export const inputAdornmentFocused = `input-focused ${inputAdornment}`;
-export const inputAdornmentInvalidAndFocused = `input-invalid-and-focused ${inputAdornment}`;
-
 export const inputRadio = `input-radio`;
 export const inputRadioFocused = `input-radio-focused ${inputRadio}`;
 export const inputRadioChecked = `input-radio-checked ${inputRadio}`;
@@ -52,6 +46,8 @@ export const inputCheckboxInvalid = `input-checkbox-invalid ${inputCheckbox}`;
 export const inputCheckboxFocused = `input-checkbox-focused ${inputCheckbox}`;
 export const inputCheckboxChecked = `input-checkbox-checked ${inputCheckbox}`;
 export const inputCheckboxCheckedFocused = `input-checkbox-checked-focused ${inputCheckbox}`;
+
+export const inputAdornment = `input-group-text`;
 
 // Alert
 export const alert = `alert ${text}`;

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -35,6 +35,12 @@ export const inputDisabled = `input-disabled ${input}`;
 export const inputFocused = `input-focused ${input}`;
 export const inputInvalidAndFocused = `input-invalid-and-focused ${input}`;
 
+export const inputAdornment = `input-group-text ${text}`;
+export const inputAdornmentInvalid = `input-invalid ${inputAdornment}`;
+export const inputAdornmentDisabled = `input-disabled ${inputAdornment}`;
+export const inputAdornmentFocused = `input-focused ${inputAdornment}`;
+export const inputAdornmentInvalidAndFocused = `input-invalid-and-focused ${inputAdornment}`;
+
 export const inputRadio = `input-radio`;
 export const inputRadioFocused = `input-radio-focused ${inputRadio}`;
 export const inputRadioChecked = `input-radio-checked ${inputRadio}`;

--- a/packages/webcomponents/src/styles/parts.ts
+++ b/packages/webcomponents/src/styles/parts.ts
@@ -47,7 +47,7 @@ export const inputCheckboxFocused = `input-checkbox-focused ${inputCheckbox}`;
 export const inputCheckboxChecked = `input-checkbox-checked ${inputCheckbox}`;
 export const inputCheckboxCheckedFocused = `input-checkbox-checked-focused ${inputCheckbox}`;
 
-export const inputAdornment = `input-group-text`;
+export const inputAdornment = `input-adornment ${text}`;
 
 // Alert
 export const alert = `alert ${text}`;

--- a/packages/webcomponents/src/ui-components/form/form-control-monetary.tsx
+++ b/packages/webcomponents/src/ui-components/form/form-control-monetary.tsx
@@ -9,7 +9,7 @@ import {
   State,
 } from '@stencil/core';
 import { FormControlErrorText, FormControlHelpText } from '..';
-import { input, inputDisabled, inputFocused, inputInvalid, label, text } from '../../styles/parts';
+import { input, inputDisabled, inputFocused, inputInvalid, label, inputAdornment, inputAdornmentInvalid, inputAdornmentDisabled, inputAdornmentFocused } from '../../styles/parts';
 import { formatCurrency } from '../../utils/utils';
 
 @Component({
@@ -62,7 +62,7 @@ export class MonetaryInput {
     this.formControlInput.emit({ name: name, value: formatRawValue });
   }
 
-  private get part() {
+  private get inputPart() {
     if (this.errorText) {
       return inputInvalid;
     }
@@ -75,6 +75,19 @@ export class MonetaryInput {
     return input;
   }
 
+  private get inputAdornmentPart() {
+    if (this.errorText) {
+      return inputAdornmentInvalid;
+    }
+    if (this.disabled) {
+      return inputAdornmentDisabled
+    }
+    if (this.isFocused) {
+      return inputAdornmentFocused;
+    }
+    return inputAdornment;
+  }
+
   render() {
     return (
       <Host>
@@ -84,7 +97,7 @@ export class MonetaryInput {
           </label>
           <FormControlHelpText name={this.name} helpText={this.helpText} />
           <div class="input-group">
-            <span class="input-group-text" part={text}>$</span>
+            <span class="input-group-text" part={this.inputAdornmentPart}>$</span>
             <input
               ref={el => this.formControl = el}
               id={this.name}
@@ -98,7 +111,7 @@ export class MonetaryInput {
               onKeyDown={this.keyDownHandler}
               onPaste={this.keyDownHandler}
               maxLength={this.maxLength}
-              part={this.part}
+              part={this.inputPart}
               class={this.errorText ? "form-control is-invalid" : "form-control"}
               type="text"
               disabled={this.disabled}

--- a/packages/webcomponents/src/ui-components/form/form-control-monetary.tsx
+++ b/packages/webcomponents/src/ui-components/form/form-control-monetary.tsx
@@ -9,7 +9,7 @@ import {
   State,
 } from '@stencil/core';
 import { FormControlErrorText, FormControlHelpText } from '..';
-import { input, inputDisabled, inputFocused, inputInvalid, label, inputAdornment, inputAdornmentInvalid, inputAdornmentDisabled, inputAdornmentFocused } from '../../styles/parts';
+import { input, inputDisabled, inputFocused, inputInvalid, label, inputAdornment } from '../../styles/parts';
 import { formatCurrency } from '../../utils/utils';
 
 @Component({
@@ -75,19 +75,6 @@ export class MonetaryInput {
     return input;
   }
 
-  private get inputAdornmentPart() {
-    if (this.errorText) {
-      return inputAdornmentInvalid;
-    }
-    if (this.disabled) {
-      return inputAdornmentDisabled
-    }
-    if (this.isFocused) {
-      return inputAdornmentFocused;
-    }
-    return inputAdornment;
-  }
-
   render() {
     return (
       <Host>
@@ -97,7 +84,7 @@ export class MonetaryInput {
           </label>
           <FormControlHelpText name={this.name} helpText={this.helpText} />
           <div class="input-group">
-            <span class="input-group-text" part={this.inputAdornmentPart}>$</span>
+            <span class="input-group-text" part={inputAdornment}>$</span>
             <input
               ref={el => this.formControl = el}
               id={this.name}

--- a/packages/webcomponents/src/ui-components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
+++ b/packages/webcomponents/src/ui-components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`form-control-monetary Renders with all props provided 1`] = `
       Enter payment amount
     </small>
     <div class="input-group">
-      <span class="input-group-text" part="text color font-family">
+      <span class="input-group-text" part="input-group-text">
         $
       </span>
       <input class="form-control is-invalid" id="amount" name="amount" part="input-invalid input text color font-family background-color" type="text" value="15.00">
@@ -29,7 +29,7 @@ exports[`form-control-monetary renders correctly with default props 1`] = `
       Amount
     </label>
     <div class="input-group">
-      <span class="input-group-text" part="text color font-family">
+      <span class="input-group-text" part="input-group-text">
         $
       </span>
       <input class="form-control" id="amount" name="amount" part="input text color font-family background-color" type="text" value="0.00">

--- a/packages/webcomponents/src/ui-components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
+++ b/packages/webcomponents/src/ui-components/form/test/__snapshots__/form-control-monetary.spec.tsx.snap
@@ -10,7 +10,7 @@ exports[`form-control-monetary Renders with all props provided 1`] = `
       Enter payment amount
     </small>
     <div class="input-group">
-      <span class="input-group-text" part="input-group-text">
+      <span class="input-group-text" part="input-adornment text color font-family">
         $
       </span>
       <input class="form-control is-invalid" id="amount" name="amount" part="input-invalid input text color font-family background-color" type="text" value="15.00">
@@ -29,7 +29,7 @@ exports[`form-control-monetary renders correctly with default props 1`] = `
       Amount
     </label>
     <div class="input-group">
-      <span class="input-group-text" part="input-group-text">
+      <span class="input-group-text" part="input-adornment text color font-family">
         $
       </span>
       <input class="form-control" id="amount" name="amount" part="input text color font-family background-color" type="text" value="0.00">


### PR DESCRIPTION
### Add CSS part for $ input adornment

This PR commits the following:

- Adds new part for input adornment shown with `form-control-monetary`
- Updates theme.css to add simple styling to the input adornment 


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/142


Developer QA steps
--------------------

- [x] Component library builds and runs
- [x] Test suites pass
- [x] Input adornment on `form-control-monetary` can be styled by targeting the new CSS part `input-group-text`(this is the name of the bootstrap class used to style the adornment from the official bootstrap docs) (this can be tested fairly simply by rendering the refund-payment.js example file and adjusting `theme.ts`)
- [x] **Light** theme on storybook successfully targets and styles input adornment (you may quickly check this by looking at the docs example for `BusinessForm` component)
- [x] **Dark** theme on storybook successfully targets and styles input adornment (you may quickly check this by looking at the docs example for `BusinessForm` component)


