### PR TITLE
`justifi-refund-payment` - Storybook Docs and Example File Improvements

### DIFF
--- a/.changeset/lovely-rabbits-call.md
+++ b/.changeset/lovely-rabbits-call.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": minor
+---
+
+Add new component: `justifi-refund-payment`. Can be used to render a form for partially or fully refunding a payment based on a provided payment ID.

--- a/apps/component-examples/css/example.css
+++ b/apps/component-examples/css/example.css
@@ -17,6 +17,7 @@
   flex-grow: 1;
   overflow-y: auto;
   width: 50vw;
+  padding: 20px;
 }
 
 .two-column-layout>.column-output {

--- a/apps/component-examples/examples/refund-payment.js
+++ b/apps/component-examples/examples/refund-payment.js
@@ -71,7 +71,7 @@ app.get('/', async (req, res) => {
       <body>
         <div class="list-component-wrapper">
           <justifi-refund-payment
-            payment-id="${paymentId}"
+            payment-id="py_2sceaivA00598CRrSY8l78"
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"
           />

--- a/apps/component-examples/examples/refund-payment.js
+++ b/apps/component-examples/examples/refund-payment.js
@@ -108,49 +108,44 @@ app.get('/', async (req, res) => {
             account-id="${subAccountId}"
             auth-token="${webComponentToken}"
             hide-submit-button="${hideSubmitButton}"
-          />
-          <button part="button" id="test-refund-button" ${hideSubmitButton ? '' : 'style="display: none;"'}>Refund</button>
+          >
+          </justifi-refund-payment>
+          <button id="test-refund-button" ${hideSubmitButton ? '' : 'style="display: none;"'}>Refund</button>
         </div>
         <div class="column-output" id="output-pane">
           <em>Refund output will appear here...</em>
         </div>
-        <script>
-          const justifiRefundPayment = document.querySelector('justifi-refund-payment');
-          const testSubmitButton = document.getElementById('test-refund-button');
-
-          function writeOutputToPage(event) {
-            document.getElementById('output-pane').innerHTML = '<code><pre>' + JSON.stringify(event.detail, null, 2) + '</pre></code>';
-          };
-
-          justifiRefundPayment.addEventListener('error-event', (event) => {
-            console.log('Error-event', event);
-            writeOutputToPage(event);
-          });
-
-          justifiRefundPayment.addEventListener('submit-event', (event) => {
-            if (event.detail.response.data) {
-              console.log('Response data from submit-event', event.detail.response.data);
-            }
-
-            if (event.detail.response.error) {
-              console.log('Error from submit-event', event.detail.response.error);
-            }
-
-            writeOutputToPage(event);
-          });
-
-          testSubmitButton.addEventListener('click', async () => {
-          const response = await justifiRefundPayment.refundPayment();
-            if (response.data) {
-              console.log('Response data from refund method', response.data);
-            }
-            
-            if (response.error) {
-              console.log('Error from refund method', response.error);
-            };
-          });
-        </script>
       </body>
+      <script>
+        const justifiRefundPayment = document.querySelector('justifi-refund-payment');
+        const testSubmitButton = document.getElementById('test-refund-button');
+
+        function writeOutputToPage(event) {
+          document.getElementById('output-pane').innerHTML = '<code><pre>' + JSON.stringify(event.detail, null, 2) + '</pre></code>';
+        };
+
+        justifiRefundPayment.addEventListener('error-event', (event) => {
+          console.log('Error-event', event);
+          writeOutputToPage(event);
+        });
+
+        justifiRefundPayment.addEventListener('submit-event', (event) => {
+          if (event.detail.response.data) {
+            console.log('Response data from submit-event', event.detail.response.data);
+          }
+
+          if (event.detail.response.error) {
+            console.log('Error from submit-event', event.detail.response.error);
+          }
+
+          writeOutputToPage(event);
+        });
+
+        testSubmitButton.addEventListener('click', async () => {
+          const refundData = await justifiRefundPayment.refundPayment();
+          console.log('Refund data', refundData);
+        });
+      </script>
     </html>
   `);
 });

--- a/apps/docs/stories/components/RefundPayment/Docs.mdx
+++ b/apps/docs/stories/components/RefundPayment/Docs.mdx
@@ -28,7 +28,7 @@ import { setUpMocks } from '../../utils/mockAllServices';
 
 ---
 
-Component to render a form for partially or fully refunding a payment based on based on a provided payment ID.
+Component to render a form for partially or fully refunding a payment based on a provided payment ID.
 
 # Index
 

--- a/apps/docs/stories/components/RefundPayment/Docs.mdx
+++ b/apps/docs/stories/components/RefundPayment/Docs.mdx
@@ -28,7 +28,7 @@ import { setUpMocks } from '../../utils/mockAllServices';
 
 ---
 
-Component to render a form for partially or fully refunding payments based on a provided payment ID.
+Component to render a form for partially or fully refunding a payment based on based on a provided payment ID.
 
 # Index
 

--- a/apps/docs/stories/components/RefundPayment/Docs.mdx
+++ b/apps/docs/stories/components/RefundPayment/Docs.mdx
@@ -1,0 +1,72 @@
+import {
+  Meta,
+  Title,
+  Subtitle,
+  Description,
+  ArgTypes,
+  Source,
+} from '@storybook/blocks';
+import dedent from 'ts-dedent';
+import { filterDocsByTag } from '../../utils';
+import example from './example';
+import {
+  Authorization,
+  ComponentBox,
+} from '../../utils/documentation-components';
+import * as JustifiRefundPayment from './index.stories.tsx';
+import { setUpMocks } from '../../utils/mockAllServices';
+
+{setUpMocks()}
+
+<Meta
+  title="Payment Facilitation/Refund Payment"
+  Components="justifi-refund-payment"
+  of={JustifiRefundPayment}
+/>
+
+<Title />
+
+---
+
+Component to render a form for partially or fully refunding payments based on a provided payment ID.
+
+# Index
+
+---
+
+- [Props, events and methods](#props-events-and-methods)
+- [Authorization](#authorization)
+- [Example usage](#example-usage)
+
+# Props, events and methods
+
+---
+
+<ArgTypes exclude={['Theme']} />
+
+# Authorization
+
+---
+
+<Authorization
+  actions={['write']}
+  entity="account"
+  identification="account_id"
+/>
+
+
+# Example Usage
+
+---
+
+<ComponentBox>
+  <justifi-refund-payment
+    payment-id="payment_123"
+    account-id="acc_123"
+    auth-token="web-component-token"
+  />
+</ComponentBox>
+
+---
+
+<Source dark language="html" code={example} />

--- a/apps/docs/stories/components/RefundPayment/example.ts
+++ b/apps/docs/stories/components/RefundPayment/example.ts
@@ -85,7 +85,7 @@ ${codeExampleHead(
   />
 
   <!-- Optional external button - this is only needed if the built in button is hidden via the hide-submit-button prop
-   and refund is submitted via provided refundPayment() method - see below. -->
+   and the refund is submitted via provided refundPayment() method - see below. -->
   <button id="submit-refund-button">Submit Refund</button>
 </body>
 

--- a/apps/docs/stories/components/RefundPayment/example.ts
+++ b/apps/docs/stories/components/RefundPayment/example.ts
@@ -83,6 +83,9 @@ ${codeExampleHead(
     auth-token="web-component-token"
     hide-submit-button="true"
   />
+
+  <!-- Optional external button - this is only needed if the built in button is hidden via the hide-submit-button prop
+   and refund is submitted via provided refundPayment() method - see below. -->
   <button id="submit-refund-button">Submit Refund</button>
 </body>
 
@@ -96,13 +99,15 @@ ${codeExampleHead(
     });
 
     refundForm.addEventListener("error-event", (event) => {
-      // here is where you would handle the error
+      /* here is where you would handle the error */
       console.error('error-event', event.detail);
     });
 
-    // manually call Refund with provided method, if built-in submit button is hidden
+    /* manually call Refund with provided method, if built-in submit button is hidden */
     document.getElementById("submit-refund-button").addEventListener("click", () => {
-      refundForm.refundPayment();
+      const refundData = await justifiRefundPayment.refundPayment();
+        console.log('Refund data', refundData);
+      });
     });
   })();
 </script>

--- a/apps/docs/stories/components/RefundPayment/example.ts
+++ b/apps/docs/stories/components/RefundPayment/example.ts
@@ -1,0 +1,109 @@
+import { codeExampleHead } from '../../utils';
+
+export default `<!DOCTYPE html>
+<html dir="ltr" lang="en">
+
+${codeExampleHead(
+  'justifi-refund-payment',
+  `<style>
+    ::part(font-family) {
+      font-family: georgia;
+    }
+
+    ::part(color) {
+      color: darkslategray;
+    }
+
+    ::part(background-color) {
+      background-color: transparent;
+    }
+
+    ::part(button) {
+      padding: 0.375rem 0.75rem;
+      font-size: 16px;
+      box-shadow: none;
+      border-radius: 0px;
+      line-height: 1.5;
+      text-transform: none;
+    }
+
+    ::part(button-disabled) {
+      opacity: 0.5;
+    }
+
+    ::part(input) {
+      border-color: #555;
+      border-width: 1px;
+      border-bottom-width: 1px;
+      border-left-width: 1px;
+      border-right-width: 1px;
+      border-top-width: 1px;
+      border-radius: 0;
+      border-style: solid;
+      box-shadow: none;
+      font-size: 1rem;
+      font-weight: normal;
+      line-height: 1.5;
+      padding: 0.375rem 0.75rem;
+    }
+
+    ::part(input-focused) {
+      border-color: #333;
+      box-shadow: 0 0 0 0.25rem rgba(0, 0, 0, 0.25);
+    }
+
+    ::part(input-invalid) {
+      border-color: #8a2a35;
+      box-shadow: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
+    }
+
+    ::part(input-invalid-and-focused) {
+      box-shadow: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
+      border-color: #8a2a35;
+    }
+
+    ::part(button-primary) {
+      color: #333;
+      background-color: transparent;
+      border-color: #333;
+    }
+
+    ::part(button-primary):hover {
+      background-color: rgba(0, 0, 0, .05);
+      border-color: #333;
+      color: #333;
+    }
+    </style>`
+)}
+
+<body>
+  <justifi-refund-payment
+    payment-id="payment_123"
+    account-id="acc_123"
+    auth-token="web-component-token"
+    hide-submit-button="true"
+  />
+  <button id="submit-refund-button">Submit Refund</button>
+</body>
+
+<script>
+  (function () {
+    var refundForm = document.querySelector("justifi-refund-payment");
+
+    refundForm.addEventListener("submit-event", (event) => {
+      /* this event is raised when the server response is received */
+      console.log("server response received", event.detail.response);
+    });
+
+    refundForm.addEventListener("error-event", (event) => {
+      // here is where you would handle the error
+      console.error('error-event', event.detail);
+    });
+
+    // manually call Refund with provided method, if built-in submit button is hidden
+    document.getElementById("submit-refund-button").addEventListener("click", () => {
+      refundForm.refundPayment();
+    });
+  })();
+</script>
+</html>`;

--- a/apps/docs/stories/components/RefundPayment/index.stories.tsx
+++ b/apps/docs/stories/components/RefundPayment/index.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta } from "@storybook/web-components";
+import { withActions } from "@storybook/addon-actions/decorator";
+import { StoryBaseArgs, customStoryDecorator } from "../../utils";
+
+import "@justifi/webcomponents/dist/module/justifi-refund-payment";
+import { ThemeNames } from "../../themes";
+
+const storyBaseArgs = new StoryBaseArgs([
+  "payment-id",
+  "account-id",
+  "auth-token",
+]);
+
+const meta: Meta = {
+  title: "Payment Facilitation/Refund Payment",
+  component: "justifi-refund-payment",
+  args: {
+    ...storyBaseArgs.args,
+    Theme: ThemeNames.Light,
+  },
+  argTypes: {
+    ...storyBaseArgs.argTypes,
+    Theme: {
+      description:
+        "Select a theme to preview the component in. [See example](https://storybook.justifi.ai/?path=/docs/introduction--docs#styling)",
+      options: Object.values(ThemeNames),
+      control: {
+        type: "select",
+      },
+    },
+    "hide-submit-button": {
+      type: "boolean",
+      description:
+        "Boolean indicating if the internal submit button should be hidden. Can be used in combination with an external button and calling the `refundPayment` method directly",
+      control: {
+        type: "boolean",
+      },
+      table: {
+        category: "props",
+        defaultValue: { summary: "false" },
+      },
+    },
+    "submit-event": {
+      description: "Emitted upon successful refund of a payment",
+      table: {
+        category: "events",
+        defaultValue: {
+          summary: "Returns the full response of the submitted refund request as `event.detail.response`",
+        },
+      },
+      action: true
+    },
+    "error-event": {
+      description: "Emitted upon an error during component intitializtion, or refund of a payment",
+      table: {
+        category: "events",
+        defaultValue: { summary: "Returns full error as `event.detail` and error message as `event.detail.message`" },
+      },
+      action: true,
+    },
+    refundPayment: {
+      description: "Can be used to call the refundPayment method programmatically with an external button. Ideally used in conjunction with the `hide-submit-button` prop.",
+      table: {
+        category: "methods",
+        defaultValue: { 
+          summary: "`refundPayment() => Promise<RefundPaymentResponse>`",
+          detail: "RefundPaymentResponse: { data: { amount: number, created_at: string, updated_at: string, description: string | null, reason: string | null, metadata: any, id: string, payment_id: string, status: Enum: 'pending' 'succeeded' 'failed'}}"
+         }
+      },
+    },
+  },
+  parameters: {
+    actions: {
+      handles: ["submit-event", "error-event"],
+    },
+    chromatic: {
+      delay: 2000,
+    },
+  },
+  decorators: [
+    customStoryDecorator,
+    withActions
+  ],
+};
+
+const Template = {};
+
+export const Example = Template;
+
+export default meta;

--- a/apps/docs/stories/components/RefundPayment/index.stories.tsx
+++ b/apps/docs/stories/components/RefundPayment/index.stories.tsx
@@ -64,7 +64,7 @@ const meta: Meta = {
         category: "methods",
         defaultValue: { 
           summary: "`refundPayment() => Promise<RefundPaymentResponse>`",
-          detail: "RefundPaymentResponse: { data: { amount: number, created_at: string, updated_at: string, description: string | null, reason: string | null, metadata: any, id: string, payment_id: string, status: Enum: 'pending' 'succeeded' 'failed'}}"
+          detail: "RefundPaymentResponse: { amount: number, created_at: string, updated_at: string, description: string | null, reason: string | null, metadata: any, id: string, payment_id: string, status: Enum: 'pending' 'succeeded' 'failed'}"
          }
       },
     },

--- a/apps/docs/stories/components/RefundPayment/index.stories.tsx
+++ b/apps/docs/stories/components/RefundPayment/index.stories.tsx
@@ -51,7 +51,7 @@ const meta: Meta = {
       action: true
     },
     "error-event": {
-      description: "Emitted upon an error during component intitializtion, or refund of a payment",
+      description: "Emitted during component initialization or refund processing errors",
       table: {
         category: "events",
         defaultValue: { summary: "Returns full error as `event.detail` and error message as `event.detail.message`" },

--- a/apps/docs/stories/utils/mockAllServices.ts
+++ b/apps/docs/stories/utils/mockAllServices.ts
@@ -10,6 +10,7 @@ import mockCheckoutsList from '../../../../mockData/mockGetCheckoutsListSuccess.
 import mockGrossPaymentChart from '../../../../mockData/mockGrossVolumeReportSuccess.json';
 import mockPayment from '../../../../mockData/mockPaymentDetailSuccess.json';
 import mockPayments from '../../../../mockData/mockPaymentsSuccess.json';
+import mockRefundResponse from '../../../../mockData/mockPostRefundSuccess.json';
 import mockPostPaymentMethods from '../../../../mockData/mockPostPaymentMethodsSuccess.json';
 import mockPayout from '../../../../mockData/mockPayoutDetailsSuccess.json';
 import mockPayouts from '../../../../mockData/mockPayoutsSuccess.json';
@@ -59,6 +60,7 @@ export const API_PATHS = {
   PAYMENT_DETAILS: '/payments/:id',
   PAYMENTS_LIST: '/account/:id/payments',
   PAYMENT_METHODS: '/payment_methods',
+  REFUND: '/payments/:id/refunds',
   PAYOUT_DETAILS: '/payouts/:id',
   PAYOUTS_LIST: '/account/:id/payouts',
   INSURANCE_QUOTES: '/insurance/quotes',
@@ -133,6 +135,9 @@ export const setUpMocks = () => {
 
       // PaymentsList
       this.get(API_PATHS.PAYMENTS_LIST, () => mockPayments);
+
+      // Post Refund
+      this.post(API_PATHS.REFUND, () => mockRefundResponse);
 
       // PayoutDetails
       this.get(API_PATHS.PAYOUT_DETAILS, () => mockPayout);

--- a/mockData/mockPostRefundSuccess.json
+++ b/mockData/mockPostRefundSuccess.json
@@ -1,0 +1,16 @@
+{
+  "id": 1,
+  "type": "refund",
+  "data": {
+  "id": "re_xyz",
+  "payment_id": "py_xyz",
+  "amount": 23456,
+  "description": "customer canceled their order",
+  "reason": "duplicate",
+  "status": "succeeded",
+  "metadata": { },
+  "created_at": "2021-01-01T12:00:00Z",
+  "updated_at": "2021-01-01T12:00:00Z"
+  },
+  "page_info": "string"
+  }

--- a/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
+++ b/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
@@ -121,7 +121,7 @@ export class RefundPayment {
   }
 
   @Method()
-  async handleSubmit(event) {
+  async refundPayment(event) {
     event.preventDefault();
     this.formController.validateAndSubmit(() => this.submitRefund());
   }
@@ -152,6 +152,7 @@ export class RefundPayment {
         this.submitEvent.emit({ response: refundResponse });
         this.submitDisabled = true;
         this.refundLoading = false;
+        return refundResponse;
       }
     })
   }
@@ -202,7 +203,7 @@ export class RefundPayment {
                 <Button
                   variant="primary"
                   type="submit"
-                  onClick={this.handleSubmit.bind(this)}
+                  onClick={this.refundPayment.bind(this)}
                   isLoading={this.paymentLoading || this.refundLoading}
                   hidden={this.hideSubmitButton}
                   disabled={this.submitDisabled}

--- a/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
+++ b/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
@@ -8,7 +8,7 @@ import {
   Method
 } from '@stencil/core';
 import RefundPaymentSchema from './refund-payment-schema';
-import { ComponentErrorCodes, ComponentErrorEvent, ComponentErrorSeverity, ComponentSubmitEvent, IRefundPayload, RefundPayload } from '../../api';
+import { ComponentErrorCodes, ComponentErrorEvent, ComponentErrorSeverity, ComponentSubmitEvent, IApiResponse, IRefund, IRefundPayload, RefundPayload } from '../../api';
 import { FormController } from '../../ui-components/form/form';
 import { Button, StyledHost } from '../../ui-components';
 import { formatCurrency } from '../../utils/utils';
@@ -120,13 +120,14 @@ export class RefundPayment {
     }
   }
 
+  
   @Method()
-  async refundPayment(event) {
-    event.preventDefault();
-    this.formController.validateAndSubmit(() => this.submitRefund());
-  }
+  async refundPayment(event?: CustomEvent): Promise<IRefund> {
+    event && event.preventDefault();
 
-  async submitRefund() {
+    const valid = await this.formController.validate();
+    if (!valid) return;
+
     const postRefund = makePostRefund({
       authToken: this.authToken,
       accountId: this.accountId,
@@ -137,24 +138,24 @@ export class RefundPayment {
     const values = this.formController.values.getValue();
     this.refundLoading = true;
 
-    let refundResponse;
-
-    postRefund({
-      refundBody: values,
-      onSuccess: (response) => {
-        refundResponse = response;
-      },
-      onError: ({ error, code, severity }) => {
-        refundResponse = error;
-        this.handleError(error, code, severity);
-      },
-      final: () => {
-        this.submitEvent.emit({ response: refundResponse });
-        this.submitDisabled = true;
-        this.refundLoading = false;
-        return refundResponse;
-      }
-    })
+    return new Promise((resolve) => {
+      let refundResponse: IApiResponse<IRefund>;
+  
+      postRefund({
+        refundBody: values,
+        onSuccess: (response) => { refundResponse = response; },
+        onError: ({ error, code, severity }) => {
+          refundResponse = error;
+          this.handleError(error, code, severity);
+        },
+        final: () => {
+          this.submitEvent.emit({ response: refundResponse });
+          this.submitDisabled = true;
+          this.refundLoading = false;
+          resolve(refundResponse.data);
+        },
+      });
+    });
   }
   
   render() {


### PR DESCRIPTION
### `justifi-refund-payment` - Storybook Docs and Example File Improvements

This PR commits the following changes:

- Adds documentation files for `justifi-refund-payment` component to Storybook
- Renames component method `handleSubmit` => `refundPayment`
- Improves example file by showing event usage, rendering output column on page, showing method usage


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/64

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

General:

- [x] Components build and run as expected
- [x] Test suites pass

Storybook: 
`pnpm dev`

- [x] Refund docs page sections are organized and index can be used to navigate between them
- [x] authorization section is accurate to roles/resources required
- [x] Component example code block is accurate and helpful
- [x] Props, Events, Methods section is accurate and descriptive
- [x] Component example page functions with mock data. successfully fetches mock payment info and makes successful refund request returning mock refund data
- [x] component example looks acceptable in Bootstrap default, Light, and Dark themes


Component Example
`pnpm dev:refund-payment`

- [x] Component example file automatically creates new payment for $10 USD when starting up
- [x] Created payment can be partially refunded
- [x] created payment can be fully refunded
- [x] refund output is successfully written to column showing response output
- [x] on line 93 of the example file - set `hideSubmitButton` to true. Refresh and verify that this successfully hides the component's provided submit button and renders a custom button from the example file HTML
- [x] the custom button can be used to successfully call the refund method from within the component