### PR TITLE
Fix background issue in terminal-quantity-selector component by updat…

### DIFF
--- a/.changeset/clean-worlds-ask.md
+++ b/.changeset/clean-worlds-ask.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Use a more correct CSS part in the terminal-quantity-selector card compoonent on the Order Terminals to fix background issue

--- a/packages/webcomponents/src/components/order-terminals/terminal-quantity-selector/terminal-quantity-selector.tsx
+++ b/packages/webcomponents/src/components/order-terminals/terminal-quantity-selector/terminal-quantity-selector.tsx
@@ -1,5 +1,5 @@
 import { Component, Event, EventEmitter, h, Prop, State } from "@stencil/core";
-import { buttonLink, image, text } from "../../../styles/parts";
+import { buttonLink, card, image } from "../../../styles/parts";
 import { TerminalModelName } from "../../../api";
 
 @Component({
@@ -33,7 +33,7 @@ export class TerminalQuantitySelector {
 
   render() {
     return (
-      <div class="rounded shadow-sm card p-2" part={text}>
+      <div class="rounded shadow-sm card p-2" part={card}>
         <div class="d-flex gap-3">
           <div class="d-flex align-items-center">
             <img src={this.imageUrl} alt={this.modelName} height={75} width={75} part={image} />

--- a/packages/webcomponents/src/components/order-terminals/terminal-quantity-selector/test/__snapshots__/terminal-quantity-selector.spec.tsx.snap
+++ b/packages/webcomponents/src/components/order-terminals/terminal-quantity-selector/test/__snapshots__/terminal-quantity-selector.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`justifi-terminal-quantity-selector should render with all props provided 1`] = `
 <terminal-quantity-selector>
-  <div class="card p-2 rounded shadow-sm" part="text color font-family">
+  <div class="card p-2 rounded shadow-sm" part="card text color font-family background-color">
     <div class="d-flex gap-3">
       <div class="align-items-center d-flex">
         <img alt="v400" height="75" part="image" src="https://device-image.com" width="75">


### PR DESCRIPTION
**This PR commits the following changes:**

`justifi-order-terminals` -> `terminal-quantity-selector` -> `.card`:  Change the applied CSS part to be `card` instead of `text`. - The `card` part is basically `text` + `background`.

**Before**
![image](https://github.com/user-attachments/assets/f0190e0b-8987-4c9e-808e-57fc4b0de240)


**After**
![image](https://github.com/user-attachments/assets/0575fdcf-3254-43dc-8e5a-42ecc53741a3)


Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/169

Developer QA steps
--------------------
- [ ] - Text inside the `terminal-quantity-selector` should be visible on dark background. 
