### PR TITLE
Add new terminal order statuses

### DIFF
--- a/.changeset/fruity-socks-smell.md
+++ b/.changeset/fruity-socks-smell.md
@@ -2,4 +2,4 @@
 "@justifi/webcomponents": patch
 ---
 
-`justifi-terminal-orders-list` shows new terminal order statuses returned from API response: `in_progress`, `on_hold`, `cancelled`.
+`justifi-terminal-orders-list` shows new terminal order statuses returned from API response: `in_progress`, `on_hold`, `canceled`. The matching filter component `justifi-terminal-orders-list-filters` now also shows these options when filtering by order status.

--- a/.changeset/fruity-socks-smell.md
+++ b/.changeset/fruity-socks-smell.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+`justifi-terminal-orders-list` shows new terminal order statuses returned from API response: `in_progress`, `on_hold`, `cancelled`.

--- a/mockData/mockTerminalOrdersListSuccess.json
+++ b/mockData/mockTerminalOrdersListSuccess.json
@@ -118,7 +118,7 @@
       "sub_account_id": "acc_3333",
       "provider": "verifone",
       "order_type": "boarding_shipping",
-      "order_status": "cancelled",
+      "order_status": "canceled",
       "terminals": [
         {
           "terminal_id": "tmn_ZZAA",

--- a/mockData/mockTerminalOrdersListSuccess.json
+++ b/mockData/mockTerminalOrdersListSuccess.json
@@ -38,6 +38,21 @@
           "terminal_id": "tmn_ASDF",
           "terminal_did": "33334444",
           "model_name": "e355"
+        },
+        {
+          "terminal_id": "tmn_ZXCV",
+          "terminal_did": "55556666",
+          "model_name": "e355"
+        },
+        {
+          "terminal_id": "tmn_QWAS",
+          "terminal_did": "77778888",
+          "model_name": "e355"
+        },
+        {
+          "terminal_id": "tmn_QWAS",
+          "terminal_did": "99990000",
+          "model_name": "e355"
         }
       ],
       "created_at": "2025-02-10T09:20:00Z",
@@ -54,6 +69,11 @@
         {
           "terminal_id": "tmn_TT99",
           "terminal_did": "99887766",
+          "model_name": "v400"
+        },
+        {
+          "terminal_id": "tmn_YYZZ",
+          "terminal_did": "55443322",
           "model_name": "v400"
         }
       ],
@@ -72,10 +92,69 @@
           "terminal_id": "tmn_XXYY",
           "terminal_did": "55667788",
           "model_name": "e355"
+        },
+        {
+          "terminal_id": "tmn_AABB",
+          "terminal_did": "99887766",
+          "model_name": "e355"
+        },
+        {
+          "terminal_id": "tmn_CCDD",
+          "terminal_did": "22334455",
+          "model_name": "e355"
+        },
+        {
+          "terminal_id": "tmn_EEFF",
+          "terminal_did": "66778899",
+          "model_name": "e355"
         }
       ],
       "created_at": "2025-04-05T11:50:00Z",
       "updated_at": "2025-04-05T12:10:00Z"
+    },
+    {
+      "id": "tord_JKL12345678",
+      "business_id": "biz_4444",
+      "sub_account_id": "acc_3333",
+      "provider": "verifone",
+      "order_type": "boarding_shipping",
+      "order_status": "cancelled",
+      "terminals": [
+        {
+          "terminal_id": "tmn_ZZAA",
+          "terminal_did": "11223344",
+          "model_name": "v400"
+        },
+        {
+          "terminal_id": "tmn_BBCC",
+          "terminal_did": "55667788",
+          "model_name": "v400"
+        }
+      ],
+      "created_at": "2025-05-15T14:00:00Z",
+      "updated_at": "2025-05-15T14:20:00Z"
+    },
+    {
+      "id": "tord_MNO98765432",
+      "business_id": "biz_2222",
+      "sub_account_id": "acc_1111",
+      "provider": "verifone",
+      "order_type": "boarding_only",
+      "order_status": "on_hold",
+      "terminals": [
+        {
+          "terminal_id": "tmn_QWERTY",
+          "terminal_did": "22334455",
+          "model_name": "e355"
+        },
+        {
+          "terminal_id": "tmn_BBCC",
+          "terminal_did": "44556677",
+          "model_name": "e355"
+        }
+      ],
+      "created_at": "2025-06-20T08:30:00Z",
+      "updated_at": "2025-06-20T08:45:00Z"
     }
   ]
 }

--- a/mockData/mockTerminalOrdersListSuccess.json
+++ b/mockData/mockTerminalOrdersListSuccess.json
@@ -135,6 +135,23 @@
       "updated_at": "2025-05-15T14:20:00Z"
     },
     {
+      "id": "tord_PQR12345678",
+      "business_id": "biz_8888",
+      "sub_account_id": "acc_2222",
+      "provider": "verifone",
+      "order_type": "boarding_shipping",
+      "order_status": "in_progress",
+      "terminals": [
+        {
+          "terminal_id": "tmn_QWERTY",
+          "terminal_did": "22334455",
+          "model_name": "e355"
+        }
+      ],
+      "created_at": "2025-06-01T08:00:00Z",
+      "updated_at": "2025-06-01T08:15:00Z"
+    },
+    {
       "id": "tord_MNO98765432",
       "business_id": "biz_2222",
       "sub_account_id": "acc_1111",

--- a/packages/webcomponents/src/api/TerminalOrder.ts
+++ b/packages/webcomponents/src/api/TerminalOrder.ts
@@ -19,7 +19,7 @@ export enum TerminalOrderStatus {
   completed = 'completed',
   in_progress = 'in_progress',
   on_hold = 'on_hold',
-  cancelled = 'cancelled'
+  canceled = 'canceled'
 }
 
 // This is the interface for the terminal item returned from the API response

--- a/packages/webcomponents/src/api/TerminalOrder.ts
+++ b/packages/webcomponents/src/api/TerminalOrder.ts
@@ -17,6 +17,9 @@ export enum TerminalOrderStatus {
   created = 'created',
   submitted = 'submitted',
   completed = 'completed',
+  in_progress = 'in_progress',
+  on_hold = 'on_hold',
+  cancelled = 'cancelled'
 }
 
 // This is the interface for the terminal item returned from the API response

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
@@ -29,7 +29,7 @@ export const MapTerminalOrderStatusToBadge = (status: TerminalOrderStatus) => {
       title: 'This order is on hold',
       text: 'On Hold',
     },
-    cancelled: {
+    canceled: {
       variant: BadgeVariant.DANGER,
       title: 'This order is canceled',
       text: 'Canceled',

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
@@ -19,6 +19,21 @@ export const MapTerminalOrderStatusToBadge = (status: TerminalOrderStatus) => {
       title: 'This order is created',
       text: 'Created',
     },
+    in_progress: {
+      variant: BadgeVariant.INFO,
+      title: 'This order is in progress',
+      text: 'In Progress',
+    },
+    on_hold: {
+      variant: BadgeVariant.WARNING,
+      title: 'This order is on hold',
+      text: 'On Hold',
+    },
+    cancelled: {
+      variant: BadgeVariant.DANGER,
+      title: 'This order is canceled',
+      text: 'Canceled',
+    }
   };
 
   const badgeProps = statusToBadgeProps[status];

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list-filters.tsx
@@ -45,12 +45,15 @@ export class TerminalOrdersListFilters {
     this.setParamsOnChange(name, utcDate);
   }
 
-  get terminalOrderStatusOptions(): { label: string, value: TerminalOrderStatus | '' }[] {
+  get terminalOrderStatusOptions(): { label: string, value: any | '' }[] {
     return [
       { label: 'All', value: '' },
       { label: 'Created', value: TerminalOrderStatus.created },
       { label: 'Completed', value: TerminalOrderStatus.completed },
       { label: 'Submitted', value: TerminalOrderStatus.submitted },
+      { label: 'In Progress', value: TerminalOrderStatus.in_progress },
+      { label: 'On Hold', value: TerminalOrderStatus.on_hold },
+      { label: 'Canceled', value: TerminalOrderStatus.canceled }
     ]
   }
 

--- a/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
@@ -137,7 +137,7 @@ exports[`terminal-orders-list-core renders properly with fetched data 1`] = `
               </span>
             </td>
             <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
-              1
+              4
             </td>
           </tr>
           <tr data-row-entity-id="tord_DEF55468789" data-test-id="table-row">
@@ -163,7 +163,7 @@ exports[`terminal-orders-list-core renders properly with fetched data 1`] = `
               </span>
             </td>
             <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
-              1
+              2
             </td>
           </tr>
           <tr data-row-entity-id="tord_GHI22168225" data-test-id="table-row">
@@ -189,7 +189,85 @@ exports[`terminal-orders-list-core renders properly with fetched data 1`] = `
               </span>
             </td>
             <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              4
+            </td>
+          </tr>
+          <tr data-row-entity-id="tord_JKL12345678" data-test-id="table-row">
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                May 15, 2025
+              </div>
+              <div class="fw-bold">
+                2:00pm
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                May 15, 2025
+              </div>
+              <div class="fw-bold">
+                2:20pm
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <span class="badge bg-danger" part="badge font-family badge-danger" title="This order is canceled">
+                Canceled
+              </span>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              2
+            </td>
+          </tr>
+          <tr data-row-entity-id="tord_PQR12345678" data-test-id="table-row">
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Jun 1, 2025
+              </div>
+              <div class="fw-bold">
+                8:00am
+              </div>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Jun 1, 2025
+              </div>
+              <div class="fw-bold">
+                8:15am
+              </div>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
+              <span class="badge bg-info" part="badge font-family badge-info" title="This order is in progress">
+                In Progress
+              </span>
+            </td>
+            <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
               1
+            </td>
+          </tr>
+          <tr data-row-entity-id="tord_MNO98765432" data-test-id="table-row">
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Jun 20, 2025
+              </div>
+              <div class="fw-bold">
+                8:30am
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <div class="fw-bold">
+                Jun 20, 2025
+              </div>
+              <div class="fw-bold">
+                8:45am
+              </div>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              <span class="badge bg-warning" part="badge font-family badge-warning" title="This order is on hold">
+                On Hold
+              </span>
+            </td>
+            <td part="table-cell-odd table-cell text color font-family background-color text color font-family background-color">
+              2
             </td>
           </tr>
         </tbody>


### PR DESCRIPTION
### Add new terminal order statuses

This PR commits the following changes:

- Adds support for new terminal order statuses:  `in_progress`, `on_hold`, `cancelled`
- Adds options to filter component's status input to show new statuses
- Adds badge mapping for new statuses to display on terminal-orders-list
- Updates mock data to add new orders showing new statuses


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/161


Developer QA steps
--------------------

This one will be easiest to test by quickly loading storybook which will show the component with mock data

- [x] component library builds and runs
- [x] test suites pass
- [x] `pnpm dev` to run storybook - confirm new statuses are showing on terminal-orders-list with badges
- [x] `pnpm dev:terminal-orders-list-with-filters` - confirm new status options show in status filter input
- [x] new status options successfully apply query params to list endpoint request

