### PR TITLE
Add JustifiCardForm and CardFormSkeleton components

### DIFF
--- a/apps/component-examples/examples/modular-checkout.js
+++ b/apps/component-examples/examples/modular-checkout.js
@@ -100,10 +100,10 @@ app.get('/', async (req, res) => {
             account-id="${subAccountId}"
             checkout-id="${checkout.id}"
           >
-            <justifi-tokenize-payment-method ]
-              hide-card-billing-form="true"
-            />
-            <button id="submit-button" class="button">Submit</button>
+            <justifi-card-form></justifi-card-form>
+            <div style="margin-top: 20px;">
+              <button id="submit-button" class="button">Submit</button>
+            </div>
           </justifi-checkout-wrapper>
         </div>
       </body>
@@ -112,7 +112,8 @@ app.get('/', async (req, res) => {
         const checkoutWrapper = document.querySelector('justifi-checkout-wrapper');
 
         submitButton.addEventListener('click', async () => {
-          const { token } = await checkoutWrapper.submit();
+          const addressPostalCode = '12345';
+          const { token } = await checkoutWrapper.tokenizePaymentMethod({ addressPostalCode });
           console.log(token);
         });
       </script>

--- a/apps/component-examples/examples/modular-checkout.js
+++ b/apps/component-examples/examples/modular-checkout.js
@@ -101,8 +101,14 @@ app.get('/', async (req, res) => {
             checkout-id="${checkout.id}"
           >
             <justifi-card-form></justifi-card-form>
-            <div style="margin-top: 20px;">
-              <button id="submit-button" class="button">Submit</button>
+            <div style="margin-top: 20px">
+              <button
+               id="submit-button" 
+               class="button"
+               style="padding:10px"
+              >
+                Submit Checkout
+              </button>
             </div>
           </justifi-checkout-wrapper>
         </div>
@@ -113,8 +119,8 @@ app.get('/', async (req, res) => {
 
         submitButton.addEventListener('click', async () => {
           const addressPostalCode = '12345';
-          const { token } = await checkoutWrapper.tokenizePaymentMethod({ addressPostalCode });
-          console.log(token);
+          const { id } = await checkoutWrapper.submitCheckout({ addressPostalCode });
+          console.log('token: ', id);
         });
       </script>
     </html>

--- a/packages/webcomponents/src/components/checkout-wrapper/checkout-wrapper.tsx
+++ b/packages/webcomponents/src/components/checkout-wrapper/checkout-wrapper.tsx
@@ -26,10 +26,6 @@ export class CheckoutWrapper {
 
   componentDidLoad() {
     this.cardFormRef = this.hostEl.querySelector('justifi-card-form');
-
-    if (this.cardFormRef) {
-      console.log('Card form loaded!', this.cardFormRef);
-    }
   }
 
   @Method()
@@ -59,6 +55,12 @@ export class CheckoutWrapper {
     } else {
       throw new Error('CardForm component not found');
     }
+  }
+
+  @Method()
+  async submitCheckout({ addressPostalCode }: { addressPostalCode?: number }): Promise<any> {
+    const tokenizeResponse = await this.tokenizePaymentMethod({ addressPostalCode });
+    return tokenizeResponse;
   }
 
   render() {

--- a/packages/webcomponents/src/components/checkout-wrapper/checkout-wrapper.tsx
+++ b/packages/webcomponents/src/components/checkout-wrapper/checkout-wrapper.tsx
@@ -1,5 +1,7 @@
 import { Component, Element, h, Method, Prop } from "@stencil/core";
 import checkoutStore from "../../store/checkout.store";
+import JustifiAnalytics from "../../api/Analytics";
+import { checkPkgVersion } from "../../utils/check-pkg-version";
 
 @Component({
   tag: 'justifi-checkout-wrapper',
@@ -11,29 +13,51 @@ export class CheckoutWrapper {
 
   @Element() hostEl: HTMLElement;
 
-  private tokenizePaymentMethodRef?: HTMLJustifiTokenizePaymentMethodElement;
+  private cardFormRef?: HTMLJustifiCardFormElement;
 
+  analytics: JustifiAnalytics;
 
   componentWillLoad() {
+    this.analytics = new JustifiAnalytics(this);
+    checkPkgVersion();
     checkoutStore.authToken = this.authToken;
     checkoutStore.accountId = this.accountId;
   }
 
   componentDidLoad() {
-    this.tokenizePaymentMethodRef = this.hostEl.querySelector('justifi-tokenize-payment-method');
+    this.cardFormRef = this.hostEl.querySelector('justifi-card-form');
 
-    if (this.tokenizePaymentMethodRef) {
-      console.log('Tokenize component loaded!', this.tokenizePaymentMethodRef);
+    if (this.cardFormRef) {
+      console.log('Card form loaded!', this.cardFormRef);
     }
   }
 
   @Method()
-  async tokenizePaymentMethod(event?: CustomEvent): Promise<any> {
-    event && event.preventDefault();
-    if (this.tokenizePaymentMethodRef) {
-      return this.tokenizePaymentMethodRef.tokenizePaymentMethod(event);
+  async validate(): Promise<boolean> {
+    if (this.cardFormRef) {
+      return this.cardFormRef.validate();
     } else {
-      throw new Error('TokenizePaymentMethod component not found');
+      throw new Error('CardForm component not found');
+    }
+  }
+
+  @Method()
+  async tokenizePaymentMethod({ addressPostalCode }: { addressPostalCode?: number }): Promise<any> {
+    if (this.cardFormRef) {
+      const isValid = await this.cardFormRef.validate();
+      if (!isValid) {
+        throw new Error('Card form is not valid');
+      }
+      return this.cardFormRef.tokenize({
+        clientId: this.authToken,
+        paymentMethodMetadata: {
+          accountId: this.accountId,
+          address_postal_code: addressPostalCode
+        },
+        account: this.accountId,
+      });
+    } else {
+      throw new Error('CardForm component not found');
     }
   }
 

--- a/packages/webcomponents/src/components/modular-checkout-parts/card-form-skeleton.tsx
+++ b/packages/webcomponents/src/components/modular-checkout-parts/card-form-skeleton.tsx
@@ -1,0 +1,38 @@
+import { FunctionalComponent, h } from "@stencil/core";
+import { Skeleton } from "../../ui-components";
+
+interface CardFormSkeletonProps {
+  isReady: boolean;
+}
+
+const CardFormSkeleton: FunctionalComponent<CardFormSkeletonProps> = (props) => {
+  const { isReady } = props;
+
+  if (isReady) {
+    return null;
+  }
+
+  return (
+    <div class="container-fluid p-0">
+      <div class="mb-3">
+        <Skeleton height="18px" width="100px" />
+        <Skeleton height="36px" />
+      </div>
+      <div class="row">
+        <div class="col-4 align-content-end">
+          <Skeleton height="18px" width="80px" />
+          <Skeleton height="36px" />
+        </div>
+        <div class="col-4 align-content-end">
+          <Skeleton height="36px" />
+        </div>
+        <div class="col-4 align-content-end">
+          <Skeleton height="18px" width="30px" />
+          <Skeleton height="36px" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CardFormSkeleton;

--- a/packages/webcomponents/src/components/modular-checkout-parts/card-form.tsx
+++ b/packages/webcomponents/src/components/modular-checkout-parts/card-form.tsx
@@ -1,0 +1,122 @@
+import { Component, h, Method, Prop, State } from "@stencil/core";
+import CardFormSkeleton from "./card-form-skeleton";
+import { StyledHost } from "../../ui-components";
+import JustifiAnalytics from "../../api/Analytics";
+import { checkPkgVersion } from "../../utils/check-pkg-version";
+
+@Component({
+  tag: "justifi-card-form",
+  shadow: true,
+})
+export class JustifiCardForm {
+  @Prop() iframeOrigin?: string = IFRAME_ORIGIN;
+
+  @State() isReady: boolean = false;
+
+  private cardNumberIframeElement!: HTMLIframeInputElement;
+  private expirationMonthIframeElement!: HTMLIframeInputElement;
+  private expirationYearIframeElement!: HTMLIframeInputElement;
+  private cvvIframeElement!: HTMLIframeInputElement;
+
+  analytics: JustifiAnalytics;
+
+  componentWillLoad() {
+    checkPkgVersion();
+    this.analytics = new JustifiAnalytics(this);
+  }
+
+  componentDidRender() {
+    const elements = [
+      this.cardNumberIframeElement,
+      this.expirationMonthIframeElement,
+      this.expirationYearIframeElement,
+      this.cvvIframeElement,
+    ];
+
+    Promise.all(elements.map((element) => {
+      return new Promise<void>((resolve) => {
+        element.addEventListener('iframeLoaded', () => { resolve(); });
+      });
+    })).then(() => {
+      this.isReady = true;
+    });
+  }
+
+  disconnectedCallback() {
+    this.analytics.cleanup();
+  }
+
+  @Method()
+  async validate(): Promise<any> {
+    const cardNumberIsValid = await this.cardNumberIframeElement.validate();
+    const expirationMonthIsValid = await this.expirationMonthIframeElement.validate();
+    const expirationYearIsValid = await this.expirationYearIframeElement.validate();
+    const cvvIsValid = await this.cvvIframeElement.validate();
+    return cardNumberIsValid && expirationMonthIsValid && expirationYearIsValid && cvvIsValid;
+  }
+
+  @Method()
+  async tokenize({
+    clientId,
+    paymentMethodMetadata,
+    account,
+  }: {
+    clientId: string,
+    paymentMethodMetadata: any,
+    account?: string,
+  }) {
+    return this.cardNumberIframeElement.tokenize(
+      clientId,
+      paymentMethodMetadata,
+      account,
+    );
+  }
+
+  render() {
+    return (
+      <StyledHost>
+        <CardFormSkeleton isReady={this.isReady} />
+        <hidden-input />
+        <div class="container-fluid p-0" style={{
+          opacity: this.isReady ? '1' : '0',
+          height: this.isReady ? 'auto' : '0',
+        }}>
+          <div class="mb-3">
+            <iframe-input
+              inputId="cardNumber"
+              ref={(el) => (this.cardNumberIframeElement = el as HTMLIframeInputElement)}
+              label="Card Number"
+              iframeOrigin={`${this.iframeOrigin}/v2/cardNumber`}
+            />
+          </div>
+          <div class="row">
+            <div class="col-4 align-content-end">
+              <iframe-input
+                inputId="expirationMonth"
+                ref={(el) => (this.expirationMonthIframeElement = el as HTMLIframeInputElement)}
+                label="Expiration"
+                iframeOrigin={`${this.iframeOrigin}/v2/expirationMonth`}
+              />
+            </div>
+            <div class="col-4 align-content-end">
+              <iframe-input
+                inputId="expirationYear"
+                ref={(el) => (this.expirationYearIframeElement = el as HTMLIframeInputElement)}
+                label=""
+                iframeOrigin={`${this.iframeOrigin}/v2/expirationYear`}
+              />
+            </div>
+            <div class="col-4 align-content-end">
+              <iframe-input
+                inputId="CVV"
+                ref={(el) => (this.cvvIframeElement = el as HTMLIframeInputElement)}
+                label="CVV"
+                iframeOrigin={`${this.iframeOrigin}/v2/CVV`}
+              />
+            </div>
+          </div>
+        </div>
+      </StyledHost>
+    );
+  }
+}

--- a/packages/webcomponents/src/store/checkout.store.ts
+++ b/packages/webcomponents/src/store/checkout.store.ts
@@ -7,12 +7,10 @@ const { state, onChange } = createStore({
 
 onChange('authToken', (newValue) => {
   state.authToken = newValue;
-  console.log('Auth token changed:', newValue);
 });
 
 onChange('accountId', (newValue) => {
   state.accountId = newValue;
-  console.log('Account ID changed:', newValue);
 });
 
 export default state;

--- a/packages/webcomponents/src/ui-components/form/readme.md
+++ b/packages/webcomponents/src/ui-components/form/readme.md
@@ -56,12 +56,14 @@ Type: `Promise<any>`
 
  - [bank-account-form](../../components/checkout/bank-account-form)
  - [card-form](../../components/checkout/card-form)
+ - [justifi-card-form](../../components/modular-checkout-parts)
 
 ### Graph
 ```mermaid
 graph TD;
   bank-account-form --> iframe-input
   card-form --> iframe-input
+  justifi-card-form --> iframe-input
   style iframe-input fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
**This PR includes the following changes:**

* Adds the new `justifi-card-form` component to the `modular-checkout-parts` folder.
* Copies `card-form-skeleton` into the `modular-checkout-parts` folder.
* Updates `checkout-wrapper` → `tokenizePaymentMethod`: adds an `addressPostalCode` argument to handle cases where the user doesn’t include the `postal-code` component.

**Key differences between the new CardForm and the old one:**

* The new version uses Shadow DOM, `StyledHost`, and `hidden-input` to support styling, as the checkout wrapper doesn’t use Shadow DOM.
* It sets a default value for the `iframeOrigin` prop.
* It initializes `checkPkgVersion` and `analytics`.

Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/100

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
- Run `pnpm dev:modular-checkout`.

- [x] - You should see the `card-form` rendered and styles are good.
- [x] - The card form should show validation errors if attempted to submit without filling it.
- [x] - Fill it correctly, submit it, you should see the successful request in the network tab.
