### PR TITLE
Terminal Orders: Update in_progress status badge color to primary

### DIFF
--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-order-status.tsx
@@ -20,7 +20,7 @@ export const MapTerminalOrderStatusToBadge = (status: TerminalOrderStatus) => {
       text: 'Created',
     },
     in_progress: {
-      variant: BadgeVariant.INFO,
+      variant: BadgeVariant.PRIMARY,
       title: 'This order is in progress',
       text: 'In Progress',
     },

--- a/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/__snapshots__/terminal-orders-list-core.spec.tsx.snap
@@ -236,7 +236,7 @@ exports[`terminal-orders-list-core renders properly with fetched data 1`] = `
               </div>
             </td>
             <td part="table-cell-even table-cell text color font-family background-color text color font-family background-color">
-              <span class="badge bg-info" part="badge font-family badge-info" title="This order is in progress">
+              <span class="badge bg-primary" part="badge font-family badge-primary" title="This order is in progress">
                 In Progress
               </span>
             </td>


### PR DESCRIPTION
### Update in_progress status badge color to primary

This PR updates the status badge color on terminal orders with `in_progress` status. Updating the status badge to be the `primary` bootstrap badge




Developer QA steps
--------------------

- [x] components build and run as expected
- [x] test suites pass
- [x] `pnpm dev` and load terminal orders list example with mock data - verify that order with in_progress status shows the primary bootstrap badge styling

