### PR TITLE
New component: `payout-transactions-list`

### DIFF
--- a/apps/component-examples/examples/payout-transactions-list.js
+++ b/apps/component-examples/examples/payout-transactions-list.js
@@ -1,0 +1,97 @@
+require('dotenv').config({ path: '../../.env' });
+
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const subAccountId = process.env.SUB_ACCOUNT_ID;
+const payoutId = process.env.PAYOUT_ID;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
+
+app.use(
+  '/scripts',
+  express.static(__dirname + '/../node_modules/@justifi/webcomponents/dist/')
+);
+app.use('/styles', express.static(__dirname + '/../css/'));
+
+async function getToken() {
+  const requestBody = JSON.stringify({
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+
+  let response;
+  try {
+    response = await fetch(authTokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
+
+  const { access_token } = await response.json();
+  return access_token;
+}
+
+async function getWebComponentToken(token) {
+  const response = await fetch(webComponentTokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      resources: [`read:payments:${subAccountId}`],
+    }),
+  });
+
+  const { access_token } = await response.json();
+  return access_token;
+}
+
+app.get('/', async (req, res) => {
+  const token = await getToken();
+  const webComponentToken = await getWebComponentToken(token);
+
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>JustiFi Payout Transactions List Component</title>
+        <script type="module" src="/scripts/webcomponents/webcomponents.esm.js"></script>
+        <link rel="stylesheet" href="/styles/theme.css">
+        <link rel="stylesheet" href="/styles/example.css">
+      </head>
+      <body>
+        <div class="list-component-wrapper">
+          <justifi-payout-transactions-list
+            payout-id="${payoutId}"
+            auth-token="${webComponentToken}"
+            api-origin=
+          />
+        </div>
+        <script>
+          const justifiPayoutTransactionsList = document.querySelector('justifi-payout-transactions-list');
+
+          justifiPayoutTransactionsList.addEventListener('error-event', (event) => {
+            console.log(event);
+          });
+
+          justifiPayoutTransactionsList.addEventListener('click-event', (event) => {
+            console.log(event);
+          });
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -25,7 +25,8 @@
     "start:terminal-orders-list": "npx nodemon ./examples/terminal-orders-list.js",
     "start:terminal-orders-list-with-filters": "npx nodemon ./examples/terminal-orders-list-with-filters.js",
     "start:payment-details": "npx nodemon ./examples/payment-details.js",
-    "start:payout-details": "npx nodemon ./examples/payout-details.js"
+    "start:payout-details": "npx nodemon ./examples/payout-details.js",
+    "start:payout-transactions-list": "npx nodemon ./examples/payout-transactions-list.js"
   },
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev:terminal-orders-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:terminal-orders-list-with-filters'",
     "dev:payment-details": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payment-details'",
     "dev:payout-details": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payout-details'",
+    "dev:payout-transactions-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payout-transactions-list'",
     "preview-storybook": "turbo run preview-storybook",
     "lint": "turbo run lint",
     "clean": "turbo run clean && rm -rf node_modules",

--- a/packages/webcomponents/src/actions/payout/get-payout-transactions.ts
+++ b/packages/webcomponents/src/actions/payout/get-payout-transactions.ts
@@ -3,7 +3,7 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayoutTransactions =
-  ({ authToken, service, apiOrigin }) =>
+  ({  authToken, service, apiOrigin }) =>
   async ({ params, onSuccess, onError, final }) => {
     try {
       const response = await service.fetchPayoutTransactions(authToken, params, apiOrigin);

--- a/packages/webcomponents/src/actions/payout/get-payout-transactions.ts
+++ b/packages/webcomponents/src/actions/payout/get-payout-transactions.ts
@@ -1,0 +1,37 @@
+import { PayoutBalanceTransaction } from '../../api';
+import { ComponentErrorSeverity } from '../../api/ComponentError';
+import { getErrorCode, getErrorMessage } from '../../api/services/utils';
+
+export const makeGetPayoutTransactions =
+  ({ authToken, service, apiOrigin }) =>
+  async ({ params, onSuccess, onError, final }) => {
+    try {
+      const response = await service.fetchPayoutTransactions(authToken, params, apiOrigin);
+      if (!response.error) {
+        const balanceTransactions = response.data.map(
+          (dataItem) => new PayoutBalanceTransaction(dataItem)
+        );
+
+        const pagingInfo = { ...response.page_info };
+
+        onSuccess({ balanceTransactions, pagingInfo });
+      } else {
+        const responseError = getErrorMessage(response.error);
+        const code = getErrorCode(response.error?.code);
+        onError({
+          error: responseError,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
+      }
+    } catch (error) {
+      const code = getErrorCode(error?.code);
+      onError({
+        error: getErrorMessage(error),
+        code,
+        severity: ComponentErrorSeverity.ERROR,
+      });
+    } finally {
+      final();
+    }
+  };

--- a/packages/webcomponents/src/api/PayoutBalanceTransaction.ts
+++ b/packages/webcomponents/src/api/PayoutBalanceTransaction.ts
@@ -1,0 +1,69 @@
+import { formatCurrency } from "../utils/utils";
+import { CurrencyTypes } from "./Payment";
+
+export enum PayoutBalanceTransactionType {
+  fee = 'fee',
+  payment = 'payment',
+  payout = 'payout',
+  refund = 'seller_payment_refund',
+  dispute = 'dispute_amount_collected',
+  disputeFee = 'dispute_fee_collected',
+  sellerPayment = 'seller_payment',
+  transfer = 'transfer',
+  fromPayment = 'partner_platform_proceeds_credit'
+}
+
+export interface IPayoutBalanceTransaction {
+  id: string;
+  account_id: string;
+  payout_id: string;
+  financial_transaction_id: string;
+  amount: number;
+  fee: number;
+  net: number;
+  currency: CurrencyTypes;
+  description: string;
+  source_id: string;
+  txn_type: PayoutBalanceTransactionType;
+  created_at: string;
+  available_on: string;
+  updated_at: string;
+}
+
+export class PayoutBalanceTransaction implements IPayoutBalanceTransaction {
+  public id: string;
+  public account_id: string;
+  public payout_id: string;
+  public financial_transaction_id: string;
+  public amount: number;
+  public fee: number;
+  public net: number;
+  public currency: CurrencyTypes;
+  public description: string;
+  public source_id: string;
+  public txn_type: PayoutBalanceTransactionType;
+  public created_at: string;
+  public available_on: string;
+  public updated_at: string;
+
+  constructor(balanceTransaction: IPayoutBalanceTransaction) {
+    this.id = balanceTransaction.id;
+    this.account_id = balanceTransaction.account_id;
+    this.payout_id = balanceTransaction.payout_id;
+    this.financial_transaction_id = balanceTransaction.financial_transaction_id;
+    this.amount = balanceTransaction.amount;
+    this.fee = balanceTransaction.fee;
+    this.net = balanceTransaction.net;
+    this.currency = balanceTransaction.currency;
+    this.source_id = balanceTransaction.source_id;
+    this.description = balanceTransaction.description;
+    this.txn_type = balanceTransaction.txn_type;
+    this.created_at = balanceTransaction.created_at;
+    this.available_on = balanceTransaction.available_on;
+    this.updated_at = balanceTransaction.updated_at;
+  }
+
+  formattedPaymentAmount(amount: number): string {
+    return formatCurrency(amount, this.currency);
+  }
+};

--- a/packages/webcomponents/src/api/index.ts
+++ b/packages/webcomponents/src/api/index.ts
@@ -7,6 +7,7 @@ export * from './Insurance';
 export * from './Pagination';
 export * from './Payment';
 export * from './Payout';
+export * from './PayoutBalanceTransaction';
 export * from './Terminal';
 export * from './TerminalOrder';
 export * from './TerminalModel';

--- a/packages/webcomponents/src/api/services/payout.service.ts
+++ b/packages/webcomponents/src/api/services/payout.service.ts
@@ -1,4 +1,4 @@
-import { Api, IApiResponse, IApiResponseCollection, IPayout } from '..';
+import { Api, IApiResponse, IApiResponseCollection, IPayout, IPayoutBalanceTransaction } from '..';
 
 export interface IPayoutService {
   fetchPayouts(
@@ -17,6 +17,11 @@ export interface IPayoutService {
     authToken: string,
     apiOrigin?: string
   ): Promise<IApiResponse<any>>;
+  fetchPayoutTransactions(
+    authToken: string,
+    params: any,
+    apiOrigin?: string
+  ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>>;
 }
 
 export class PayoutService implements IPayoutService {
@@ -49,5 +54,15 @@ export class PayoutService implements IPayoutService {
     const api = Api({ authToken, apiOrigin });
     const endpoint = `reports/payouts/${payoutId}`;
     return api.get({ endpoint });
+  }
+
+  async fetchPayoutTransactions(
+    authToken: string,
+    params: any,
+    apiOrigin: string = PROXY_API_ORIGIN
+  ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>> {
+    const api = Api({ authToken, apiOrigin });
+    const endpoint = `balance_transactions`;
+    return api.get({ endpoint, params });
   }
 }

--- a/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-list.tsx
+++ b/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-list.tsx
@@ -1,0 +1,182 @@
+
+import { Component, h, Prop, State, Watch, Event, EventEmitter } from '@stencil/core';
+import { ComponentClickEvent, ComponentErrorCodes, ComponentErrorEvent, ComponentErrorSeverity, pagingDefaults, PagingInfo, PayoutBalanceTransaction } from '../../api';
+import JustifiAnalytics from '../../api/Analytics';
+import { checkPkgVersion } from '../../utils/check-pkg-version';
+import { makeGetPayoutTransactions } from '../../actions/payout/get-payout-transactions';
+import { PayoutService } from '../../api/services/payout.service';
+import { Table } from '../../utils/table';
+import { TableClickActions } from '../../ui-components/table/event-types';
+import { table, tableCell } from '../../styles/parts';
+import { StyledHost, TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
+import { defaultColumnsKeys, payoutTransactionTableCells, payoutTransactionTableColumns } from './payout-transactions-table';
+
+@Component({
+  tag: 'justifi-payout-transactions-list',
+  shadow: true
+})
+export class PayoutTransactionsList {
+  @State() balanceTransactions: PayoutBalanceTransaction[] = [];
+  @State() transactionsTable: Table<PayoutBalanceTransaction>;
+  @State() isLoading: boolean = true;
+  @State() errorMessage: string = null;
+  @State() paging: PagingInfo = pagingDefaults;
+  @State() pagingParams: any = {};
+
+  @Prop() payoutId: string;
+  @Prop() authToken: string;
+  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
+  @Prop() columns?: string = defaultColumnsKeys;
+
+  @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<ComponentClickEvent>;
+  @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
+  
+  analytics: JustifiAnalytics;
+
+  componentWillLoad() {
+    this.transactionsTable = new Table<PayoutBalanceTransaction>(this.balanceTransactions, this.columns, payoutTransactionTableColumns, payoutTransactionTableCells);
+    checkPkgVersion();
+    this.analytics = new JustifiAnalytics(this);
+    this.initializeApi();
+  }
+
+  disconnectedCallback() {
+    this.analytics.cleanup();
+  }
+
+  @Watch('payoutId')
+  @Watch('authToken')
+  propChanged() {
+    this.initializeApi();
+  }
+
+  private handleError(code: ComponentErrorCodes, errorMessage: string, severity: ComponentErrorSeverity) {
+    this.errorEvent.emit({ errorCode: code, message: errorMessage, severity });
+  }
+
+  private initializeApi() {
+    if (this.payoutId && this.authToken) {
+      const getPayoutTransactions = makeGetPayoutTransactions({
+        authToken: this.authToken,
+        service: new PayoutService(),
+        apiOrigin: this.apiOrigin
+      });
+
+      getPayoutTransactions({
+        params: this.requestParams,
+        onSuccess: ({ balanceTransactions, pagingInfo }) => {
+          this.balanceTransactions = balanceTransactions;
+          this.paging = pagingInfo;
+          this.transactionsTable.collectionData = this.balanceTransactions;
+        },
+        onError: ({ error, code, severity }) => {
+          this.errorMessage = error.message;
+          this.handleError(error, code, severity);
+        },
+        final: () => {
+          this.isLoading = false;
+        }
+      });
+    } else {
+      this.errorMessage = 'payout-id and auth-token props are required';
+      this.handleError(ComponentErrorCodes.MISSING_PROPS, this.errorMessage, ComponentErrorSeverity.ERROR);
+    }
+  }
+
+  handleClickPrevious = (beforeCursor: string) => {
+    this.pagingParams = { before_cursor: beforeCursor };
+    this.clickEvent.emit({ name: TableClickActions.previous });
+  };
+
+  handleClickNext = (afterCursor: string) => {
+    this.pagingParams = { after_cursor: afterCursor };
+    this.clickEvent.emit({ name: TableClickActions.next });
+  };
+
+  rowClickHandler = (e) => {
+    const clickedPayoutId = e.target.closest('tr').dataset.rowEntityId;
+    if (!clickedPayoutId) return;
+
+    const transactionData = this.balanceTransactions.find((payment) => payment.id === clickedPayoutId);
+    this.clickEvent.emit({ name: TableClickActions.row, data: transactionData });
+  };
+
+  get entityId() {
+    return this.balanceTransactions.map((transaction) => transaction.id);
+  }
+
+  get showEmptyState() {
+    return !this.isLoading && !this.errorMessage && this.transactionsTable.rowData.length < 1;
+  }
+
+  get showErrorState() {
+    return !this.isLoading && !!this.errorMessage;
+  }
+
+  get showRowData() {
+    return !this.showEmptyState && !this.showErrorState && !this.isLoading;
+  }
+
+  get requestParams() {
+    return {
+      payout_id: this.payoutId,
+      ...this.pagingParams
+    };
+  }
+
+  render() {
+    return (
+      <StyledHost>
+        <div>
+          <div class="table-wrapper">
+            <table class="table table-hover" part={table}>
+              <thead class="table-head sticky-top">
+                <tr class="table-light text-nowrap">
+                  {this.transactionsTable.columnData.map((column) => column)}
+                </tr>
+              </thead>
+              <tbody class="table-body">
+                <TableLoadingState
+                  columnSpan={this.transactionsTable.columnData.length}
+                  isLoading={this.isLoading}
+                />
+                <TableEmptyState
+                  isEmpty={this.showEmptyState}
+                  columnSpan={this.transactionsTable.columnData.length}
+                />
+                <TableErrorState
+                  columnSpan={this.transactionsTable.columnData.length}
+                  errorMessage={this.errorMessage}
+                />
+                {this.showRowData && this.transactionsTable.rowData.map((data, index) => (
+                  <tr
+                    data-test-id="table-row"
+                    data-row-entity-id={this.entityId[index]}
+                    onClick={this.rowClickHandler}
+                  >
+                    {data}
+                  </tr>
+                ))}
+              </tbody>
+              {this.paging && (
+                <tfoot class="sticky-bottom">
+                  <tr class="table-light align-middle">
+                    <td part={tableCell} colSpan={this.transactionsTable.columnData.length}>
+                      <pagination-menu
+                        paging={{
+                          ...this.paging,
+                          handleClickPrevious: this.handleClickPrevious,
+                          handleClickNext: this.handleClickNext,
+                        }}
+                      />
+                    </td>
+                  </tr>
+                </tfoot>
+              )}
+            </table>
+          </div>
+        </div>
+      </StyledHost>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-list.tsx
+++ b/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-list.tsx
@@ -97,7 +97,7 @@ export class PayoutTransactionsList {
     const clickedPayoutId = e.target.closest('tr').dataset.rowEntityId;
     if (!clickedPayoutId) return;
 
-    const transactionData = this.balanceTransactions.find((payment) => payment.id === clickedPayoutId);
+    const transactionData = this.balanceTransactions.find((payout) => payout.id === clickedPayoutId);
     this.clickEvent.emit({ name: TableClickActions.row, data: transactionData });
   };
 

--- a/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-table.tsx
+++ b/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-table.tsx
@@ -1,0 +1,155 @@
+import { h } from '@stencil/core';
+import { convertToLocal } from '../../utils/utils';
+import { getAlternateTableCellPart, tableHeadCell } from '../../styles/parts';
+import { PayoutBalanceTransaction } from '../../api';
+
+export const defaultColumnsKeys = 'created_at,txn_type,description,amount,fee,net';
+
+export const payoutTransactionTableColumns = {
+  id: () => (
+    <th part={tableHeadCell} scope="col" title="The unique identifier of each transaction">
+      ID
+    </th>
+  ),
+  account_id: () => (
+    <th part={tableHeadCell} scope="col" title="The unique identifier of the account associated with each transaction">
+      Account ID
+    </th>
+  ),
+  payout_id: () => (
+    <th part={tableHeadCell} scope="col" title="The unique identifier of the payout associated with each transaction">
+      Payout ID
+    </th>
+  ),
+  financial_transaction_id: () => (
+    <th part={tableHeadCell} scope="col" title="The unique identifier of the financial transaction associated with the payment balance transaction">
+      Financial Transaction ID
+    </th>
+  ),
+  amount: () => (
+    <th part={tableHeadCell} scope="col" title="The dollar amount of each transaction">
+      Amount
+    </th>
+  ),
+  fee: () => (
+    <th part={tableHeadCell} scope="col" title="The fee associated with each transaction">
+      Fee
+    </th>
+  ),
+  net: () => (
+    <th part={tableHeadCell} scope="col" title="The net amount of each transaction">
+      Net
+    </th>
+  ),
+  currency: () => (
+    <th part={tableHeadCell} scope="col" title="The currency of each transaction">
+      Currency
+    </th>
+  ),
+  description: () => (
+    <th part={tableHeadCell} scope="col" title="The description of each transaction">
+      Description
+    </th>
+  ),
+  source_id: () => (
+    <th part={tableHeadCell} scope="col" title="The unique identifier of the source object associated with the payment balance transaction">
+      Source ID
+    </th>
+  ),
+  txn_type: () => (
+    <th part={tableHeadCell} scope="col" title="The type of each transaction">
+      Type
+    </th>
+  ),
+  created_at: () => (
+    <th part={tableHeadCell} scope="col" title="The date and time each transaction was made">
+      Processed On
+    </th>
+  ),
+  available_on: () => (
+    <th part={tableHeadCell} scope="col" title="The date and time each transaction will be available">
+      Available On
+    </th>
+  ),
+  updated_at: () => (
+    <th part={tableHeadCell} scope="col" title="The date and time each transaction was last updated">
+      Updated On
+    </th>
+  ),
+};
+
+export const payoutTransactionTableCells = {
+  id: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.id)}>
+      {transaction.id}
+    </td>
+  ),
+  account_id: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.account_id)}>
+      {transaction.account_id}
+    </td>
+  ),
+  payout_id: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.payout_id)}>
+      {transaction.payout_id}
+    </td>
+  ),
+  financial_transaction_id: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.financial_transaction_id)}>
+      {transaction.financial_transaction_id}
+    </td>
+  ),
+  amount: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.amount)}>
+      {transaction.formattedPaymentAmount(transaction.amount)}
+    </td>
+  ),
+  fee: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.fee)}>
+      {transaction.formattedPaymentAmount(transaction.fee)}
+    </td>
+  ),
+  net: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.net)}>
+      {transaction.formattedPaymentAmount(transaction.net)}
+    </td>
+  ),
+  currency: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.currency)}>
+      {transaction.currency}
+    </td>
+  ),
+  description: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.description)}>
+      {transaction.description}
+    </td>
+  ),
+  source_id: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.source_id)}>
+      {transaction.source_id}
+    </td>
+  ),
+  txn_type: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.txn_type)}>
+      {transaction.txn_type}
+    </td>
+  ),
+  created_at: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.created_at)}>
+      <div class="fw-bold">{convertToLocal(transaction.created_at, { showDisplayDate: true })}</div>
+      <div class="fw-bold">{convertToLocal(transaction.created_at, { showTime: true })}</div>
+    </td>
+  ),
+  available_on: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.available_on)}>
+      <div class="fw-bold">{convertToLocal(transaction.available_on, { showDisplayDate: true })}</div>
+      <div class="fw-bold">{convertToLocal(transaction.available_on, { showTime: true })}</div>
+    </td>
+  ),
+  updated_at: (transaction: PayoutBalanceTransaction) => (
+    <td part={getAlternateTableCellPart(transaction.updated_at)}>
+      <div class="fw-bold">{convertToLocal(transaction.updated_at, { showDisplayDate: true })}</div>
+      <div class="fw-bold">{convertToLocal(transaction.updated_at, { showTime: true })}</div>
+    </td>
+  ),
+};

--- a/packages/webcomponents/src/ui-components/pagination-menu/readme.md
+++ b/packages/webcomponents/src/ui-components/pagination-menu/readme.md
@@ -18,6 +18,7 @@
 ### Used by
 
  - [checkouts-list-core](../../components/checkouts-list)
+ - [justifi-payout-transactions-list](../../components/payout-transactions-list)
  - [payments-list-core](../../components/payments-list)
  - [payouts-list-core](../../components/payouts-list)
  - [terminal-orders-list-core](../../components/terminal-orders-list)
@@ -27,6 +28,7 @@
 ```mermaid
 graph TD;
   checkouts-list-core --> pagination-menu
+  justifi-payout-transactions-list --> pagination-menu
   payments-list-core --> pagination-menu
   payouts-list-core --> pagination-menu
   terminal-orders-list-core --> pagination-menu


### PR DESCRIPTION
### New component: `payout-transactions-list`

This PR commits the following:

- adds new component `justifi-payout-transactions-list`
- adds new table component file used for payout transactions. default columns match the ones in the dashboard, but lots of column options based on the available data
- adds example file for testing. Make sure your env file as a PAYOUT_ID value or provide one manually in the example file


NOTE: Documentation and unit test coverage coming in separate PR.


Links
-----
 
Closes https://github.com/justifi-tech/engineering-artifacts/issues/206


Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [ ] Component library builds and runs
- [ ] test suites pass


Component Usage:

Example file `pnpm dev:payout-transactions-list`

- [ ] running component file without payout ID or auth token passed will emit error event: `payout-id and auth-token props are required`
- [ ] with proper auth token and payout ID - component makes successful request to `balance_transactions` endpoint
- [ ] After successful request, component displays transactions in table
- [ ] default columns match the existing payout balance transactions table on the dashboard
- [ ] additional columns can be displayed using the columns prop to modify the string.
- [ ] clicking on table row emits `click-event` with data 

