### PR TITLE
`refund-payment` - always return full response

### DIFF
--- a/apps/component-examples/examples/refund-payment.js
+++ b/apps/component-examples/examples/refund-payment.js
@@ -87,8 +87,7 @@ async function getWebComponentToken(token) {
 
 app.get('/', async (req, res) => {
   const token = await getToken();
-  // const paymentId = await createPayment(token);
-  const paymentId = 'py_7Ejx6JVs0IQVZ6wcUfXq3A';
+  const paymentId = await createPayment(token);
   const webComponentToken = await getWebComponentToken(token);
 
   const hideSubmitButton = false;
@@ -131,7 +130,19 @@ app.get('/', async (req, res) => {
         });
 
         justifiRefundPayment.addEventListener('submit-event', (event) => {
-          console.log('Submit-event', event);
+
+          // The submit-event will always return a response object
+          
+          // The response object will contain a data object if the request was successful
+          if (event.detail.response.data) {
+            console.log('Response data from submit-event', event);
+          }
+
+          // The response object will contain an error object if the request was not successful
+          if (event.detail.response.error) {
+            console.log('Error from submit-event', event);
+          }
+
           writeOutputToPage(event);
         });
 

--- a/apps/component-examples/examples/refund-payment.js
+++ b/apps/component-examples/examples/refund-payment.js
@@ -87,7 +87,8 @@ async function getWebComponentToken(token) {
 
 app.get('/', async (req, res) => {
   const token = await getToken();
-  const paymentId = await createPayment(token);
+  // const paymentId = await createPayment(token);
+  const paymentId = 'py_7Ejx6JVs0IQVZ6wcUfXq3A';
   const webComponentToken = await getWebComponentToken(token);
 
   const hideSubmitButton = false;
@@ -130,14 +131,7 @@ app.get('/', async (req, res) => {
         });
 
         justifiRefundPayment.addEventListener('submit-event', (event) => {
-          if (event.detail.response.data) {
-            console.log('Response data from submit-event', event.detail.response.data);
-          }
-
-          if (event.detail.response.error) {
-            console.log('Error from submit-event', event.detail.response.error);
-          }
-
+          console.log('Submit-event', event);
           writeOutputToPage(event);
         });
 

--- a/packages/webcomponents/src/actions/refund/refund-actions.ts
+++ b/packages/webcomponents/src/actions/refund/refund-actions.ts
@@ -59,7 +59,7 @@ export const makePostRefund = (requestProps: requestProps) => {
           severity: ComponentErrorSeverity.ERROR,
         });
     } finally {
-        final(response);
+        return final(response);
     }
   };
 };

--- a/packages/webcomponents/src/actions/refund/refund-actions.ts
+++ b/packages/webcomponents/src/actions/refund/refund-actions.ts
@@ -1,4 +1,4 @@
-import { IApiResponse, IRefund, IRefundPayload } from '../../api';
+import { IApiResponse, IRefund, IRefundPayload, isErrorObject } from '../../api';
 import { ComponentErrorCodes, ComponentErrorSeverity } from '../../api/ComponentError';
 import { RefundService } from '../../api/services/refund.service';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
@@ -31,13 +31,14 @@ export const makePostRefund = (props: requestProps) => {
         const err = response.error;
         let errorMessage: string;
         let code: string;
+        const errorObject = isErrorObject(err);
 
-        if (typeof err === 'string') {
-          errorMessage = err;
-          code = ComponentErrorCodes.POST_ERROR;
-        } else {
+        if (errorObject) {
           errorMessage = getErrorMessage(err);
           code = getErrorCode(err.code);
+        } else {
+          errorMessage = err;
+          code = ComponentErrorCodes.POST_ERROR;
         }
         return onError({
           error: errorMessage,

--- a/packages/webcomponents/src/actions/refund/refund-actions.ts
+++ b/packages/webcomponents/src/actions/refund/refund-actions.ts
@@ -18,14 +18,17 @@ interface usageProps {
 }
 
 export const makePostRefund = (requestProps: requestProps) => {
+  
   const { authToken, accountId, paymentId, service, apiOrigin } = requestProps;
-    return async (usageProps: usageProps) => {
+  
+  return async (usageProps: usageProps) => {
+    
     const { body, onError, final } = usageProps;
     
-      let response: IApiResponse<IRefund>;
-    
-      try {
-        response = await service.postRefund(paymentId, accountId, authToken, body, apiOrigin);
+    let response: IApiResponse<IRefund>;
+  
+    try {
+      response = await service.postRefund(paymentId, accountId, authToken, body, apiOrigin);
 
       if (response.error) {
         const err = response.error;

--- a/packages/webcomponents/src/actions/refund/refund-actions.ts
+++ b/packages/webcomponents/src/actions/refund/refund-actions.ts
@@ -14,7 +14,7 @@ interface requestProps {
 interface usageProps {
   body: IRefundPayload;
   onError: (error: any) => void;
-  final: (response: IApiResponse<IRefund>) => void;
+  onComplete: (response: IApiResponse<IRefund>) => void;
 }
 
 export const makePostRefund = (requestProps: requestProps) => {
@@ -23,7 +23,7 @@ export const makePostRefund = (requestProps: requestProps) => {
   
   return async (usageProps: usageProps) => {
     
-    const { body, onError, final } = usageProps;
+    const { body, onError, onComplete } = usageProps;
     
     let response: IApiResponse<IRefund>;
   
@@ -59,7 +59,7 @@ export const makePostRefund = (requestProps: requestProps) => {
           severity: ComponentErrorSeverity.ERROR,
         });
     } finally {
-        return final(response);
+        return onComplete(response);
     }
   };
 };

--- a/packages/webcomponents/src/actions/refund/refund-actions.ts
+++ b/packages/webcomponents/src/actions/refund/refund-actions.ts
@@ -17,10 +17,10 @@ interface usageProps {
   final: (response: IApiResponse<IRefund>) => void;
 }
 
-export const makePostRefund = (props: requestProps) => {
-  const { authToken, accountId, paymentId, service, apiOrigin } = props;
-    return async (props: usageProps) => {
-    const { body, onError, final } = props;
+export const makePostRefund = (requestProps: requestProps) => {
+  const { authToken, accountId, paymentId, service, apiOrigin } = requestProps;
+    return async (usageProps: usageProps) => {
+    const { body, onError, final } = usageProps;
     
       let response: IApiResponse<IRefund>;
     
@@ -40,6 +40,7 @@ export const makePostRefund = (props: requestProps) => {
           errorMessage = err;
           code = ComponentErrorCodes.POST_ERROR;
         }
+
         return onError({
           error: errorMessage,
           code,
@@ -47,14 +48,15 @@ export const makePostRefund = (props: requestProps) => {
         });
       }
     } catch (error) {
-      const code = getErrorCode(error?.code);
-      return onError({
-        error: error.message || error,
-        code,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+        const code = getErrorCode(error?.code);
+
+        return onError({
+          error: error.message || error,
+          code,
+          severity: ComponentErrorSeverity.ERROR,
+        });
     } finally {
-      final(response);
+        final(response);
     }
   };
 };

--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -18,6 +18,10 @@ export interface IErrorObject {
   param?: string;
 }
 
+export const isErrorObject = (e: any): e is IErrorObject => {
+  return typeof e === 'object' && 'message' in e && 'code' in e;
+}
+
 export interface IApiResponseCollection<T> extends IApiResponse<T> {
   page_info: PagingInfo;
 }

--- a/packages/webcomponents/src/api/services/refund.service.ts
+++ b/packages/webcomponents/src/api/services/refund.service.ts
@@ -1,11 +1,11 @@
-import { Api, IApiResponse, IRefund, RefundPayload } from '..';
+import { Api, IApiResponse, IRefund, IRefundPayload } from '..';
 
 export interface IRefundService {
   postRefund(
     paymentId: string,
     accountId: string,
     authToken: string,
-    refundBody: RefundPayload,
+    body: IRefundPayload,
     apiOrigin?: string
   ): Promise<IApiResponse<IRefund>>;
 };
@@ -15,12 +15,12 @@ export class RefundService implements IRefundService {
     paymentId: string,
     accountId: string,
     authToken: string,
-    refundBody: RefundPayload,
+    body: IRefundPayload,
     apiOrigin: string = PROXY_API_ORIGIN
   ): Promise<IApiResponse<IRefund>> {
     const api = Api({ authToken, apiOrigin });
     const endpoint = `payments/${paymentId}/refunds`;
     const headers = { 'Sub-Account': accountId };
-    return api.post({ endpoint, headers, body: refundBody });
+    return api.post({ endpoint, headers, body });
   }
 }

--- a/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
+++ b/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
@@ -122,7 +122,7 @@ export class RefundPayment {
 
   
   @Method()
-  async refundPayment(event?: CustomEvent): Promise<IRefund> {
+  async refundPayment(event?: CustomEvent): Promise<IApiResponse<IRefund>> {
     event && event.preventDefault();
 
     const valid = await this.formController.validate();
@@ -135,24 +135,21 @@ export class RefundPayment {
       service: new RefundService(),
       apiOrigin: this.apiOrigin
     });
-    const values = this.formController.values.getValue();
+
     this.refundLoading = true;
 
     return new Promise((resolve) => {
-      let refundResponse: IApiResponse<IRefund>;
   
       postRefund({
-        refundBody: values,
-        onSuccess: (response) => { refundResponse = response; },
+        body: this.refundPayload,
         onError: ({ error, code, severity }) => {
-          refundResponse = error;
           this.handleError(error, code, severity);
         },
-        final: () => {
-          this.submitEvent.emit({ response: refundResponse });
+        final: (response) => {
+          this.submitEvent.emit({ response: response });
           this.submitDisabled = true;
           this.refundLoading = false;
-          resolve(refundResponse.data);
+          resolve(response);
         },
       });
     });

--- a/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
+++ b/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
@@ -145,7 +145,7 @@ export class RefundPayment {
         onError: ({ error, code, severity }) => {
           this.handleError(error, code, severity);
         },
-        final: (response) => {
+        onComplete: (response) => {
           this.submitEvent.emit({ response: response });
           this.submitDisabled = true;
           this.refundLoading = false;


### PR DESCRIPTION
### `refund-payment` - always return full response

This PR commits the following changes to the `refund-payment` component:

- Improved TypeScript usage in API files - tried to remove cases where `any` is used and supply expected types where possible
- Refactored `refund-actions.ts`
  - removed `onSuccess` and always return full API response in `final` block (success or error)
- Return full response (success or error) when calling `refundPayment()` method programatically


Links
-----



Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [ ] Component library builds and runs as expected
- [ ] Test suites pass


Refund Component Specific QA

- [ ] Successful refund request emits `submit-event` with full response (`IApiResponse<IRefund>`) contained in `event.detail.response`. data property is included.
- [ ] Unsuccessful refund request emits `submit-event` with full response (`IApiResponse<IRefund>`) contained in `event.detail.response`. error property is included
- [ ] Unsuccessful refund request emits `error-event` with `event.detail` being `ComponentErrorEvent`
- [ ] Calling `refundPayment()` method with successful refund request returns full response from method (`IApiResponse<IRefund>`)
- [ ] Calling `refundPayment()` method with failed refund request returns full response from method (`IApiResponse<IRefund>`)


