### PR TITLE
`payout-details`: Pass api-origin prop to payout GET request

### DIFF
--- a/packages/webcomponents/src/actions/payout/get-payout-details.ts
+++ b/packages/webcomponents/src/actions/payout/get-payout-details.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayoutDetails =
-  ({ id, authToken, service }) =>
+  ({ id, authToken, service, apiOrigin }) =>
   async ({ onSuccess, onError }) => {
     try {
-      const response = await service.fetchPayout(id, authToken);
+      const response = await service.fetchPayout(id, authToken, apiOrigin);
 
       if (!response.error) {
         const payout = new Payout(response.data);

--- a/packages/webcomponents/src/components/payout-details/payout-details.tsx
+++ b/packages/webcomponents/src/components/payout-details/payout-details.tsx
@@ -47,7 +47,8 @@ export class PayoutDetails {
       this.getPayout = makeGetPayoutDetails({
         id: this.payoutId,
         authToken: this.authToken,
-        service: new PayoutService()
+        service: new PayoutService(),
+        apiOrigin: this.apiOrigin
       });
       this.getPayoutCSV = makeGetPayoutCSV({
         authToken: this.authToken,

--- a/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
+++ b/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
@@ -26,6 +26,7 @@ describe('getPayout', () => {
       id: mockId,
       authToken: mockAuthToken,
       service: mockServiceInstance,
+      apiOrigin: PROXY_API_ORIGIN
     });
     await getPayout({ onSuccess, onError });
 
@@ -45,6 +46,7 @@ describe('getPayout', () => {
       id: mockId,
       authToken: mockAuthToken,
       service: mockServiceInstance,
+      apiOrigin: PROXY_API_ORIGIN
     });
     await getPayout({ onSuccess, onError });
 
@@ -68,6 +70,7 @@ describe('getPayout', () => {
       id: mockId,
       authToken: mockAuthToken,
       service: mockServiceInstance,
+      apiOrigin: PROXY_API_ORIGIN
     });
     await getPayout({ onSuccess, onError });
 

--- a/packages/webcomponents/src/components/payout-details/test/payout-details-core.spec.tsx
+++ b/packages/webcomponents/src/components/payout-details/test/payout-details-core.spec.tsx
@@ -37,6 +37,7 @@ describe('payout-details-core', () => {
       id: 'some-id',
       authToken: 'some-auth-token',
       service: mockService,
+      apiOrigin: PROXY_API_ORIGIN
     });
 
     const page = await newSpecPage({
@@ -64,7 +65,8 @@ describe('payout-details-core', () => {
     const getPayout = makeGetPayoutDetails({
       id: 'some-id', // Use appropriate id
       authToken: 'some-auth-token', // Use appropriate auth token
-      service: mockService // Injecting the mocked service
+      service: mockService, // Injecting the mocked service
+      apiOrigin: PROXY_API_ORIGIN
     });
 
     const page = await newSpecPage({
@@ -87,7 +89,8 @@ describe('payout-details-core', () => {
     const getPayout = makeGetPayoutDetails({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService
+      service: mockService,
+      apiOrigin: PROXY_API_ORIGIN
     });
 
     const onErrorEvent = jest.fn();
@@ -116,7 +119,8 @@ describe('payout-details-core', () => {
     const getPayout = makeGetPayoutDetails({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService
+      service: mockService,
+      apiOrigin: PROXY_API_ORIGIN
     });
 
     const onErrorEvent = jest.fn();


### PR DESCRIPTION
### `payout-details`: Pass api-origin prop to payout GET request

This PR passes the `api-origin` prop from the component to the underlying api request handlers


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/276




Developer QA steps
--------------------

Run `pnpm dev:payout-details` example to test. Update example file to modify `api-origin` prop on the component. 

- [x] Component library builds and runs as expected
- [x] Test suites pass
- [x] api-origin prop on payout-details successfully updates API origin used for requests

