### PR TITLE
Internal Component: `justifi-config-provider` for dashboard use

### DIFF
--- a/packages/webcomponents/src/actions/payout/get-payout-details.ts
+++ b/packages/webcomponents/src/actions/payout/get-payout-details.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayoutDetails =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ onSuccess, onError }) => {
     try {
-      const response = await service.fetchPayout(id, authToken, apiOrigin);
+      const response = await service.fetchPayout(id, authToken);
 
       if (!response.error) {
         const payout = new Payout(response.data);

--- a/packages/webcomponents/src/actions/payout/get-payout-transactions.ts
+++ b/packages/webcomponents/src/actions/payout/get-payout-transactions.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayoutTransactions =
-  ({  authToken, service, apiOrigin }) =>
+  ({  accountId, authToken, service }) =>
   async ({ params, onSuccess, onError, final }) => {
     try {
-      const response = await service.fetchPayoutTransactions(authToken, params, apiOrigin);
+      const response = await service.fetchPayoutTransactions(accountId, authToken, params);
       if (!response.error) {
         const balanceTransactions = response.data.map(
           (dataItem) => new PayoutBalanceTransaction(dataItem)

--- a/packages/webcomponents/src/actions/payout/get-payouts.ts
+++ b/packages/webcomponents/src/actions/payout/get-payouts.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayouts =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ params, onSuccess, onError }) => {
     try {
-      const response = await service.fetchPayouts(id, authToken, params, apiOrigin);
+      const response = await service.fetchPayouts(id, authToken, params);
 
       if (!response.error) {
         const pagingInfo = {

--- a/packages/webcomponents/src/actions/sub-account/get-subaccounts.ts
+++ b/packages/webcomponents/src/actions/sub-account/get-subaccounts.ts
@@ -2,14 +2,13 @@ import { ComponentErrorSeverity, SubAccount } from '../../api';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetSubAccounts =
-  ({ accountId, authToken, service, apiOrigin }) =>
+  ({ accountId, authToken, service }) =>
   async ({ params, onSuccess, onError }) => {
     try {
       const response = await service.fetchSubAccounts(
         accountId,
         authToken,
-        params,
-        apiOrigin
+        params
       );
 
       if (!response.error) {

--- a/packages/webcomponents/src/api/ApiNew.ts
+++ b/packages/webcomponents/src/api/ApiNew.ts
@@ -1,4 +1,4 @@
-import { configState } from '../components/config-provider/config-state';
+import { waitForConfig, configState } from '../components/config-provider/config-state';
 import { generateId } from '../utils/utils';
 import { PagingInfo } from './Pagination';
 
@@ -74,9 +74,6 @@ interface DestroyProps {
 }
 
 const Api = () => {
-  
-  const apiOrigin = configState.apiOrigin;
-  
   async function getAuthorizationHeader(authToken: string) {
     if (!authToken) {
       return {
@@ -93,6 +90,9 @@ const Api = () => {
 
   async function makeRequest(props: MakeRequestProps) {
     const { authToken, endpoint, method, params, body, signal, headers } = props;
+
+    await waitForConfig();
+    const apiOrigin = configState.apiOrigin;
 
     const url = `${apiOrigin}/v1/${endpoint}`;
     const requestUrl = params ? `${url}?${new URLSearchParams(params)}` : url;

--- a/packages/webcomponents/src/api/ApiNew.ts
+++ b/packages/webcomponents/src/api/ApiNew.ts
@@ -23,7 +23,8 @@ export interface IApiResponseCollection<T> extends IApiResponse<T> {
   page_info: PagingInfo;
 }
 
-interface RequestProps {
+interface MakeRequestProps {
+  authToken: string;
   endpoint: string;
   method: string;
   params?: any;
@@ -32,11 +33,51 @@ interface RequestProps {
   headers?: HeadersInit;
 }
 
-const Api = (authToken: string) => {
+interface GetProps {
+  authToken: string;
+  endpoint: string;
+  params?: any;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+}
+
+interface PostProps {
+  authToken: string;
+  endpoint: string;
+  body?: any;
+  params?: any;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+}
+
+interface PutProps {
+  authToken: string;
+  endpoint: string;
+  body?: any;
+  params?: any;
+  signal?: AbortSignal;
+}
+
+interface PatchProps {
+  authToken: string;
+  endpoint: string;
+  body?: any;
+  params?: any;
+  signal?: AbortSignal;
+}
+
+interface DestroyProps {
+  authToken: string;
+  endpoint: string;
+  params?: any;
+  signal?: AbortSignal;
+}
+
+const Api = () => {
   
   const apiOrigin = configState.apiOrigin;
   
-  async function getAuthorizationHeader() {
+  async function getAuthorizationHeader(authToken: string) {
     if (!authToken) {
       return {
         'Content-Type': 'application/json',
@@ -50,13 +91,13 @@ const Api = (authToken: string) => {
     };
   }
 
-  async function makeRequest(props: RequestProps) {
-    const { endpoint, method, params, body, signal, headers } = props;
+  async function makeRequest(props: MakeRequestProps) {
+    const { authToken, endpoint, method, params, body, signal, headers } = props;
 
     const url = `${apiOrigin}/v1/${endpoint}`;
     const requestUrl = params ? `${url}?${new URLSearchParams(params)}` : url;
 
-    const defaultHeaders = await getAuthorizationHeader();
+    const defaultHeaders = await getAuthorizationHeader(authToken);
     const mergedHeaders = { ...defaultHeaders, ...headers };
 
     const response = await fetch(requestUrl, {
@@ -72,34 +113,15 @@ const Api = (authToken: string) => {
     handleError(requestUrl);
   }
 
-  async function get({
-    endpoint,
-    params,
-    signal,
-    headers,
-  }: {
-    endpoint: string;
-    params?: any;
-    signal?: AbortSignal;
-    headers?: HeadersInit;
-  }) {
-    return makeRequest({ endpoint, method: 'GET', params, signal, headers });
+  async function get(props: GetProps) {
+    const { authToken, endpoint, params, signal, headers } = props;
+    return makeRequest({ authToken, endpoint, method: 'GET', params, signal, headers });
   }
 
-  async function post({
-    endpoint,
-    body,
-    params,
-    signal,
-    headers,
-  }: {
-    endpoint: string;
-    body?: any;
-    params?: any;
-    signal?: AbortSignal;
-    headers?: HeadersInit;
-  }) {
+  async function post(props: PostProps) {
+    const { authToken, endpoint, body, params, signal, headers } = props;
     return makeRequest({
+      authToken,
       endpoint,
       method: 'POST',
       params,
@@ -109,18 +131,10 @@ const Api = (authToken: string) => {
     });
   }
 
-  async function put({
-    endpoint,
-    body,
-    params,
-    signal,
-  }: {
-    endpoint: string;
-    body?: any;
-    params?: any;
-    signal?: AbortSignal;
-  }) {
+  async function put(props: PutProps) {
+    const { authToken, endpoint, body, params, signal } = props;
     return makeRequest({
+      authToken,
       endpoint,
       method: 'PUT',
       params,
@@ -129,18 +143,10 @@ const Api = (authToken: string) => {
     });
   }
 
-  async function patch({
-    endpoint,
-    body,
-    params,
-    signal,
-  }: {
-    endpoint: string;
-    body?: any;
-    params?: any;
-    signal?: AbortSignal;
-  }) {
+  async function patch(props: PatchProps) {
+    const { authToken, endpoint, body, params, signal } = props;
     return makeRequest({
+      authToken,
       endpoint,
       method: 'PATCH',
       params,
@@ -149,16 +155,9 @@ const Api = (authToken: string) => {
     });
   }
 
-  async function destroy({
-    endpoint,
-    params,
-    signal,
-  }: {
-    endpoint: string;
-    params?: any;
-    signal?: AbortSignal;
-  }) {
-    return makeRequest({ endpoint, method: 'DELETE', params, signal });
+  async function destroy(props: DestroyProps) {
+    const { authToken, endpoint, params, signal } = props;
+    return makeRequest({ authToken, endpoint, method: 'DELETE', params, signal });
   }
 
   return { get, post, put, patch, destroy };

--- a/packages/webcomponents/src/api/ApiNew.ts
+++ b/packages/webcomponents/src/api/ApiNew.ts
@@ -1,0 +1,171 @@
+import { configState } from '../components/config-provider/config-state';
+import { generateId } from '../utils/utils';
+import { PagingInfo } from './Pagination';
+
+export interface IApiResponse<T> {
+  data: T;
+  error?: IErrorObject | IServerError;
+  page_info?: PagingInfo;
+  errors?: string[];
+  id: number | string;
+  type: string;
+}
+
+export type IServerError = string;
+
+export interface IErrorObject {
+  message: string;
+  code: string;
+  param?: string;
+}
+
+export interface IApiResponseCollection<T> extends IApiResponse<T> {
+  page_info: PagingInfo;
+}
+
+interface RequestProps {
+  endpoint: string;
+  method: string;
+  params?: any;
+  body?: any;
+  signal?: AbortSignal;
+  headers?: HeadersInit;
+}
+
+const Api = (authToken: string) => {
+  
+  const apiOrigin = configState.apiOrigin;
+  
+  async function getAuthorizationHeader() {
+    if (!authToken) {
+      return {
+        'Content-Type': 'application/json',
+      };
+    }
+
+    return {
+      Authorization: `Bearer ${authToken}`,
+      'Idempotency-Key': generateId(),
+      'Content-Type': 'application/json',
+    };
+  }
+
+  async function makeRequest(props: RequestProps) {
+    const { endpoint, method, params, body, signal, headers } = props;
+
+    const url = `${apiOrigin}/v1/${endpoint}`;
+    const requestUrl = params ? `${url}?${new URLSearchParams(params)}` : url;
+
+    const defaultHeaders = await getAuthorizationHeader();
+    const mergedHeaders = { ...defaultHeaders, ...headers };
+
+    const response = await fetch(requestUrl, {
+      method: method,
+      headers: mergedHeaders,
+      body: body,
+      signal: signal,
+    });
+
+    if (response) {
+      return response.status === 204 ? {} : response.json();
+    }
+    handleError(requestUrl);
+  }
+
+  async function get({
+    endpoint,
+    params,
+    signal,
+    headers,
+  }: {
+    endpoint: string;
+    params?: any;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  }) {
+    return makeRequest({ endpoint, method: 'GET', params, signal, headers });
+  }
+
+  async function post({
+    endpoint,
+    body,
+    params,
+    signal,
+    headers,
+  }: {
+    endpoint: string;
+    body?: any;
+    params?: any;
+    signal?: AbortSignal;
+    headers?: HeadersInit;
+  }) {
+    return makeRequest({
+      endpoint,
+      method: 'POST',
+      params,
+      body: JSON.stringify(body),
+      signal,
+      headers,
+    });
+  }
+
+  async function put({
+    endpoint,
+    body,
+    params,
+    signal,
+  }: {
+    endpoint: string;
+    body?: any;
+    params?: any;
+    signal?: AbortSignal;
+  }) {
+    return makeRequest({
+      endpoint,
+      method: 'PUT',
+      params,
+      body: JSON.stringify(body),
+      signal,
+    });
+  }
+
+  async function patch({
+    endpoint,
+    body,
+    params,
+    signal,
+  }: {
+    endpoint: string;
+    body?: any;
+    params?: any;
+    signal?: AbortSignal;
+  }) {
+    return makeRequest({
+      endpoint,
+      method: 'PATCH',
+      params,
+      body: JSON.stringify(body),
+      signal,
+    });
+  }
+
+  async function destroy({
+    endpoint,
+    params,
+    signal,
+  }: {
+    endpoint: string;
+    params?: any;
+    signal?: AbortSignal;
+  }) {
+    return makeRequest({ endpoint, method: 'DELETE', params, signal });
+  }
+
+  return { get, post, put, patch, destroy };
+};
+
+function handleError(requestUrl: string): void {
+  console.error(`Error fetching from ${requestUrl}`);
+}
+
+export default Api;

--- a/packages/webcomponents/src/api/services/payout.service.ts
+++ b/packages/webcomponents/src/api/services/payout.service.ts
@@ -1,6 +1,5 @@
 import { IPayout, IPayoutBalanceTransaction } from '..';
 import Api, { IApiResponse, IApiResponseCollection } from '../ApiNew';
-
 export interface IPayoutService {
   fetchPayouts(
     accountId: string,
@@ -22,13 +21,14 @@ export interface IPayoutService {
   ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>>;
 }
 
+const api = Api();
+
 export class PayoutService implements IPayoutService {
   async fetchPayouts(
     accountId: string,
     authToken: string,
     params: any
   ): Promise<IApiResponseCollection<IPayout[]>> {
-    const api = Api();
     const endpoint = `account/${accountId}/payouts`;
     return api.get({ authToken, endpoint, params });
   }
@@ -37,7 +37,6 @@ export class PayoutService implements IPayoutService {
     payoutId: string,
     authToken: string,
   ): Promise<IApiResponse<IPayout>> {
-    const api = Api();
     const endpoint = `payouts/${payoutId}`;
     return api.get({ authToken, endpoint });
   }
@@ -46,7 +45,6 @@ export class PayoutService implements IPayoutService {
     payoutId: string,
     authToken: string,
   ): Promise<IApiResponse<any>> {
-    const api = Api();
     const endpoint = `reports/payouts/${payoutId}`;
     return api.get({ authToken, endpoint });
   }
@@ -56,7 +54,6 @@ export class PayoutService implements IPayoutService {
     authToken: string,
     params: any,
   ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>> {
-    const api = Api();
     const endpoint = `balance_transactions`;
     const headers = { 'sub-account': accountId };
     return api.get({ authToken, endpoint, params, headers });

--- a/packages/webcomponents/src/api/services/payout.service.ts
+++ b/packages/webcomponents/src/api/services/payout.service.ts
@@ -28,27 +28,27 @@ export class PayoutService implements IPayoutService {
     authToken: string,
     params: any
   ): Promise<IApiResponseCollection<IPayout[]>> {
-    const api = Api(authToken);
+    const api = Api();
     const endpoint = `account/${accountId}/payouts`;
-    return api.get({ endpoint, params });
+    return api.get({ authToken, endpoint, params });
   }
 
   async fetchPayout(
     payoutId: string,
     authToken: string,
   ): Promise<IApiResponse<IPayout>> {
-    const api = Api(authToken);
+    const api = Api();
     const endpoint = `payouts/${payoutId}`;
-    return api.get({ endpoint });
+    return api.get({ authToken, endpoint });
   }
 
   async fetchCSV(
     payoutId: string,
     authToken: string,
   ): Promise<IApiResponse<any>> {
-    const api = Api(authToken);
+    const api = Api();
     const endpoint = `reports/payouts/${payoutId}`;
-    return api.get({ endpoint });
+    return api.get({ authToken, endpoint });
   }
 
   async fetchPayoutTransactions(
@@ -56,9 +56,9 @@ export class PayoutService implements IPayoutService {
     authToken: string,
     params: any,
   ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>> {
-    const api = Api(authToken);
+    const api = Api();
     const endpoint = `balance_transactions`;
     const headers = { 'sub-account': accountId };
-    return api.get({ endpoint, params, headers });
+    return api.get({ authToken, endpoint, params, headers });
   }
 }

--- a/packages/webcomponents/src/api/services/payout.service.ts
+++ b/packages/webcomponents/src/api/services/payout.service.ts
@@ -1,26 +1,24 @@
-import { Api, IApiResponse, IApiResponseCollection, IPayout, IPayoutBalanceTransaction } from '..';
+import { IPayout, IPayoutBalanceTransaction } from '..';
+import Api, { IApiResponse, IApiResponseCollection } from '../ApiNew';
 
 export interface IPayoutService {
   fetchPayouts(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<IPayout[]>>;
   fetchPayout(
     payoutId: string,
-    authToken: string,
-    apiOrigin?: string
+    authToken: string
   ): Promise<IApiResponse<IPayout>>;
   fetchCSV(
     payoutId: string,
-    authToken: string,
-    apiOrigin?: string
+    authToken: string
   ): Promise<IApiResponse<any>>;
   fetchPayoutTransactions(
+    accountId: string,
     authToken: string,
     params: any,
-    apiOrigin?: string
   ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>>;
 }
 
@@ -28,10 +26,9 @@ export class PayoutService implements IPayoutService {
   async fetchPayouts(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin: string = PROXY_API_ORIGIN
+    params: any
   ): Promise<IApiResponseCollection<IPayout[]>> {
-    const api = Api({ authToken, apiOrigin });
+    const api = Api(authToken);
     const endpoint = `account/${accountId}/payouts`;
     return api.get({ endpoint, params });
   }
@@ -39,9 +36,8 @@ export class PayoutService implements IPayoutService {
   async fetchPayout(
     payoutId: string,
     authToken: string,
-    apiOrigin: string = PROXY_API_ORIGIN
   ): Promise<IApiResponse<IPayout>> {
-    const api = Api({ authToken, apiOrigin });
+    const api = Api(authToken);
     const endpoint = `payouts/${payoutId}`;
     return api.get({ endpoint });
   }
@@ -49,20 +45,20 @@ export class PayoutService implements IPayoutService {
   async fetchCSV(
     payoutId: string,
     authToken: string,
-    apiOrigin: string = PROXY_API_ORIGIN
   ): Promise<IApiResponse<any>> {
-    const api = Api({ authToken, apiOrigin });
+    const api = Api(authToken);
     const endpoint = `reports/payouts/${payoutId}`;
     return api.get({ endpoint });
   }
 
   async fetchPayoutTransactions(
+    accountId: string,
     authToken: string,
     params: any,
-    apiOrigin: string = PROXY_API_ORIGIN
   ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>> {
-    const api = Api({ authToken, apiOrigin });
+    const api = Api(authToken);
     const endpoint = `balance_transactions`;
-    return api.get({ endpoint, params });
+    const headers = { 'sub-account': accountId };
+    return api.get({ endpoint, params, headers });
   }
 }

--- a/packages/webcomponents/src/api/services/subaccounts.service.ts
+++ b/packages/webcomponents/src/api/services/subaccounts.service.ts
@@ -1,7 +1,6 @@
 import { ISubAccount } from '..';
 import Api, { IApiResponseCollection } from '../ApiNew';
 
-
 export interface ISubAccountService {
   fetchSubAccounts(
     accountId: string,
@@ -10,16 +9,16 @@ export interface ISubAccountService {
   ): Promise<IApiResponseCollection<ISubAccount[]>>;
 }
 
+const api = Api();
+
 export class SubAccountService implements ISubAccountService {
   async fetchSubAccounts(
     accountId: string,
     authToken: string,
     params: any
   ): Promise<IApiResponseCollection<ISubAccount[]>> {
-    const headers = { Account: accountId };
-
-    const api = Api();
     const endpoint = 'sub_accounts';
+    const headers = { Account: accountId };
     return api.get({ authToken, endpoint, params, headers });
   }
 }

--- a/packages/webcomponents/src/api/services/subaccounts.service.ts
+++ b/packages/webcomponents/src/api/services/subaccounts.service.ts
@@ -1,11 +1,12 @@
-import { Api, IApiResponseCollection, ISubAccount } from '..';
+import { ISubAccount } from '..';
+import Api, { IApiResponseCollection } from '../ApiNew';
+
 
 export interface ISubAccountService {
   fetchSubAccounts(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<ISubAccount[]>>;
 }
 
@@ -13,12 +14,11 @@ export class SubAccountService implements ISubAccountService {
   async fetchSubAccounts(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin: string = PROXY_API_ORIGIN
+    params: any
   ): Promise<IApiResponseCollection<ISubAccount[]>> {
     const headers = { Account: accountId };
 
-    const api = Api({ authToken, apiOrigin: apiOrigin });
+    const api = Api(authToken);
     const endpoint = 'sub_accounts';
     return api.get({ endpoint, params, headers });
   }

--- a/packages/webcomponents/src/api/services/subaccounts.service.ts
+++ b/packages/webcomponents/src/api/services/subaccounts.service.ts
@@ -18,8 +18,8 @@ export class SubAccountService implements ISubAccountService {
   ): Promise<IApiResponseCollection<ISubAccount[]>> {
     const headers = { Account: accountId };
 
-    const api = Api(authToken);
+    const api = Api();
     const endpoint = 'sub_accounts';
-    return api.get({ endpoint, params, headers });
+    return api.get({ authToken, endpoint, params, headers });
   }
 }

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
@@ -73,8 +73,7 @@ export class CheckoutsList {
       this.getSubAccounts = makeGetSubAccounts({
         accountId: this.accountId,
         authToken: this.authToken,
-        service: new SubAccountService(),
-        apiOrigin: this.apiOrigin
+        service: new SubAccountService()
       });
     }
   }

--- a/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-core.spec.tsx
@@ -39,8 +39,7 @@ describe('checkouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({
@@ -76,8 +75,7 @@ describe('checkouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({
@@ -110,8 +108,7 @@ describe('checkouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
 
@@ -151,8 +148,7 @@ describe('checkouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const errorEvent = jest.fn();
@@ -197,8 +193,7 @@ describe('checkouts-list-core pagination', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
 

--- a/packages/webcomponents/src/components/config-provider/config-provider.tsx
+++ b/packages/webcomponents/src/components/config-provider/config-provider.tsx
@@ -8,7 +8,7 @@ import { setConfigState } from './config-state';
 export class ConfigProvider {
   @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() iFrameOrigin?: string = IFRAME_ORIGIN;
-  @Prop() accountId?: string = undefined;
+  @Prop() accountId?: string = '';
 
   componentWillLoad() {
     setConfigState({

--- a/packages/webcomponents/src/components/config-provider/config-provider.tsx
+++ b/packages/webcomponents/src/components/config-provider/config-provider.tsx
@@ -1,0 +1,24 @@
+import { Component, Prop } from '@stencil/core';
+import { setConfigState } from './config-state';
+
+@Component({
+  tag: 'justifi-config-provider',
+  shadow: false
+})
+export class ConfigProvider {
+  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
+  @Prop() iFrameOrigin?: string = IFRAME_ORIGIN;
+  @Prop() accountId?: string = undefined;
+
+  componentWillLoad() {
+    setConfigState({
+      apiOrigin: this.apiOrigin,
+      iFrameOrigin: this.iFrameOrigin,
+      accountId: this.accountId
+    });
+  }
+
+  render() {
+    return null;
+  }
+}

--- a/packages/webcomponents/src/components/config-provider/config-state.ts
+++ b/packages/webcomponents/src/components/config-provider/config-state.ts
@@ -33,7 +33,7 @@ const setConfigState = (vals: Partial<ConfigState>) => {
  * Wait for configProvider to run, but safe guard against never mounting.
  * @param timeoutMs max time to wait before resolving with default values
  */
-const waitForConfig = (timeoutMs = 500): Promise<void> => {
+const waitForConfig = (timeoutMs = 200): Promise<void> => {
   return new Promise<void>(resolve => {
     const timer = setTimeout(() => {
       // timeout expired, proceed with default config state values

--- a/packages/webcomponents/src/components/config-provider/config-state.ts
+++ b/packages/webcomponents/src/components/config-provider/config-state.ts
@@ -1,0 +1,29 @@
+import { createStore } from '@stencil/store';
+
+interface ConfigState {
+  apiOrigin?: string;
+  iFrameOrigin?: string;
+  accountId?: string;
+}
+
+const initialState: ConfigState = {
+  apiOrigin: PROXY_API_ORIGIN,
+  iFrameOrigin: IFRAME_ORIGIN,
+  accountId: ''
+};
+
+const configStore = createStore<ConfigState>(() => initialState);
+const { state: configState, on: onConfigChange } = configStore;
+
+const setConfigState = (vals: Partial<ConfigState>) => {
+  Object.assign(configState, vals);
+};
+
+const getConfigState = (): ConfigState => configState;
+
+export {
+  configState,
+  onConfigChange,
+  getConfigState,
+  setConfigState,
+};

--- a/packages/webcomponents/src/components/payout-details/get-payout-csv.ts
+++ b/packages/webcomponents/src/components/payout-details/get-payout-csv.ts
@@ -2,10 +2,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayoutCSV =
-  ({ authToken, service, apiOrigin }) =>
+  ({ authToken, service }) =>
   async ({ payoutId, onError }) => {
     try {
-      const { data } = await service.fetchCSV(payoutId, authToken, apiOrigin);
+      const { data } = await service.fetchCSV(payoutId, authToken);
       const a = document.createElement('a');
       a.href = data.csv_url;
       a.click();

--- a/packages/webcomponents/src/components/payout-details/payout-details.tsx
+++ b/packages/webcomponents/src/components/payout-details/payout-details.tsx
@@ -16,7 +16,6 @@ import { ComponentErrorEvent } from '../../api/ComponentEvents';
 export class PayoutDetails {
   @Prop() payoutId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
 
   @State() getPayout: Function;
   @State() getPayoutCSV: Function;
@@ -47,13 +46,11 @@ export class PayoutDetails {
       this.getPayout = makeGetPayoutDetails({
         id: this.payoutId,
         authToken: this.authToken,
-        service: new PayoutService(),
-        apiOrigin: this.apiOrigin
+        service: new PayoutService()
       });
       this.getPayoutCSV = makeGetPayoutCSV({
         authToken: this.authToken,
-        service: new PayoutService(),
-        apiOrigin: this.apiOrigin
+        service: new PayoutService()
       });
     } else {
       this.errorMessage = 'Failed to load payout details. payoutId or authToken is not provided.';

--- a/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
+++ b/packages/webcomponents/src/components/payout-details/test/get-payout-details.spec.ts
@@ -25,8 +25,7 @@ describe('getPayout', () => {
     const getPayout = makeGetPayoutDetails({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockServiceInstance
     });
     await getPayout({ onSuccess, onError });
 
@@ -45,8 +44,7 @@ describe('getPayout', () => {
     const getPayout = makeGetPayoutDetails({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockServiceInstance
     });
     await getPayout({ onSuccess, onError });
 
@@ -69,8 +67,7 @@ describe('getPayout', () => {
     const getPayout = makeGetPayoutDetails({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockServiceInstance
     });
     await getPayout({ onSuccess, onError });
 

--- a/packages/webcomponents/src/components/payout-details/test/payout-details-core.spec.tsx
+++ b/packages/webcomponents/src/components/payout-details/test/payout-details-core.spec.tsx
@@ -36,8 +36,7 @@ describe('payout-details-core', () => {
     const getPayout = makeGetPayoutDetails({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockService
     });
 
     const page = await newSpecPage({
@@ -65,8 +64,7 @@ describe('payout-details-core', () => {
     const getPayout = makeGetPayoutDetails({
       id: 'some-id', // Use appropriate id
       authToken: 'some-auth-token', // Use appropriate auth token
-      service: mockService, // Injecting the mocked service
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockService, // Injecting the mocked servic
     });
 
     const page = await newSpecPage({
@@ -89,8 +87,7 @@ describe('payout-details-core', () => {
     const getPayout = makeGetPayoutDetails({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockService
     });
 
     const onErrorEvent = jest.fn();
@@ -119,8 +116,7 @@ describe('payout-details-core', () => {
     const getPayout = makeGetPayoutDetails({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockService
     });
 
     const onErrorEvent = jest.fn();

--- a/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-list.tsx
+++ b/packages/webcomponents/src/components/payout-transactions-list/payout-transactions-list.tsx
@@ -10,6 +10,7 @@ import { TableClickActions } from '../../ui-components/table/event-types';
 import { table, tableCell } from '../../styles/parts';
 import { StyledHost, TableEmptyState, TableErrorState, TableLoadingState } from '../../ui-components';
 import { defaultColumnsKeys, payoutTransactionTableCells, payoutTransactionTableColumns } from './payout-transactions-table';
+import { configState } from '../config-provider/config-state';
 
 @Component({
   tag: 'justifi-payout-transactions-list',
@@ -25,7 +26,6 @@ export class PayoutTransactionsList {
 
   @Prop() payoutId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys;
 
   @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<ComponentClickEvent>;
@@ -59,9 +59,9 @@ export class PayoutTransactionsList {
   private initializeApi() {
     if (this.payoutId && this.authToken) {
       const getPayoutTransactions = makeGetPayoutTransactions({
+        accountId: configState.accountId,
         authToken: this.authToken,
-        service: new PayoutService(),
-        apiOrigin: this.apiOrigin
+        service: new PayoutService()
       });
 
       getPayoutTransactions({

--- a/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
+++ b/packages/webcomponents/src/components/payouts-list/payouts-list.tsx
@@ -24,7 +24,6 @@ export class PayoutsList {
 
   @Prop() accountId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys;
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
@@ -57,8 +56,7 @@ export class PayoutsList {
       const serviceParams = {
         id: this.accountId,
         authToken: this.authToken,
-        service: new PayoutService(),
-        apiOrigin: this.apiOrigin
+        service: new PayoutService()
       };
       this.getPayouts = makeGetPayouts(serviceParams);
       this.getPayoutCSV = makeGetPayoutCSV(serviceParams);
@@ -77,8 +75,7 @@ export class PayoutsList {
       this.getSubAccounts = makeGetSubAccounts({
         accountId: this.accountId,
         authToken: this.authToken,
-        service: new SubAccountService(),
-        apiOrigin: this.apiOrigin
+        service: new SubAccountService()
       });
     }
   }

--- a/packages/webcomponents/src/components/payouts-list/test/get-payouts.spec.ts
+++ b/packages/webcomponents/src/components/payouts-list/test/get-payouts.spec.ts
@@ -7,7 +7,6 @@ describe('makeGetPayouts', () => {
   const mockId = '123';
   const mockAuthToken = 'token';
   const mockParams = { limit: 10, page: 1 };
-  const mockApiOrigin = 'http://localhost:3000';
 
   let mockServiceInstance: jest.Mocked<PayoutService>;
 
@@ -33,8 +32,7 @@ describe('makeGetPayouts', () => {
     const getPayouts = makeGetPayouts({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getPayouts({ params: mockParams, onSuccess, onError });
 
@@ -56,8 +54,7 @@ describe('makeGetPayouts', () => {
     const getPayouts = makeGetPayouts({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getPayouts({ params: mockParams, onSuccess, onError });
 
@@ -80,8 +77,7 @@ describe('makeGetPayouts', () => {
     const getPayouts = makeGetPayouts({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getPayouts({ params: mockParams, onSuccess, onError });
 

--- a/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/payouts-list/test/payouts-list-core.spec.tsx
@@ -26,8 +26,7 @@ describe('payouts-list-core', () => {
     const getPayouts = makeGetPayouts({
       id: '123',
       authToken: '123',
-      service: mockPayoutService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPayoutService
     });
 
     const mockSubAccountsService = {
@@ -37,8 +36,7 @@ describe('payouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     // components.pop();
@@ -63,8 +61,7 @@ describe('payouts-list-core', () => {
     const getPayouts = makeGetPayouts({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockPayoutService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPayoutService
     });
 
     const mockSubAccountsService = {
@@ -74,8 +71,7 @@ describe('payouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({
@@ -98,8 +94,7 @@ describe('payouts-list-core', () => {
     const getPayouts = makeGetPayouts({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockPayoutService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPayoutService
     });
 
     const mockSubAccountsService = {
@@ -109,8 +104,7 @@ describe('payouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const errorSpy = jest.fn();
@@ -139,8 +133,7 @@ describe('payouts-list-core', () => {
     const getPayouts = makeGetPayouts({
       id: '123',
       authToken: '123',
-      service: mockPayoutService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPayoutService
     });
 
     const mockSubAccountsService = {
@@ -150,8 +143,7 @@ describe('payouts-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({
@@ -182,8 +174,7 @@ describe('payouts-list-core pagination', () => {
     const getPayouts = makeGetPayouts({
       id: '123',
       authToken: '123',
-      service: mockPayoutService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPayoutService
     });
 
     const mockSubAccountsService = {
@@ -193,8 +184,7 @@ describe('payouts-list-core pagination', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({

--- a/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
@@ -73,8 +73,7 @@ export class TerminalsList {
       this.getSubAccounts = makeGetSubAccounts({
         accountId: this.accountId,
         authToken: this.authToken,
-        service: new SubAccountService(),
-        apiOrigin: this.apiOrigin
+        service: new SubAccountService()
       });
     }
   }

--- a/packages/webcomponents/src/components/terminals-list/test/terminals-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/terminals-list/test/terminals-list-core.spec.tsx
@@ -39,8 +39,7 @@ describe('terminals-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: '123',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({
@@ -76,8 +75,7 @@ describe('terminals-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: '123',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({
@@ -110,8 +108,7 @@ describe('terminals-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: '123',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({
@@ -150,8 +147,7 @@ describe('terminals-list-core', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: '123',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const errorEvent = jest.fn();
@@ -196,8 +192,7 @@ describe('terminals-list-core pagination', () => {
     const getSubAccounts = makeGetSubAccounts({
       accountId: '123',
       authToken: '123',
-      service: mockSubAccountsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockSubAccountsService
     });
 
     const page = await newSpecPage({


### PR DESCRIPTION
### Internal Component: `justifi-config-provider` for dashboard use

This PR commits the following:

- Adds new component for internal use in our dashboard: `justifi-config-provider` which will handle passing certain values to components in the dashboard without the need to write hidden / undocumented props. 
- Creates new `ApiNew.ts` file which is almost an exact copy of the existing Api.ts file - but only requires authToken as a prop when initializing Api() and grabs `apiOrigin` from `config-state` by default. 
- Refactors payout related components: `payouts-list`, `payout-details`, and `payout-transactions-list` to no longer accept `apiOrigin` prop. 
- Refactors `subaccounts` api requests (used in payouts-list, terminals-list, checkouts-list) to use new ApiNew.ts file
  - Note: this was just easiest to go ahead and do this as well since payouts-list needs to make an api request for the sub accounts list in the context of our dashboard. 
- Adjusts several test files to no longer reference apiOrigin when mocking requests.   

Eventually - if we are satisfied with this refactor, we can begin converting other existing components to this system and thus reduce complexity going forward handling component auth or api logic in the dashboard. 

Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/291


Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [x] Component library builds and runs as expected
- [x] Test suites pass

In order to test the config-provider - you'll need to render it anywhere in the payout example files. We're going to test all 3 payout components to verify correct behavior. 

`payouts-list`

- [x] Do not render config component. `payouts-list` successfully requests and displays payouts data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `payouts-list` component is now using that value as it's api-origin in it's network requests. 

`payout-details`

- [x] Do not render config component. `payout-details` successfully requests and displays payout data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `payout-details` component is now using that value as it's api-origin in it's network requests. 

`payout-transactions-list`

- [x] Do not render config component. `payout-transactions-list` successfully requests and displays payout transactions data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `payout-transactions-list` component is now using that value as it's api-origin in it's network requests. 
- [x] Render `justifi-config-provider` in example file body and set `account-id="${subAccountId}"`. Verify that request is now sending the `Sub-Account` header with the `subAccountId` value provided by the prop passed to the config-provider

