### PR TITLE
Fix role references in authorization section of Dispute Management documentaion

### DIFF
--- a/apps/docs/stories/components/DisputeManagement/Docs.mdx
+++ b/apps/docs/stories/components/DisputeManagement/Docs.mdx
@@ -55,8 +55,8 @@ Component to render notification of disputed payments and allow platform to resp
     API](https://docs.justifi.tech/api-spec#tag/Web-Component-Tokens/operation/CreateWebComponentToken).
     Each token can be scoped to perform a set number of actions and is active
     for 60 minutes. When creating a web component token for this specific
-    component you'll need to use the role: `read:dispute:account_id` or
-    `write:dispute:account_id`. Make sure the value for `account_id` matches the
+    component you'll need to use the role: `read:dispute:dispute_id` or
+    `write:dispute:dispute_id`. Make sure the value for `dispute_id` matches the
     prop you also pass separately.
   </li>
 </ul>


### PR DESCRIPTION
**Summary**

Fixes Authorization instructions for the Dispute Management component: 
`read:dispute:account_id` ❌
`read:dispute:dispute_id` ✅

Links
-----
Closes https://github.com/justifi-tech/engineering-artifacts/issues/293

Developer QA steps
--------------------
- [ ] - http://localhost:6006/?path=/docs/payment-facilitation-dispute-management--docs#authorization should display right Authorization instructions.
