### PR TITLE
Remove `apiOrigin` prop from Payment related components

### DIFF
--- a/packages/webcomponents/src/actions/payment/get-payment-details.ts
+++ b/packages/webcomponents/src/actions/payment/get-payment-details.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPaymentDetails =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ onSuccess, onError, final }) => {
     try {
-      const response = await service.fetchPayment(id, authToken, apiOrigin);
+      const response = await service.fetchPayment(id, authToken);
       if (!response.error) {
         onSuccess({ payment: new Payment(response.data) });
       } else {

--- a/packages/webcomponents/src/actions/payment/get-payment-transactions.ts
+++ b/packages/webcomponents/src/actions/payment/get-payment-transactions.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPaymentTransactions =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ params, onSuccess, onError, final }) => {
     try {
-      const response = await service.fetchPaymentTransactions(id, authToken, params, apiOrigin);
+      const response = await service.fetchPaymentTransactions(id, authToken, params);
       if (!response.error) {
         const balanceTransactions = response.data.map(
           (dataItem) => new PaymentBalanceTransaction(dataItem)

--- a/packages/webcomponents/src/actions/payment/get-payments.ts
+++ b/packages/webcomponents/src/actions/payment/get-payments.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetPayments =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ params, onSuccess, onError, final }) => {
     try {
-      const response = await service.fetchPayments(id, authToken, params, apiOrigin);
+      const response = await service.fetchPayments(id, authToken, params);
 
       if (!response.error) {
         const pagingInfo = {

--- a/packages/webcomponents/src/actions/refund/refund-actions.ts
+++ b/packages/webcomponents/src/actions/refund/refund-actions.ts
@@ -2,10 +2,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makePostRefund =
-  ({ authToken, accountId, paymentId, service, apiOrigin }) =>
+  ({ authToken, accountId, paymentId, service }) =>
     async ({ refundBody, onSuccess, onError, final }) => {
     try {
-      const response = await service.postRefund(paymentId, accountId, authToken, refundBody, apiOrigin);
+      const response = await service.postRefund(paymentId, accountId, authToken, refundBody);
 
       if (!response.error) {
         onSuccess(response);

--- a/packages/webcomponents/src/api/services/payment.service.ts
+++ b/packages/webcomponents/src/api/services/payment.service.ts
@@ -1,22 +1,22 @@
-import { Api, IApiResponseCollection, IApiResponse, IPayment } from '..';
+import { IApiResponseCollection, IApiResponse, IPayment, IPaymentBalanceTransaction } from '..';
+import Api from '../ApiNew';
+
+const api = Api();
 
 export interface IPaymentService {
   fetchPayments(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<IPayment[]>>;
   fetchPayment(
     paymentId: string,
-    authToken: string,
-    apiOrigin?: string
+    authToken: string
   ): Promise<IApiResponse<IPayment>>;
   fetchPaymentTransactions(
     paymentId: string,
-    authToken: string,
     params: any,
-    apiOrigin?: string
+    authToken: string
   ): Promise<IApiResponseCollection<any>>;
 }
 
@@ -24,31 +24,27 @@ export class PaymentService implements IPaymentService {
   async fetchPayments(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin: string = PROXY_API_ORIGIN
+    params: any
   ): Promise<IApiResponseCollection<IPayment[]>> {
-    const api = Api({ authToken, apiOrigin: apiOrigin });
     const endpoint = `account/${accountId}/payments`;
-    return api.get({ endpoint, params });
+    return api.get({ endpoint, params, authToken });
   }
 
   async fetchPayment(
     paymentId: string,
-    authToken: string,
-    apiOrigin: string = PROXY_API_ORIGIN
+    authToken: string
   ): Promise<IApiResponse<IPayment>> {
     const endpoint = `payments/${paymentId}`;
-    return Api({ authToken, apiOrigin }).get({ endpoint });
+    return api.get({ endpoint, authToken });
   }
 
   async fetchPaymentTransactions(
     paymentId: string,
     authToken: string,
-    params: any,
-    apiOrigin: string = PROXY_API_ORIGIN
-  ): Promise<IApiResponseCollection<any>> {
+    params: any
+  ): Promise<IApiResponseCollection<IPaymentBalanceTransaction[]>> {
     const endpoint = `payments/${paymentId}/payment_balance_transactions`;
-    return Api({ authToken, apiOrigin }).get({ endpoint, params });
+    return api.get({ endpoint, params, authToken });
   }
 
 }

--- a/packages/webcomponents/src/api/services/payout.service.ts
+++ b/packages/webcomponents/src/api/services/payout.service.ts
@@ -1,5 +1,8 @@
 import { IPayout, IPayoutBalanceTransaction } from '..';
 import Api, { IApiResponse, IApiResponseCollection } from '../ApiNew';
+
+const api = Api();
+
 export interface IPayoutService {
   fetchPayouts(
     accountId: string,
@@ -20,8 +23,6 @@ export interface IPayoutService {
     params: any,
   ): Promise<IApiResponseCollection<IPayoutBalanceTransaction[]>>;
 }
-
-const api = Api();
 
 export class PayoutService implements IPayoutService {
   async fetchPayouts(

--- a/packages/webcomponents/src/api/services/refund.service.ts
+++ b/packages/webcomponents/src/api/services/refund.service.ts
@@ -1,12 +1,14 @@
-import { Api, IApiResponse, IRefund, RefundPayload } from '..';
+import { IApiResponse, IRefund, RefundPayload } from '..';
+import Api from '../ApiNew';
+
+const api = Api();
 
 export interface IRefundService {
   postRefund(
     paymentId: string,
     accountId: string,
     authToken: string,
-    refundBody: RefundPayload,
-    apiOrigin?: string
+    refundBody: RefundPayload
   ): Promise<IApiResponse<IRefund>>;
 };
 
@@ -15,12 +17,11 @@ export class RefundService implements IRefundService {
     paymentId: string,
     accountId: string,
     authToken: string,
-    refundBody: RefundPayload,
-    apiOrigin: string = PROXY_API_ORIGIN
+    refundBody: RefundPayload
   ): Promise<IApiResponse<IRefund>> {
-    const api = Api({ authToken, apiOrigin });
     const endpoint = `payments/${paymentId}/refunds`;
     const headers = { 'Sub-Account': accountId };
-    return api.post({ endpoint, headers, body: refundBody });
+    const body = refundBody;
+    return api.post({ endpoint, headers, body, authToken });
   }
 }

--- a/packages/webcomponents/src/components/payment-details/payment-details.tsx
+++ b/packages/webcomponents/src/components/payment-details/payment-details.tsx
@@ -15,7 +15,6 @@ import { ComponentErrorEvent } from '../../api/ComponentEvents';
 export class PaymentDetails {
   @Prop() paymentId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   
   @State() getPaymentDetails: Function;
   @State() errorMessage: string = null;
@@ -45,8 +44,7 @@ export class PaymentDetails {
       this.getPaymentDetails = makeGetPaymentDetails({
         id: this.paymentId,
         authToken: this.authToken,
-        service: new PaymentService(),
-        apiOrigin: this.apiOrigin
+        service: new PaymentService()
       });
     } else {
       this.errorMessage = 'Payment ID and Auth Token are required';

--- a/packages/webcomponents/src/components/payment-details/test/get-payment-details.spec.ts
+++ b/packages/webcomponents/src/components/payment-details/test/get-payment-details.spec.ts
@@ -35,8 +35,7 @@ describe('getPaymentDetails', () => {
     const getPaymentDetails = makeGetPaymentDetails({
       id: paymentId,
       authToken: authToken,
-      service: mockServiceInstance,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockServiceInstance
     });
     await getPaymentDetails({ onSuccess, onError, final });
 
@@ -58,8 +57,7 @@ describe('getPaymentDetails', () => {
     const getPaymentDetails = makeGetPaymentDetails({
       id: paymentId,
       authToken: authToken,
-      service: mockServiceInstance,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockServiceInstance
     });
     await getPaymentDetails({ onSuccess, onError, final });
 
@@ -83,8 +81,7 @@ describe('getPaymentDetails', () => {
     const getPaymentDetails = makeGetPaymentDetails({
       id: paymentId,
       authToken: authToken,
-      service: mockServiceInstance,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockServiceInstance
     });
     await getPaymentDetails({ onSuccess, onError, final });
 

--- a/packages/webcomponents/src/components/payment-details/test/payment-details-core.spec.tsx
+++ b/packages/webcomponents/src/components/payment-details/test/payment-details-core.spec.tsx
@@ -18,8 +18,7 @@ describe('payment-details-core', () => {
     const getPaymentDetails = makeGetPaymentDetails({
       id: '123',
       authToken: '123',
-      service: mockPaymentService,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockPaymentService
     });
 
     const page = await newSpecPage({
@@ -42,8 +41,7 @@ describe('payment-details-core', () => {
     const getPaymentDetails = makeGetPaymentDetails({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockService
     });
 
     const page = await newSpecPage({
@@ -64,8 +62,7 @@ describe('payment-details-core', () => {
     const getPaymentDetails = makeGetPaymentDetails({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockService
     });
 
     const errorSpy = jest.fn();
@@ -94,8 +91,7 @@ describe('payment-details-core', () => {
     const getPaymentDetails = makeGetPaymentDetails({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService,
-      apiOrigin: PROXY_API_ORIGIN
+      service: mockService
     });
 
     const errorSpy = jest.fn();

--- a/packages/webcomponents/src/components/payment-transactions-list/payment-transactions-list.tsx
+++ b/packages/webcomponents/src/components/payment-transactions-list/payment-transactions-list.tsx
@@ -24,7 +24,6 @@ export class PaymentTransactionsList {
 
   @Prop() paymentId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys;
 
   @Event({ eventName: 'click-event', bubbles: true }) clickEvent: EventEmitter<ComponentClickEvent>;
@@ -60,8 +59,7 @@ export class PaymentTransactionsList {
       const getPaymentTransactions = makeGetPaymentTransactions({
         id: this.paymentId,
         authToken: this.authToken,
-        service: new PaymentService(),
-        apiOrigin: this.apiOrigin
+        service: new PaymentService()
       });
 
       getPaymentTransactions({

--- a/packages/webcomponents/src/components/payments-list/payments-list.tsx
+++ b/packages/webcomponents/src/components/payments-list/payments-list.tsx
@@ -19,7 +19,6 @@ export class PaymentsList {
 
   @Prop() accountId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys;
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
@@ -47,8 +46,7 @@ export class PaymentsList {
       this.getPayments = makeGetPayments({
         id: this.accountId,
         authToken: this.authToken,
-        service: new PaymentService(),
-        apiOrigin: this.apiOrigin,
+        service: new PaymentService()
       });
     } else {
       this.errorMessage = 'Account ID and Auth Token are required';

--- a/packages/webcomponents/src/components/payments-list/test/get-payments.spec.ts
+++ b/packages/webcomponents/src/components/payments-list/test/get-payments.spec.ts
@@ -10,7 +10,6 @@ describe('makeGetPayments', () => {
   const mockId = '123';
   const mockAuthToken = 'token';
   const mockParams = { limit: 10, page: 1 };
-  const mockApiOrigin = 'http://localhost:3000';
 
   let mockServiceInstance: jest.Mocked<PaymentService>;
 
@@ -37,8 +36,7 @@ describe('makeGetPayments', () => {
     const getPayments = makeGetPayments({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getPayments({ params: mockParams, onSuccess, onError, final });
 
@@ -64,8 +62,7 @@ describe('makeGetPayments', () => {
     const getPayments = makeGetPayments({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getPayments({ params: mockParams, onSuccess, onError, final });
 
@@ -89,8 +86,7 @@ describe('makeGetPayments', () => {
     const getPayments = makeGetPayments({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getPayments({ params: mockParams, onSuccess, onError, final });
 

--- a/packages/webcomponents/src/components/payments-list/test/payments-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/payments-list/test/payments-list-core.spec.tsx
@@ -27,8 +27,7 @@ describe('payments-list-core render and events', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPaymentsService
     });
 
     const page = await newSpecPage({
@@ -53,8 +52,7 @@ describe('payments-list-core render and events', () => {
     const getPayments = makeGetPayments({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockService
     });
 
     const page = await newSpecPage({
@@ -76,8 +74,7 @@ describe('payments-list-core render and events', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPaymentsService
     });
 
     const page = await newSpecPage({
@@ -105,8 +102,7 @@ describe('payments-list-core render and events', () => {
     const getPayments = makeGetPayments({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockService
     });
 
     const errorEvent = jest.fn();
@@ -144,8 +140,7 @@ describe('payments-list-core pagination', () => {
     const getPayments = makeGetPayments({
       id: '123',
       authToken: '123',
-      service: mockPaymentsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockPaymentsService
     });
 
     const page = await newSpecPage({

--- a/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
+++ b/packages/webcomponents/src/components/refund-payment/refund-payment.tsx
@@ -38,7 +38,6 @@ export class RefundPayment {
   @Prop() accountId: string;
   @Prop() paymentId: string;
   @Prop() hideSubmitButton?: boolean = false;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
   @Event({ eventName: 'submit-event' }) submitEvent: EventEmitter<ComponentSubmitEvent>;
@@ -96,8 +95,7 @@ export class RefundPayment {
       const getPayment = makeGetPaymentDetails({
         id: this.paymentId,
         authToken: this.authToken,
-        service: new PaymentService(),
-        apiOrigin: this.apiOrigin
+        service: new PaymentService()
       });
       
       getPayment({
@@ -132,8 +130,7 @@ export class RefundPayment {
       authToken: this.authToken,
       accountId: this.accountId,
       paymentId: this.paymentId,
-      service: new RefundService(),
-      apiOrigin: this.apiOrigin
+      service: new RefundService()
     });
     const values = this.formController.values.getValue();
     this.refundLoading = true;


### PR DESCRIPTION
### Remove `apiOrigin` prop from Payment related components

This PR commits the following:

- removes `apiOrigin` prop from the following components: `payments-list`, `payment-details`, `payment-transactions-list`, `refund-payment`
- Updates service and api files
- Updates broken test files


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/316

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] Component library builds and runs as expected
- [x] Test suites pass

In order to test the config-provider - you'll need to render it anywhere in the payment example files. We're going to test all 3 payment components and the refund component to verify correct behavior. 

`payments-list`

- [x] Do not render config component. `payments-list` successfully requests and displays payments data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `payments-list` component is now using that value as it's api-origin in it's network requests. 

`payment-details`

- [x] Do not render config component. `payment-details` successfully requests and displays payments data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `payment-details` component is now using that value as it's api-origin in it's network requests. 

`payment-transactions-list`

- [x] Do not render config component. `payment-transactions-list` successfully requests and displays payment transactions data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `payment-transactions-list` component is now using that value as it's api-origin in it's network requests. 

`refund-payment`

- [x] Do not render config component. `refund-payment` successfully request and loads payment data on load with default component logic. (successful payment detail request)
- [x] Do not render config component. `refund-payment` successfully posts refund with default component logic. 
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `refund-payment` component is now using that value as it's api-origin in it's network requests. (you should fail the initial request to load payment data)




