### PR TITLE
Remove `apiOrigin` prop from Terminal related components

### DIFF
--- a/packages/webcomponents/src/actions/business/get-business.ts
+++ b/packages/webcomponents/src/actions/business/get-business.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetBusiness =
-  ({ id, authToken, service, apiOrigin = PROXY_API_ORIGIN }) =>
+  ({ id, authToken, service }) =>
   async ({ onSuccess, onError }) => {
     try {
-      const response = await service.fetchBusiness(id, authToken, apiOrigin);
+      const response = await service.fetchBusiness(id, authToken);
 
       if (!response.error) {
         onSuccess({ business: new Business(response.data) });

--- a/packages/webcomponents/src/actions/terminal/get-terminal-models.ts
+++ b/packages/webcomponents/src/actions/terminal/get-terminal-models.ts
@@ -2,14 +2,10 @@ import { ComponentErrorSeverity, TerminalModel } from '../../api';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetTerminalModels =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ onSuccess, onError }) => {
     try {
-      const response = await service.fetchTerminalModels(
-        id,
-        authToken,
-        apiOrigin
-      );
+      const response = await service.fetchTerminalModels(id, authToken);
 
       if (!response.error) {
         const terminals =

--- a/packages/webcomponents/src/actions/terminal/get-terminal-orders.ts
+++ b/packages/webcomponents/src/actions/terminal/get-terminal-orders.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetTerminalOrders = 
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ params, onSuccess, onError, final }) => {
     try {
-      const response = await service.fetchTerminalOrders(id, authToken, params, apiOrigin);
+      const response = await service.fetchTerminalOrders(id, authToken, params);
 
       if (!response.error) {
         const pagingInfo = {

--- a/packages/webcomponents/src/actions/terminal/get-terminals.ts
+++ b/packages/webcomponents/src/actions/terminal/get-terminals.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetTerminals =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
   async ({ params, onSuccess, onError }) => {
     try {
-      const response = await service.fetchTerminals(id, authToken, params, apiOrigin);
+      const response = await service.fetchTerminals(id, authToken, params);
 
       if (!response.error) {
         const pagingInfo = {

--- a/packages/webcomponents/src/api/services/business.service.ts
+++ b/packages/webcomponents/src/api/services/business.service.ts
@@ -1,4 +1,5 @@
 import Api, { IApiResponse } from '../Api';
+import NewApi from '../ApiNew';
 import { IBankAccount } from '../BankAccount';
 import { IBusiness } from '../Business';
 import { DocumentRecordData } from '../Document';
@@ -19,11 +20,11 @@ export interface IBusinessService {
 export class BusinessService implements IBusinessService {
   async fetchBusiness(
     businessId: string,
-    authToken: string,
-    apiOrigin: string = PROXY_API_ORIGIN
+    authToken: string
   ): Promise<IApiResponse<IBusiness>> {
+    const api = NewApi();
     const endpoint = `entities/business/${businessId}`;
-    return Api({ authToken, apiOrigin }).get({ endpoint });
+    return api.get({ endpoint, authToken });
   }
 
   async patchBusiness(

--- a/packages/webcomponents/src/api/services/terminal.service.ts
+++ b/packages/webcomponents/src/api/services/terminal.service.ts
@@ -1,27 +1,26 @@
-import { Api, IApiResponse, IApiResponseCollection, ITerminal } from '..';
+import { IApiResponse, IApiResponseCollection, ITerminal } from '..';
+import Api from '../ApiNew';
+
+const api = Api();
 
 export interface ITerminalService {
   fetchTerminals(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<ITerminal[]>>;
   fetchTerminal(
     terminalId: string,
-    authToken: string,
-    apiOrigin?: string
+    authToken: string
   ): Promise<IApiResponse<ITerminal>>;
   fetchTerminalModels(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<ITerminal>>;
   orderTerminals(
     authToken: string,
-    terminalOrder: any,
-    apiOrigin?: string
+    terminalOrder: any
   ): Promise<IApiResponse<ITerminal>>;
 }
 
@@ -29,45 +28,37 @@ export class TerminalService implements ITerminalService {
   async fetchTerminals(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin: string = PROXY_API_ORIGIN
+    params: any
   ): Promise<IApiResponseCollection<ITerminal[]>> {
-    const headers = { Account: accountId };
-
-    const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals';
-    return api.get({ endpoint, params, headers });
+    const headers = { Account: accountId };
+    return api.get({ endpoint, params, headers, authToken });
   }
 
   async fetchTerminal(
     terminalId: string,
-    authToken: string,
-    apiOrigin: string = PROXY_API_ORIGIN
+    authToken: string
   ): Promise<IApiResponse<ITerminal>> {
     const endpoint = `terminals/${terminalId}`;
-    return Api({ authToken, apiOrigin: apiOrigin }).get({ endpoint });
+    return api.get({ endpoint, authToken });
   }
 
   async fetchTerminalModels(
     accountId: string,
-    authToken: string,
-    apiOrigin: string = API_ORIGIN
+    authToken: string
   ): Promise<IApiResponseCollection<ITerminal>> {
-    const headers = { 'sub-account': accountId };
-
-    const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals/order_models';
-    return api.get({ endpoint, headers });
+    const headers = { 'sub-account': accountId };
+    return api.get({ endpoint, headers, authToken });
   }
 
   async orderTerminals(
     authToken: string,
-    terminalOrder: any,
-    apiOrigin: string = API_ORIGIN
+    terminalOrder: any
   ): Promise<IApiResponse<ITerminal>> {
-    const headers = { 'sub-account': terminalOrder.sub_account_id };
-    const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals/orders';
-    return api.post({ endpoint, body: terminalOrder, headers });
+    const body = terminalOrder;
+    const headers = { 'sub-account': terminalOrder.sub_account_id };
+    return api.post({ endpoint, body, headers, authToken });
   }
 }

--- a/packages/webcomponents/src/api/services/terminal_orders.service.ts
+++ b/packages/webcomponents/src/api/services/terminal_orders.service.ts
@@ -1,11 +1,13 @@
-import { Api, IApiResponseCollection, ITerminalOrder } from '..';
+import { IApiResponseCollection, ITerminalOrder } from '..';
+import Api from '../ApiNew';
+
+const api = Api();
 
 export interface ITerminalOrderService {
   fetchTerminalOrders(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<ITerminalOrder[]>>;
 }
 
@@ -13,17 +15,10 @@ export class TerminalOrderService implements ITerminalOrderService {
   async fetchTerminalOrders(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin: string = PROXY_API_ORIGIN
+    params: any
   ): Promise<IApiResponseCollection<ITerminalOrder[]>> {
-    const headers = { account: accountId };
-
-    const api = Api({ authToken, apiOrigin });
     const endpoint = 'terminals/orders';
-    return api.get({
-      endpoint,
-      params,
-      headers,
-    });
+    const headers = { account: accountId };
+    return api.get({ endpoint, params, headers, authToken });
   }
 }

--- a/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
+++ b/packages/webcomponents/src/components/order-terminals/order-terminals.tsx
@@ -25,7 +25,6 @@ export class OrderTerminals {
   @Prop() authToken: string;
   @Prop() accountId: string;
   @Prop() shipping: boolean = false;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() submitButtonText: string = 'Submit Order';
 
   @State() loading = {
@@ -78,8 +77,7 @@ export class OrderTerminals {
     makeGetBusiness({
       id: this.businessId,
       authToken: this.authToken,
-      service: new BusinessService(),
-      apiOrigin: this.apiOrigin,
+      service: new BusinessService()
     })({
       onSuccess: ({ business }) => {
         this.business = new Business(business);
@@ -96,8 +94,7 @@ export class OrderTerminals {
     makeGetTerminalModels({
       id: this.accountId,
       authToken: this.authToken,
-      service: new TerminalService(),
-      apiOrigin: this.apiOrigin,
+      service: new TerminalService()
     })({
       onSuccess: ({ terminals, orderLimit }) => {
         this.terminalModels = terminals;
@@ -114,8 +111,7 @@ export class OrderTerminals {
   private submitOrder() {
     const orderTerminals = makeOrderTerminals({
       authToken: this.authToken,
-      service: new TerminalService(),
-      apiOrigin: this.apiOrigin,
+      service: new TerminalService()
     });
 
     this.submitting = true;

--- a/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/terminal-orders-list.tsx
@@ -18,7 +18,6 @@ export class TerminalOrdersList {
 
   @Prop() accountId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
@@ -36,8 +35,7 @@ export class TerminalOrdersList {
       this.getTerminalOrders = makeGetTerminalOrders({
         id: this.accountId,
         authToken: this.authToken,
-        service: new TerminalOrderService(),
-        apiOrigin: this.apiOrigin
+        service: new TerminalOrderService()
       });
     } else {
       this.errorMessage = 'Account ID and Auth Token are required';

--- a/packages/webcomponents/src/components/terminal-orders-list/test/get-terminal-orders.spec.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/get-terminal-orders.spec.tsx
@@ -10,7 +10,6 @@ describe('makeGetTerminalOrders', () => {
   const mockId = '123';
   const mockAuthToken = 'fake_token_789';
   const mockParams = { limit: 10, page: 1 };
-  const mockApiOrigin = 'http://localhost:3000';
 
   const onSuccess = jest.fn();
   const onError = jest.fn();
@@ -38,8 +37,7 @@ describe('makeGetTerminalOrders', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin
+      service: mockServiceInstance
     });
     await getTerminalOrders({ params: mockParams, onSuccess, onError, final });
 
@@ -64,8 +62,7 @@ describe('makeGetTerminalOrders', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin
+      service: mockServiceInstance
     });
     await getTerminalOrders({ params: mockParams, onSuccess, onError, final });
 
@@ -88,8 +85,7 @@ describe('makeGetTerminalOrders', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin
+      service: mockServiceInstance
     });
     await getTerminalOrders({ params: mockParams, onSuccess, onError, final });
 

--- a/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/terminal-orders-list/test/terminal-orders-list-core.spec.tsx
@@ -25,8 +25,7 @@ describe('terminal-orders-list-core', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: '123',
       authToken: '123',
-      service: mockTerminalsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockTerminalsService
     });
 
     const page = await newSpecPage({
@@ -51,8 +50,7 @@ describe('terminal-orders-list-core', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockService
     });
 
     const page = await newSpecPage({
@@ -74,8 +72,7 @@ describe('terminal-orders-list-core', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: '123',
       authToken: '123',
-      service: mockTerminalsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockTerminalsService
     });
 
     const page = await newSpecPage({
@@ -103,8 +100,7 @@ describe('terminal-orders-list-core', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockService
     });
 
     const errorEvent = jest.fn();
@@ -138,8 +134,7 @@ describe('terminal-orders-list-core pagination', () => {
     const getTerminalOrders = makeGetTerminalOrders({
       id: '123',
       authToken: '123',
-      service: mockTerminalsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockTerminalsService
     });
 
     const page = await newSpecPage({

--- a/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
+++ b/packages/webcomponents/src/components/terminals-list/terminals-list.tsx
@@ -22,7 +22,6 @@ export class TerminalsList {
 
   @Prop() accountId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys;
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
@@ -55,8 +54,7 @@ export class TerminalsList {
       this.getTerminals = makeGetTerminals({
         id: this.accountId,
         authToken: this.authToken,
-        service: new TerminalService(),
-        apiOrigin: this.apiOrigin
+        service: new TerminalService()
       });
     } else {
       this.errorMessage = 'Account ID and Auth Token are required';

--- a/packages/webcomponents/src/components/terminals-list/test/get-terminals.spec.tsx
+++ b/packages/webcomponents/src/components/terminals-list/test/get-terminals.spec.tsx
@@ -10,7 +10,6 @@ describe('makeGetTerminals', () => {
   const mockId = '123';
   const mockAuthToken = 'fake_token_789';
   const mockParams = { limit: 10, page: 1 };
-  const mockApiOrigin = 'http://localhost:3000';
 
   let mockServiceInstance: jest.Mocked<TerminalService>;
 
@@ -36,8 +35,7 @@ describe('makeGetTerminals', () => {
     const getTerminals = makeGetTerminals({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin
+      service: mockServiceInstance
     });
     await getTerminals({ params: mockParams, onSuccess, onError });
 
@@ -62,8 +60,7 @@ describe('makeGetTerminals', () => {
     const getTerminals = makeGetTerminals({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin
+      service: mockServiceInstance
     });
     await getTerminals({ params: mockParams, onSuccess, onError });
 
@@ -86,8 +83,7 @@ describe('makeGetTerminals', () => {
     const getTerminals = makeGetTerminals({
       id: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin
+      service: mockServiceInstance
     });
     await getTerminals({ params: mockParams, onSuccess, onError });
 

--- a/packages/webcomponents/src/components/terminals-list/test/terminals-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/terminals-list/test/terminals-list-core.spec.tsx
@@ -28,8 +28,7 @@ describe('terminals-list-core', () => {
     const getTerminals = makeGetTerminals({
       id: '123',
       authToken: '123',
-      service: mockTerminalsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockTerminalsService
     });
 
     const mockSubAccountsService = {
@@ -64,8 +63,7 @@ describe('terminals-list-core', () => {
     const getTerminals = makeGetTerminals({
       id: 'some-id',
       authToken: 'some-auth-token',
-      service: mockService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockService
     });
 
     const mockSubAccountsService = {
@@ -97,8 +95,7 @@ describe('terminals-list-core', () => {
     const getTerminals = makeGetTerminals({
       id: '123',
       authToken: '123',
-      service: mockTerminalsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockTerminalsService
     });
 
     const mockSubAccountsService = {
@@ -136,8 +133,7 @@ describe('terminals-list-core', () => {
     const getTerminals = makeGetTerminals({
       id: 'some-id',
       authToken: 'some-auth',
-      service: mockService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockService
     });
 
     const mockSubAccountsService = {
@@ -181,8 +177,7 @@ describe('terminals-list-core pagination', () => {
     const getTerminals = makeGetTerminals({
       id: '123',
       authToken: '123',
-      service: mockTerminalsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockTerminalsService
     });
 
     const mockSubAccountsService = {


### PR DESCRIPTION
### Remove `apiOrigin` prop from Terminal related components

This PR commits the following:

- removes `apiOrigin` prop from the following components: `terminals-list`, `terminal-orders-list`, `order-terminals`
- Updates service and api files
- Updates broken test files


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/328

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] Component library builds and runs as expected
- [x] Test suites pass

In order to test the config-provider - you'll need to render it anywhere in the payment example files. We're going to test all 3 payment components and the refund component to verify correct behavior. 

`terminals-list`

- [x] Do not render config component. `terminals-list` successfully requests and displays terminals data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `terminals-list` component is now using that value as it's api-origin in it's network requests. 

`terminal-orders-list`

- [x] Do not render config component. `terminal-orders-list` successfully requests and displays terminal-orders data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `terminal-orders-list` component is now using that value as it's api-origin in it's network requests. 

`order-terminals`

- [x] Do not render config component. `order-terminals` successfully request and loads business and terminal model data on load with default component logic.
- [x] Do not render config component. `order-terminals` successfully posts terminal order with default component logic. 
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `order-terminals` component is now using that value as it's api-origin in it's network requests. (you should fail the initial request to load business and terminal model data)




