### PR TITLE
Implement `config-state` to `tokenize-payment`, `checkouts-list`, `dispute`,  and `analytics`

### DIFF
--- a/packages/webcomponents/src/actions/checkout/get-checkouts.ts
+++ b/packages/webcomponents/src/actions/checkout/get-checkouts.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetCheckouts =
-  ({ accountId, authToken, service, apiOrigin }) =>
+  ({ accountId, authToken, service }) =>
     async ({ params, onSuccess, onError }) => {
       try {
-        const response = await service.fetchCheckouts(accountId, authToken, params, apiOrigin);
+        const response = await service.fetchCheckouts(accountId, authToken, params);
 
         if (!response.error) {
           const pagingInfo = {

--- a/packages/webcomponents/src/actions/dispute/dispute-actions.ts
+++ b/packages/webcomponents/src/actions/dispute/dispute-actions.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../api/services/utils';
 
 export const makeGetDispute =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
     async ({ onSuccess, onError }) => {
       try {
-        const response = await service.fetchDispute(id, authToken, apiOrigin);
+        const response = await service.fetchDispute(id, authToken);
 
         if (!response.error) {
           const pagingInfo = {

--- a/packages/webcomponents/src/api/ApiNew.ts
+++ b/packages/webcomponents/src/api/ApiNew.ts
@@ -42,7 +42,7 @@ interface GetProps {
 }
 
 interface PostProps {
-  authToken: string;
+  authToken?: string;
   endpoint: string;
   body?: any;
   params?: any;

--- a/packages/webcomponents/src/api/services/analytics.service.ts
+++ b/packages/webcomponents/src/api/services/analytics.service.ts
@@ -1,4 +1,6 @@
-import Api from '../Api';
+import Api from "../ApiNew";
+
+const api = Api();
 
 interface iAnayticsBody {
   event_type: string;
@@ -15,6 +17,6 @@ interface iAnayticsBody {
 export class AnalyticsService {
   async record(body: iAnayticsBody): Promise<void> {
     const endpoint = 'analytics';
-    return Api({ apiOrigin: PROXY_API_ORIGIN }).post({ endpoint, body });
+    return api.post({ endpoint, body });
   }
 }

--- a/packages/webcomponents/src/api/services/checkout.service.ts
+++ b/packages/webcomponents/src/api/services/checkout.service.ts
@@ -5,6 +5,8 @@ import {
   ICheckout,
   ICheckoutCompleteResponse,
 } from '..';
+import NewApi from '../ApiNew';
+
 
 export interface ICheckoutService {
   fetchCheckout(
@@ -15,8 +17,7 @@ export interface ICheckoutService {
   fetchCheckouts(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<ICheckout[]>>;
 
   complete(
@@ -38,18 +39,12 @@ export class CheckoutService implements ICheckoutService {
   async fetchCheckouts(
     accountId: string,
     authToken: string,
-    params: any,
-    apiOrigin?: string
+    params: any
   ): Promise<IApiResponseCollection<ICheckout[]>> {
-    if (!apiOrigin) {
-      apiOrigin = PROXY_API_ORIGIN;
-    }
-
+    const api = NewApi();
     const headers = { Account: accountId };
-
-    const api = Api({ authToken, apiOrigin: apiOrigin });
     const endpoint = 'checkouts';
-    return api.get({ endpoint, params, headers });
+    return api.get({ endpoint, params, headers, authToken });
   }
 
   async complete(

--- a/packages/webcomponents/src/api/services/checkout.service.ts
+++ b/packages/webcomponents/src/api/services/checkout.service.ts
@@ -1,12 +1,12 @@
 import {
-  Api,
   IApiResponse,
   IApiResponseCollection,
   ICheckout,
   ICheckoutCompleteResponse,
 } from '..';
-import NewApi from '../ApiNew';
+import Api from '../ApiNew';
 
+const api = Api();
 
 export interface ICheckoutService {
   fetchCheckout(
@@ -33,7 +33,7 @@ export class CheckoutService implements ICheckoutService {
     checkoutId: string
   ): Promise<IApiResponse<ICheckout>> {
     const endpoint = `checkouts/${checkoutId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get({ endpoint });
+    return api.get({ endpoint, authToken });
   }
 
   async fetchCheckouts(
@@ -41,9 +41,8 @@ export class CheckoutService implements ICheckoutService {
     authToken: string,
     params: any
   ): Promise<IApiResponseCollection<ICheckout[]>> {
-    const api = NewApi();
-    const headers = { Account: accountId };
     const endpoint = 'checkouts';
+    const headers = { Account: accountId };
     return api.get({ endpoint, params, headers, authToken });
   }
 
@@ -53,15 +52,12 @@ export class CheckoutService implements ICheckoutService {
     payment: { payment_mode: string; payment_token?: string }
   ): Promise<IApiResponse<ICheckoutCompleteResponse>> {
     const endpoint = `checkouts/${checkoutId}/complete`;
-    const payload: { payment_mode: string; payment_token?: string } = {
+    const body: { payment_mode: string; payment_token?: string } = {
       payment_mode: payment.payment_mode,
     };
     if (payment.payment_token) {
-      payload.payment_token = payment.payment_token;
+      body.payment_token = payment.payment_token;
     }
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
-      endpoint,
-      body: payload,
-    });
+    return api.post({ endpoint, body, authToken });
   }
 }

--- a/packages/webcomponents/src/api/services/dispute.service.ts
+++ b/packages/webcomponents/src/api/services/dispute.service.ts
@@ -1,5 +1,8 @@
-import { Api, IApiResponse } from '..';
+import { IApiResponse } from '..';
+import Api from '../ApiNew';
 import { IDispute } from '../Dispute';
+
+const api = Api();
 
 export interface IDisputeService {
   fetchDispute(
@@ -32,7 +35,7 @@ export class DisputeService implements IDisputeService {
     authToken: string
   ): Promise<IApiResponse<IDispute>> {
     const endpoint = `disputes/${disputeId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get({ endpoint });
+    return api.get({ endpoint, authToken });
   }
 
   async updateDisputeResponse(
@@ -41,10 +44,8 @@ export class DisputeService implements IDisputeService {
     payload: any
   ): Promise<IApiResponse<IDispute>> {
     const endpoint = `disputes/${disputeId}/response`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.patch({ endpoint, body, authToken });
   }
 
   async submitDisputeResponse(
@@ -53,10 +54,8 @@ export class DisputeService implements IDisputeService {
     payload: any
   ): Promise<IApiResponse<IDispute>> {
     const endpoint = `disputes/${disputeId}/response`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.post({ endpoint, body, authToken });
   }
 
   async createDisputeEvidence(
@@ -65,9 +64,7 @@ export class DisputeService implements IDisputeService {
     payload: any
   ): Promise<IApiResponse<any>> {
     const endpoint = `disputes/${disputeId}/evidence`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).put({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.put({ endpoint, body, authToken });
   }
 }

--- a/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
+++ b/packages/webcomponents/src/components/checkout/bank-account-form/bank-account-form.tsx
@@ -1,16 +1,36 @@
-import { Component, h, Host, Method, Prop, State } from "@stencil/core";
+import { Component, h, Host, Method, State } from "@stencil/core";
 import BankAccountFormSkeleton from "./bank-account-form-skeleton";
+import { configState, waitForConfig } from "../../config-provider/config-state";
 
 @Component({
   tag: "bank-account-form",
 })
 export class BankAccountForm {
-  @Prop() iframeOrigin: string;
-
   @State() isReady: boolean = false;
+  @State() iframeOrigin: string;
 
   private accountNumberIframeElement!: HTMLIframeInputElement;
   private routingNumberIframeElement!: HTMLIframeInputElement;
+
+  async componentWillLoad() {
+    await waitForConfig();
+    this.iframeOrigin = configState.iframeOrigin;
+  }
+  
+  componentDidRender() {
+    const elements = [
+      this.accountNumberIframeElement,
+      this.routingNumberIframeElement,
+    ];
+
+    Promise.all(elements.map((element) => {
+      return new Promise<void>((resolve) => {
+        element.addEventListener('iframeLoaded', () => { resolve(); });
+      });
+    })).then(() => {
+      this.isReady = true;
+    });
+  }
 
   @Method()
   async validate(): Promise<any> {
@@ -32,20 +52,6 @@ export class BankAccountForm {
     );
   }
 
-  componentDidRender() {
-    const elements = [
-      this.accountNumberIframeElement,
-      this.routingNumberIframeElement,
-    ];
-
-    Promise.all(elements.map((element) => {
-      return new Promise<void>((resolve) => {
-        element.addEventListener('iframeLoaded', () => { resolve(); });
-      });
-    })).then(() => {
-      this.isReady = true;
-    });
-  }
 
   render() {
     return (

--- a/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
+++ b/packages/webcomponents/src/components/checkout/card-form/card-form.tsx
@@ -1,18 +1,23 @@
-import { Component, h, Host, Method, Prop, State } from "@stencil/core";
+import { Component, h, Host, Method, State } from "@stencil/core";
 import CardFormSkeleton from "./card-form-skeleton";
+import { configState, waitForConfig } from "../../config-provider/config-state";
 
 @Component({
   tag: "card-form",
 })
 export class CardForm {
-  @Prop() iframeOrigin: string;
-
   @State() isReady: boolean = false;
+  @State() iframeOrigin: string;
 
   private cardNumberIframeElement!: HTMLIframeInputElement;
   private expirationMonthIframeElement!: HTMLIframeInputElement;
   private expirationYearIframeElement!: HTMLIframeInputElement;
   private cvvIframeElement!: HTMLIframeInputElement;
+
+  async componentWillLoad() {
+    await waitForConfig();
+    this.iframeOrigin = configState.iframeOrigin;
+  }
 
   componentDidRender() {
     const elements = [

--- a/packages/webcomponents/src/components/checkout/checkout-core.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout-core.tsx
@@ -18,7 +18,6 @@ export class CheckoutCore {
   @Prop() getCheckout: Function;
   @Prop() complete: Function;
   @Prop() checkoutId: string;
-  @Prop() iframeOrigin: string;
 
   @Prop() disableCreditCard?: boolean;
   @Prop() disableBankAccount?: boolean;
@@ -178,7 +177,6 @@ export class CheckoutCore {
             savedPaymentMethods={this.checkout?.payment_methods || []}
             paymentAmount={this.checkout?.payment_amount}
             insuranceToggled={this.insuranceToggled}
-            iframeOrigin={this.iframeOrigin}
           />
         </div>
       </section>

--- a/packages/webcomponents/src/components/checkout/checkout.tsx
+++ b/packages/webcomponents/src/components/checkout/checkout.tsx
@@ -20,7 +20,6 @@ export class Checkout {
   @Prop() disablePaymentMethodGroup?: boolean;
   @Prop() hideCardBillingForm?: boolean;
   @Prop() hideBankAccountBillingForm?: boolean;
-  @Prop() iframeOrigin?: string = IFRAME_ORIGIN;
 
   @State() getCheckout: Function;
   @State() complete: Function;
@@ -95,7 +94,6 @@ export class Checkout {
         disablePaymentMethodGroup={this.disablePaymentMethodGroup}
         hideCardBillingForm={this.hideCardBillingForm}
         hideBankAccountBillingForm={this.hideBankAccountBillingForm}
-        iframeOrigin={this.iframeOrigin}
         ref={el => {
           if (el) {
             this.checkoutCoreRef = el;

--- a/packages/webcomponents/src/components/checkout/new-payment-method.tsx
+++ b/packages/webcomponents/src/components/checkout/new-payment-method.tsx
@@ -25,7 +25,6 @@ export class NewPaymentMethod {
   @Prop() showAch?: boolean;
   @Prop() hideCardBillingForm?: boolean;
   @Prop() hideBankAccountBillingForm?: boolean;
-  @Prop() iframeOrigin: string;
 
   @State() saveNewPaymentMethodChecked: boolean = false;
 
@@ -103,15 +102,9 @@ export class NewPaymentMethod {
       <div class="mt-4 pb-4">
         <hidden-input />
           {paymentMethodType === 'card' ? (
-            <card-form
-              ref={(el) => this.paymentMethodFormRef = el}
-              iframeOrigin={this.iframeOrigin}
-            />
+            <card-form ref={(el) => this.paymentMethodFormRef = el} />
           ) : (
-            <bank-account-form
-              ref={(el) => this.paymentMethodFormRef = el}
-              iframeOrigin={this.iframeOrigin}
-            />
+            <bank-account-form ref={(el) => this.paymentMethodFormRef = el} />
           )}
         <justifi-billing-form
           ref={(el) => (this.billingFormRef = el)}

--- a/packages/webcomponents/src/components/checkout/payment-method-options.tsx
+++ b/packages/webcomponents/src/components/checkout/payment-method-options.tsx
@@ -22,11 +22,9 @@ export class PaymentMethodOptions {
   @Prop() paymentAmount: number;
   @Prop() hideCardBillingForm?: boolean;
   @Prop() hideBankAccountBillingForm?: boolean;
-  @Prop() iframeOrigin: string;
 
   @State() selectedPaymentMethodId: string;
   @State() paymentMethodOptions: PaymentMethodOption[] = [];
-
 
   private selectedPaymentMethodOptionRef?: HTMLJustifiNewPaymentMethodElement | HTMLJustifiSavedPaymentMethodElement | HTMLJustifiSezzlePaymentMethodElement;
 
@@ -104,7 +102,6 @@ export class PaymentMethodOptions {
                 paymentMethodGroupId={this.paymentMethodGroupId}
                 hideCardBillingForm={this.hideCardBillingForm}
                 hideBankAccountBillingForm={this.hideBankAccountBillingForm}
-                iframeOrigin={this.iframeOrigin}
                 ref={(el) => {
                   if (isSelected) {
                     this.selectedPaymentMethodOptionRef = el;

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout.spec.tsx.snap
@@ -44,7 +44,7 @@ exports[`justifi-checkout renders loading 1`] = `
                 <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="height: 300px;"></div>
               </div>
               <div class="visually-hidden">
-                <justifi-payment-method-options iframeorigin="https://components.justifi.ai" show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
+                <justifi-payment-method-options show-ach="" show-bnpl="" show-card="" show-saved-payment-methods=""></justifi-payment-method-options>
               </div>
             </section>
           </div>

--- a/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/checkouts-list.tsx
@@ -22,7 +22,6 @@ export class CheckoutsList {
 
   @Prop() accountId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
   @Prop() columns?: string = defaultColumnsKeys;
 
   @Event({ eventName: 'error-event' }) errorEvent: EventEmitter<ComponentErrorEvent>;
@@ -55,8 +54,7 @@ export class CheckoutsList {
       this.getCheckouts = makeGetCheckouts({
         accountId: this.accountId,
         authToken: this.authToken,
-        service: new CheckoutService(),
-        apiOrigin: this.apiOrigin,
+        service: new CheckoutService()
       });
     } else {
       this.errorMessage = 'Account ID and Auth Token are required';

--- a/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-core.spec.tsx
+++ b/packages/webcomponents/src/components/checkouts-list/test/checkouts-list-core.spec.tsx
@@ -28,8 +28,7 @@ describe('checkouts-list-core', () => {
     const getCheckouts = makeGetCheckouts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockCheckoutsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockCheckoutsService
     });
 
     const mockSubAccountsService = {
@@ -64,8 +63,7 @@ describe('checkouts-list-core', () => {
     const getCheckouts = makeGetCheckouts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockCheckoutsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockCheckoutsService
     });
 
     const mockSubAccountsService = {
@@ -97,8 +95,7 @@ describe('checkouts-list-core', () => {
     const getCheckouts = makeGetCheckouts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockCheckoutsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockCheckoutsService
     });
 
     const mockSubAccountsService = {
@@ -137,8 +134,7 @@ describe('checkouts-list-core', () => {
     const getCheckouts = makeGetCheckouts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockCheckoutsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockCheckoutsService
     });
 
     const mockSubAccountsService = {
@@ -182,8 +178,7 @@ describe('checkouts-list-core pagination', () => {
     const getCheckouts = makeGetCheckouts({
       accountId: 'mock_id',
       authToken: '123',
-      service: mockCheckoutsService,
-      apiOrigin: 'http://localhost:3000'
+      service: mockCheckoutsService
     });
 
     const mockSubAccountsService = {

--- a/packages/webcomponents/src/components/checkouts-list/test/get-checkouts.spec.ts
+++ b/packages/webcomponents/src/components/checkouts-list/test/get-checkouts.spec.ts
@@ -10,7 +10,6 @@ describe('makeGetCheckouts', () => {
   const mockId = 'mock_id';
   const mockAuthToken = 'mock_token';
   const mockParams = { limit: 10, page: 1 };
-  const mockApiOrigin = 'http://localhost:3000';
 
   let mockServiceInstance: jest.Mocked<CheckoutService>;
 
@@ -36,8 +35,7 @@ describe('makeGetCheckouts', () => {
     const getCheckoutsList = makeGetCheckouts({
       accountId: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getCheckoutsList({ params: mockParams, onSuccess, onError });
 
@@ -62,8 +60,7 @@ describe('makeGetCheckouts', () => {
     const getCheckoutsList = makeGetCheckouts({
       accountId: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getCheckoutsList({ params: mockParams, onSuccess, onError });
 
@@ -86,8 +83,7 @@ describe('makeGetCheckouts', () => {
     const getCheckoutsList = makeGetCheckouts({
       accountId: mockId,
       authToken: mockAuthToken,
-      service: mockServiceInstance,
-      apiOrigin: mockApiOrigin,
+      service: mockServiceInstance
     });
     await getCheckoutsList({ params: mockParams, onSuccess, onError });
 

--- a/packages/webcomponents/src/components/config-provider/config-provider.tsx
+++ b/packages/webcomponents/src/components/config-provider/config-provider.tsx
@@ -7,13 +7,13 @@ import { setConfigState } from './config-state';
 })
 export class ConfigProvider {
   @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
-  @Prop() iFrameOrigin?: string = IFRAME_ORIGIN;
+  @Prop() iframeOrigin?: string = IFRAME_ORIGIN;
   @Prop() accountId?: string = '';
 
   componentWillLoad() {
     setConfigState({
       apiOrigin: this.apiOrigin,
-      iFrameOrigin: this.iFrameOrigin,
+      iframeOrigin: this.iframeOrigin,
       accountId: this.accountId
     });
   }

--- a/packages/webcomponents/src/components/config-provider/config-state.ts
+++ b/packages/webcomponents/src/components/config-provider/config-state.ts
@@ -2,13 +2,13 @@ import { createStore } from '@stencil/store';
 
 interface ConfigState {
   apiOrigin?: string;
-  iFrameOrigin?: string;
+  iframeOrigin?: string;
   accountId?: string;
 }
 
 const initialState: ConfigState = {
   apiOrigin: PROXY_API_ORIGIN,
-  iFrameOrigin: IFRAME_ORIGIN,
+  iframeOrigin: IFRAME_ORIGIN,
   accountId: '',
 };
 

--- a/packages/webcomponents/src/components/dispute-management/dispute-management.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-management.tsx
@@ -12,7 +12,6 @@ import { ComponentErrorEvent } from '../../api/ComponentEvents';
 export class DisputeManagement {
   @Prop() disputeId: string;
   @Prop() authToken: string;
-  @Prop() apiOrigin?: string = PROXY_API_ORIGIN;
 
   @State() getDispute: Function;
   @State() errorMessage: string = null;
@@ -42,8 +41,7 @@ export class DisputeManagement {
       this.getDispute = makeGetDispute({
         id: this.disputeId,
         authToken: this.authToken,
-        service: new DisputeService(),
-        apiOrigin: this.apiOrigin,
+        service: new DisputeService()
       });
     } else {
       this.errorMessage = 'Dispute ID and Auth Token are required';

--- a/packages/webcomponents/src/components/dispute-management/dispute-response/dispute-response-actions.ts
+++ b/packages/webcomponents/src/components/dispute-management/dispute-response/dispute-response-actions.ts
@@ -3,10 +3,10 @@ import { ComponentErrorSeverity } from '../../../api/ComponentError';
 import { getErrorCode, getErrorMessage } from '../../../api/services/utils';
 
 export const makeGetDisputeResponse =
-  ({ id, authToken, service, apiOrigin }) =>
+  ({ id, authToken, service }) =>
     async ({ params, onSuccess, onError }) => {
       try {
-        const response = await service.fetchDisputeResponse(id, authToken, params, apiOrigin);
+        const response = await service.fetchDisputeResponse(id, authToken, params);
 
         if (!response.error) {
           const pagingInfo = {

--- a/packages/webcomponents/src/components/tokenize-payment-method/tokenize-payment-method.tsx
+++ b/packages/webcomponents/src/components/tokenize-payment-method/tokenize-payment-method.tsx
@@ -25,7 +25,6 @@ export class TokenizePaymentMethod {
   @Prop() hideSubmitButton?: boolean;
   @Prop() hideCardBillingForm?: boolean;
   @Prop() hideBankAccountBillingForm?: boolean;
-  @Prop() iframeOrigin?: string = IFRAME_ORIGIN;
 
   @State() isLoading: boolean = false;
 
@@ -98,7 +97,6 @@ export class TokenizePaymentMethod {
                   hideBankAccountBillingForm={this.hideBankAccountBillingForm}
                   authToken={this.authToken}
                   account-id={this.accountId}
-                  iframeOrigin={this.iframeOrigin}
                 />
               </div>
               <div class="col-12">


### PR DESCRIPTION
### Implement `config-state` to `tokenize-payment-method`, `checkouts-list`, `dispute`,  and `analytics`

This PR commits the following:

- removes `apiOrigin` prop from the following components: `checkouts-list`, `dispute`. Now uses new api file which awaits config provider to determine api-origin used for requests.
- Removes `iframeOrigin` prop from `tokenize-payment-method`. Now waits for config-provider before using provided iframe value or falling back to default value in env variables
- Updates service and api files for checkouts and disputes.
- Updates broken test files


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/336

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] Component library builds and runs as expected
- [x] Test suites pass

In order to test the config-provider - you'll need to render it anywhere in the payment example files. We're going to test all 3 payment components and the refund component to verify correct behavior. 

`checkouts-list`

- [x] Do not render config component. `checkouts-list` successfully requests and displays checkouts data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `checkouts-list` component is now using that value as it's api-origin in it's network requests. 

`dispute`

- [x] Do not render config component. `dispute` successfully requests and displays dispute data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `dispute` component is now using that value as it's api-origin in it's network requests. 

`tokenize-payment-method`

- [x] Do not render config component. `tokenize-payment-method` loads and uses default env variable for iframeOrigin in iframe inputs.
- [x] Render `justifi-config-provider` in example file body and set `iframe-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://components.justifi.ai`. Verify that `tokenize-payment-method` component is now using that value as it's iframe-origin in the iframe inputs



