### PR TITLE
`PaymentProvisioning`: add clearer error message for `tax_id` field

### DIFF
--- a/.changeset/spotty-lands-ring.md
+++ b/.changeset/spotty-lands-ring.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Update tooltip and error text for `tax_id` (SSN / EIN) field in the first form step of the `justifi-payment-provisioning` component. Tooltip and error text has been updated to clarify that tax ID value must be entered without dashes or hyphens.

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -176,7 +176,7 @@ export class BusinessCoreInfoFormStepCore {
                 inputHandler={this.inputHandler}
                 keyDownHandler={numberOnlyHandler}
                 maxLength={9}
-                helpText="Employer Identification Numbers (EINs) are nine digits. The federal tax identification number/EIN issued to you by the IRS. It can be found on your tax returns. Enter value without dashes or spaces."
+                helpText="Employer Identification Numbers (EINs) are nine digits. The federal tax identification number/EIN issued to you by the IRS. It can be found on your tax returns. Enter value without dashes."
               />
             </div>
             <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -176,7 +176,7 @@ export class BusinessCoreInfoFormStepCore {
                 inputHandler={this.inputHandler}
                 keyDownHandler={numberOnlyHandler}
                 maxLength={9}
-                helpText="Employer Identification Numbers (EINs) are nine digits. The federal tax identification number/EIN issued to you by the IRS. It can be found on your tax returns."
+                helpText="Employer Identification Numbers (EINs) are nine digits. The federal tax identification number/EIN issued to you by the IRS. It can be found on your tax returns. Enter value without dashes or spaces."
               />
             </div>
             <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -20,7 +20,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     doing_business_as: doingBusinessAsValidation.nullable(),
     classification: businessClassificationValidation.required('Select business classification'),
     industry: industryValidation.required('Enter a business industry'),
-    tax_id: taxIdValidation.required('Enter tax id, SSN, or EIN'),
+    tax_id: taxIdValidation.required('Enter valid tax id (SSN or EIN) without dashes'),
     date_of_incorporation: dateOfIncorporationValidation.required('Enter date of incorporation'),
   });
 

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -20,7 +20,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     doing_business_as: doingBusinessAsValidation.nullable(),
     classification: businessClassificationValidation.required('Select business classification'),
     industry: industryValidation.required('Enter a business industry'),
-    tax_id: taxIdValidation.required('Enter valid tax id (SSN or EIN) without dashes'),
+    tax_id: taxIdValidation.required('Enter valid tax ID (SSN or EIN) without dashes'),
     date_of_incorporation: dateOfIncorporationValidation.required('Enter date of incorporation'),
   });
 


### PR DESCRIPTION
### `PaymentProvisioning`: add clearer error message for `tax_id` field

This PR commits the following changes to the first step of  `payment-provisioning`:

- Updates help text for `tax_id` field to add in new sentence: `Enter value without dashes.`
- Updates error text for `tax_id` field to be: `Enter valid tax id (SSN or EIN) without dashes`


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/334


Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] Component library builds and runs
- [x] Tests pass
- [x] Verify changes to help text and error text for `tax_id` field on first form step of `payment-provisioning` component

