### PR TITLE
Implement `config-state` to Business related components

### DIFF
--- a/apps/component-examples/examples/business-details.js
+++ b/apps/component-examples/examples/business-details.js
@@ -1,0 +1,92 @@
+require('dotenv').config({ path: '../../.env' });
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
+const businessId = process.env.BUSINESS_ID;
+
+app.use(
+  '/scripts',
+  express.static(__dirname + '/../node_modules/@justifi/webcomponents/dist/')
+);
+app.use('/styles', express.static(__dirname + '/../css/'));
+
+async function getToken() {
+  const requestBody = JSON.stringify({
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+
+  let response;
+  try {
+    response = await fetch(authTokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
+
+  const { access_token } = await response.json();
+  return access_token;
+}
+
+async function getWebComponentToken(token) {
+  const response = await fetch(webComponentTokenEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      resources: [`read:business:${businessId}`],
+    }),
+  });
+
+  const responseJson = await response.json();
+
+  const { access_token } = responseJson;
+  return access_token;
+}
+
+app.get('/', async (req, res) => {
+  const token = await getToken();
+  const webComponentToken = await getWebComponentToken(token);
+
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>JustiFi Business Details Component</title>
+        <script type="module" src="/scripts/webcomponents/webcomponents.esm.js"></script>
+        <link rel="stylesheet" href="/styles/theme.css">
+        <link rel="stylesheet" href="/styles/example.css">
+      </head>
+      <body>
+        <div class="list-component-wrapper">
+          <justifi-business-details
+            auth-token="${webComponentToken}"
+            business-id="${businessId}"
+          />
+        </div>
+        <script>
+          const justifiBusinessDetails = document.querySelector('justifi-business-details');
+
+          justifiBusinessDetails.addEventListener('error-event', (event) => {
+            console.log(event);
+          });
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening at http://localhost:${port}`);
+});

--- a/apps/component-examples/examples/business-form.js
+++ b/apps/component-examples/examples/business-form.js
@@ -1,0 +1,120 @@
+require('dotenv').config({ path: '../../.env' });
+
+const express = require('express');
+const { generateRandomLegalName } = require('../utils/random-business-names');
+const app = express();
+const port = process.env.PORT || 3000;
+const authTokenEndpoint = process.env.AUTH_TOKEN_ENDPOINT;
+const businessEndpoint = process.env.BUSINESS_ENDPOINT;
+const webComponentTokenEndpoint = process.env.WEB_COMPONENT_TOKEN_ENDPOINT;
+const clientId = process.env.CLIENT_ID;
+const clientSecret = process.env.CLIENT_SECRET;
+
+app.use(
+  '/scripts',
+  express.static(__dirname + '/../node_modules/@justifi/webcomponents/dist/')
+);
+app.use('/styles', express.static(__dirname + '/../css/'));
+
+async function getToken() {
+  const requestBody = JSON.stringify({
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+
+  let response;
+  try {
+    response = await fetch(authTokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: requestBody,
+    });
+  } catch (error) {
+    console.log('ERROR:', error);
+  }
+
+  const { access_token } = await response.json();
+  console.log('response from getToken', access_token);
+
+  return access_token;
+}
+
+async function createBusiness(token) {
+  const randomLegalName = generateRandomLegalName();
+  const response = await fetch(businessEndpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      legal_name: randomLegalName,
+    }),
+  });
+  const res = await response.json();
+  console.log('response from createBusiness', res);
+  return res.id;
+}
+
+async function getWebComponentToken(token, businessId) {
+  const response = await fetch(webComponentTokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        resources: [`write:business:${businessId}`],
+      }),
+    }
+  );
+
+  const res = await response.json();
+  console.log('response from getWebComponentToken', res);
+
+  return res.access_token;
+}
+
+app.get('/', async (req, res) => {
+  const token = await getToken();
+  // const businessId = await createBusiness(token);
+  const businessId = 'biz_5e77XQkCoARKHn9Wk7TOES';
+  const webComponentToken = await getWebComponentToken(token, businessId);
+
+  res.send(`
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <title>JustiFi Business Form Component</title>
+        <script type="module" src="/scripts/webcomponents/webcomponents.esm.js"></script>
+        <link rel="stylesheet" href="/styles/theme.css">
+        <link rel="stylesheet" href="/styles/example.css">
+      </head>
+      <body>
+        <div style="margin:0 auto;max-width:700px;">
+          <justifi-business-form
+            business-id="${businessId}"
+            auth-token="${webComponentToken}"
+          >
+          </justifi-business-form>
+        </div>
+
+        <script>
+          const justifiBusinessForm = document.querySelector('justifi-business-form');
+
+          justifiBusinessForm.addEventListener('submit-event', (event) => console.log(event));
+
+          justifiBusinessForm.addEventListener('click-event', (event) => console.log(event));
+          
+          justifiBusinessForm.addEventListener('error-event', (event) => console.log(event));
+        </script>
+      </body>
+    </html>
+  `);
+});
+
+app.listen(port, () => {
+  console.log(`Example app listening on port ${port}`);
+});

--- a/apps/component-examples/examples/business-form.js
+++ b/apps/component-examples/examples/business-form.js
@@ -79,8 +79,7 @@ async function getWebComponentToken(token, businessId) {
 
 app.get('/', async (req, res) => {
   const token = await getToken();
-  // const businessId = await createBusiness(token);
-  const businessId = 'biz_5e77XQkCoARKHn9Wk7TOES';
+  const businessId = await createBusiness(token);
   const webComponentToken = await getWebComponentToken(token, businessId);
 
   res.send(`

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -13,6 +13,7 @@
     "start:checkouts-list": "npx nodemon ./examples/checkouts-list.js",
     "start:checkouts-list-with-filters": "npx nodemon ./examples/checkouts-list-with-filters.js",
     "start:payment-provisioning": "npx nodemon ./examples/payment-provisioning.js",
+    "start:business-details": "npx nodemon ./examples/business-details.js",
     "start:tokenize-payment-method": "npx nodemon ./examples/tokenize-payment-method.js",
     "start:terminals-list": "npx nodemon ./examples/terminals-list.js",
     "start:terminals-list-with-filters": "npx nodemon ./examples/terminals-list-with-filters.js",

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -12,6 +12,7 @@
     "start:dispute": "npx nodemon ./examples/dispute.js",
     "start:checkouts-list": "npx nodemon ./examples/checkouts-list.js",
     "start:checkouts-list-with-filters": "npx nodemon ./examples/checkouts-list-with-filters.js",
+    "start:business-form": "npx nodemon ./examples/business-form.js",
     "start:payment-provisioning": "npx nodemon ./examples/payment-provisioning.js",
     "start:business-details": "npx nodemon ./examples/business-details.js",
     "start:tokenize-payment-method": "npx nodemon ./examples/tokenize-payment-method.js",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:checkouts-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:checkouts-list'",
     "dev:checkouts-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:checkouts-list-with-filters'",
     "dev:payment-provisioning": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payment-provisioning'",
+    "dev:business-details": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:business-details'",
     "dev:tokenize-payment-method": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:tokenize-payment-method'",
     "dev:terminals-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:terminals-list'",
     "dev:terminals-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:terminals-list-with-filters'",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev:dispute": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:dispute'",
     "dev:checkouts-list": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:checkouts-list'",
     "dev:checkouts-list-with-filters": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:checkouts-list-with-filters'",
+    "dev:business-form": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:business-form'",
     "dev:payment-provisioning": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:payment-provisioning'",
     "dev:business-details": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:business-details'",
     "dev:tokenize-payment-method": "concurrently 'pnpm --filter @justifi/webcomponents dev' 'pnpm --filter @repo/component-examples start:tokenize-payment-method'",

--- a/packages/webcomponents/src/api/services/business.service.ts
+++ b/packages/webcomponents/src/api/services/business.service.ts
@@ -1,9 +1,11 @@
-import Api, { IApiResponse } from '../Api';
-import NewApi from '../ApiNew';
+import { IApiResponse } from '../Api';
+import Api from '../ApiNew';
 import { IBankAccount } from '../BankAccount';
 import { IBusiness } from '../Business';
 import { DocumentRecordData } from '../Document';
 import { Identity } from '../Identity';
+
+const api = Api();
 
 export interface IBusinessService {
   fetchBusiness(
@@ -22,7 +24,6 @@ export class BusinessService implements IBusinessService {
     businessId: string,
     authToken: string
   ): Promise<IApiResponse<IBusiness>> {
-    const api = NewApi();
     const endpoint = `entities/business/${businessId}`;
     return api.get({ endpoint, authToken });
   }
@@ -33,10 +34,8 @@ export class BusinessService implements IBusinessService {
     payload: Partial<IBusiness>
   ): Promise<IApiResponse<IBusiness>> {
     const endpoint = `entities/business/${businessId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.patch({ endpoint, body, authToken });
   }
 }
 
@@ -66,7 +65,7 @@ export class IdentityService implements IdentityService {
     authToken: string
   ): Promise<IApiResponse<Identity>> {
     const endpoint = `entities/identity/${identityId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).get({ endpoint });
+    return api.get({ endpoint, authToken });
   }
 
   async patchIdentity(
@@ -75,10 +74,8 @@ export class IdentityService implements IdentityService {
     payload: Partial<Identity>
   ): Promise<IApiResponse<Identity>> {
     const endpoint = `entities/identity/${identityId}`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).patch({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.patch({ endpoint, body, authToken });
   }
 
   async postIdentity(
@@ -86,10 +83,8 @@ export class IdentityService implements IdentityService {
     payload: Partial<Identity>
   ): Promise<IApiResponse<Identity>> {
     const endpoint = `entities/identity`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.post({ endpoint, body, authToken });
   }
 }
 
@@ -108,10 +103,8 @@ export class BusinessBankAccountService implements IBusinessBankAccountService {
     payload: Partial<IBankAccount>
   ): Promise<IApiResponse<IBankAccount>> {
     const endpoint = `entities/bank_accounts`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.post({ endpoint, body, authToken });
   }
 }
 
@@ -130,9 +123,7 @@ export class DocumentRecordService implements IDocumentRecordService {
     payload: DocumentRecordData
   ): Promise<IApiResponse<any>> {
     const endpoint = `entities/document`;
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
-      endpoint,
-      body: payload,
-    });
+    const body = payload;
+    return api.post({ endpoint, body, authToken });
   }
 }

--- a/packages/webcomponents/src/api/services/provision.service.ts
+++ b/packages/webcomponents/src/api/services/provision.service.ts
@@ -1,4 +1,8 @@
-import Api, { IApiResponse } from '../Api';
+import { IApiResponse } from '../Api';
+import Api from '../ApiNew';
+
+
+const api = Api();
 
 export interface IProvisionService {
   postProvisioning(
@@ -15,13 +19,10 @@ export class ProvisionService implements IProvisionService {
     product: string
   ): Promise<IApiResponse<any>> {
     const endpoint = `entities/provisioning`;
-    const payload = {
+    const body = {
       business_id: businessId,
       product_category: product,
     };
-    return Api({ authToken, apiOrigin: PROXY_API_ORIGIN }).post({
-      endpoint,
-      body: payload,
-    });
+    return api.post({ endpoint, body, authToken });
   }
 }

--- a/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-form.tsx
@@ -78,6 +78,20 @@ export class BusinessForm {
         businessId: this.businessId,
         service: new BusinessService()
       });
+
+      this.getBusiness({
+        onSuccess: (response) => {
+          this.instantiateBusiness(response.data);
+        },
+        onError: ({ error, code, severity }) => {
+          this.errorMessage = error.message;
+          this.errorEvent.emit({ errorCode: code, message: error.message, severity });
+        },
+        final: () => {
+          this.isLoading = false;
+        }
+      });
+
     } else {
       this.errorEvent.emit({
         message: 'auth-token and business-id are required',
@@ -85,19 +99,6 @@ export class BusinessForm {
         severity: ComponentErrorSeverity.ERROR,
       });
     }
-
-    this.getBusiness({
-      onSuccess: (response) => {
-        this.instantiateBusiness(response.data);
-      },
-      onError: ({ error, code, severity }) => {
-        this.errorMessage = error.message;
-        this.errorEvent.emit({ errorCode: code, message: error.message, severity });
-      },
-      final: () => {
-        this.isLoading = false;
-      }
-    });
   }
 
   private sendData = async () => {

--- a/packages/webcomponents/src/components/business-forms/business-form/readme.md
+++ b/packages/webcomponents/src/components/business-forms/business-form/readme.md
@@ -21,6 +21,7 @@
 | Event          | Description | Type                                |
 | -------------- | ----------- | ----------------------------------- |
 | `click-event`  |             | `CustomEvent<ComponentClickEvent>`  |
+| `error-event`  |             | `CustomEvent<ComponentErrorEvent>`  |
 | `submit-event` |             | `CustomEvent<ComponentSubmitEvent>` |
 
 

--- a/packages/webcomponents/src/components/business-forms/business-form/test/business-form.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/test/business-form.spec.tsx
@@ -1,3 +1,4 @@
+import { h } from "@stencil/core";
 import { newSpecPage } from '@stencil/core/testing';
 import { BusinessForm } from '../business-form';
 import JustifiAnalytics from '../../../../api/Analytics';
@@ -22,23 +23,23 @@ describe('justifi-business-form', () => {
     consoleSpy.mockRestore();
   });
 
-  it('should log a warning if no authToken is provided', async () => {
-    await newSpecPage({
-      components: [BusinessForm],
-      html: `<justifi-business-form></justifi-business-form>`,
+  it('emit an error event when accountId and authToken are not provided', async () => {
+      const errorEvent = jest.fn();
+      const page = await newSpecPage({
+        components: [BusinessForm],
+        template: () => <justifi-business-form onError-event={errorEvent} />,
+      });
+      await page.waitForChanges();
+      expect(errorEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detail: {
+            errorCode: 'missing-props',
+            message: 'auth-token and business-id are required',
+            severity: 'error',
+          },
+        })
+      );
     });
-
-    expect(consoleSpy).toHaveBeenCalledWith('Warning: Missing auth-token. The form will not be functional without it.');
-  });
-
-  it('should log a warning if no businessId is provided', async () => {
-    await newSpecPage({
-      components: [BusinessForm],
-      html: `<justifi-business-form></justifi-business-form>`,
-    });
-
-    expect(consoleSpy).toHaveBeenCalledWith('Warning: Missing business-id. The form requires an existing business-id to function.');
-  });
 
   it('should not log a warning if an authToken is provided', async () => {
     await newSpecPage({


### PR DESCRIPTION
### Implement `config-state` to Business related components

This PR commits the following changes:

- Uses new api file `ApiNew.ts` to form api requests in business components - `business-form`, `business-details`, `payment-provisioning`


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/343

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari


Developer QA steps
--------------------

- [x] Component library builds and runs as expected
- [x] Test suites pass

In order to test the config-provider - you'll need to render it anywhere in the example files. We're going to test all 3 business components to verify correct behavior. 

`business-form`

- [x] Do not render config component. `business-form` successfully requests and displays business data with default component logic.
  - [x] component can successfully patch business using default component logic (no config-provider)
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `business-form` component is now using that value as it's api-origin in it's network requests. 
  - [x] GET Request on load uses api origin value provided to config
  - [x] PATCH Request uses api origin value provided to config

`business-details`

- [x] Do not render config component. `business-details` successfully requests and displays business data with default component logic.
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `business-details` component is now using that value as it's api-origin in it's network requests. 

`payment-provisioning`

- [x] Do not render config component. `payment-provisioning` successfully requests and displays business data with default component logic.
  - [x] component can successfully patch business using default component logic (no config-provider)
- [x] Render `justifi-config-provider` in example file body and set `api-origin` prop to whichever environment you're not currently hooked up to. IE - if you are using staging credentials - use `https://wc-proxy.justifi.ai`. Verify that `payment-provisioning` component is now using that value as it's api-origin in it's network requests. 
  - [x] GET Request on load uses api origin value provided to config
  - [x] PATCH Request uses api origin value provided to config

