### PR TITLE
Implement checkout summary component and enhance checkout store with payment details

### DIFF
--- a/packages/webcomponents/src/components/modular-checkout-parts/summary.tsx
+++ b/packages/webcomponents/src/components/modular-checkout-parts/summary.tsx
@@ -1,0 +1,28 @@
+import { Component, h } from "@stencil/core";
+import { text } from "../../styles/parts";
+import { formatCurrency } from "../../utils/utils";
+import checkoutStore from "../../store/checkout.store";
+import { StyledHost } from "../../ui-components";
+
+@Component({
+  tag: 'justifi-checkout-summary',
+  shadow: true,
+})
+export class Summary {
+  render() {
+    return (
+      <StyledHost>
+        <section>
+          <div>
+            <div part={text}>{checkoutStore?.paymentDescription}</div>
+            <div>
+              <span part={text}>Total</span>&nbsp;
+              <span part={text}>{formatCurrency(+checkoutStore?.totalAmount)}</span>
+            </div>
+          </div>
+        </section>
+      </StyledHost>
+    );
+  }
+}
+

--- a/packages/webcomponents/src/store/checkout.store.ts
+++ b/packages/webcomponents/src/store/checkout.store.ts
@@ -3,6 +3,10 @@ import { createStore } from '@stencil/store';
 const { state, onChange } = createStore({
   authToken: '',
   accountId: '',
+  paymentMethods: [],
+  paymentMethodGroupId: '',
+  paymentDescription: '',
+  totalAmount: 0,
 });
 
 onChange('authToken', (newValue) => {
@@ -11,6 +15,14 @@ onChange('authToken', (newValue) => {
 
 onChange('accountId', (newValue) => {
   state.accountId = newValue;
+});
+
+onChange('paymentDescription', (newValue) => {
+  state.paymentDescription = newValue;
+});
+
+onChange('totalAmount', (newValue) => {
+  state.totalAmount = newValue;
 });
 
 export default state;


### PR DESCRIPTION
**This PR commits the following changes**

* Adds the new component `justifi-checkout-summary` to be used with `justifi-checkout-wrapper`.
* Enhances `checkoutStore` with checkout data necessary for the Summary.

Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/74

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
To test the new bank account component in a real-world setup, follow the steps below:

**Local Setup:**
1  - **Run iframe components locally**
* Navigate to `iframe-components`.
* Run: `npm run build` && `npm run dev`.
* This should start the server on `localhost:3003` and avoid `Not Authorized` errors during `payment-methods` API calls.

2  - **Configure environment for web component library**
* In `web-component-library`, set `.env`:
```
IFRAME_ORIGIN=http://localhost:3003
```
3 - **Build and link the component package.**
* Run: `pnpm build && pnpm dev`.
* Then: `cd packages/webcomponents && pnpm link --global`.

4 - **Run the test app on main branch**
* Run: 
```
npm link @justifi/webcomponents
npm run build && npm run dev
```
* The app should be available at `localhost:3420`.

**QA Scenarios.**

- [X] A Summary should be displayed correctly.

