### PR TITLE
`payment-details` and `payout-details`: conditionally render Metadata section

### DIFF
--- a/.changeset/gentle-poems-slide.md
+++ b/.changeset/gentle-poems-slide.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+`justifi-payment-details` and `justifi-payout-details` will now only show `Metadata` section if payment or payout contains `metadata`.

--- a/mockData/mockPayoutDetailsSuccess.json
+++ b/mockData/mockPayoutDetailsSuccess.json
@@ -20,7 +20,9 @@
     "created_at": "2023-12-28T01:27:00.742Z",
     "updated_at": "2023-12-28T01:27:06.070Z",
     "deposits_at": "2023-12-28T00:00:00.000Z",
-    "metadata": null,
+    "metadata": {
+      "customer_payout_id": "cp_12345"
+    },
     "bank_account": {
       "id": "ba_4MUXhq5ZZZfR5GF7fM3427",
       "full_name": "Jenny Rosen",

--- a/packages/webcomponents/src/components/payment-details/payment-details-core.tsx
+++ b/packages/webcomponents/src/components/payment-details/payment-details-core.tsx
@@ -110,10 +110,12 @@ export class PaymentDetailsCore {
                     <DetailItem title="Account Owner" value={this.payment.payment_method.payersName} />
                   </div>
                 ]}
-                <DetailSectionTitle sectionTitle='Metadata' />
-                <div class="d-table gap-2 w-100">
-                  <CodeBlock metadata={this.payment.metadata} />
-                </div>
+                {this.payment.metadata && [
+                  <DetailSectionTitle sectionTitle='Metadata' />,
+                  <div class="d-table gap-2 w-100">
+                    <CodeBlock metadata={this.payment.metadata} />
+                  </div>
+                ]}
               </div>
             </justifi-details>
           )}

--- a/packages/webcomponents/src/components/payment-details/test/__snapshots__/payment-details-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payment-details/test/__snapshots__/payment-details-core.spec.tsx.snap
@@ -162,10 +162,6 @@ exports[`payment-details-core it renders properly with fetched data 1`] = `
             </span>
           </div>
         </div>
-        <h2 class="border-bottom fs-5 mt-4 pb-3" part="heading-2 heading text color font-family">
-          Metadata
-        </h2>
-        <div class="d-table gap-2 w-100"></div>
       </div>
     </main>
   </justifi-details>

--- a/packages/webcomponents/src/components/payout-details/payout-details-core.tsx
+++ b/packages/webcomponents/src/components/payout-details/payout-details-core.tsx
@@ -113,10 +113,12 @@ export class PayoutDetailsCore {
                 <DetailItem title="Routing Number" value={this.payout.bank_account.routing_number} />
                 <DetailItem title="Account Number" value={this.payout.bank_account.account_number_last4} />
               </div>
-              <DetailSectionTitle sectionTitle='Metadata' />
-              <div class="d-table gap-2 w-100">
-                <CodeBlock metadata={this.payout.metadata} />
-              </div>
+              {this.payout.metadata && [
+                <DetailSectionTitle sectionTitle='Metadata' />,
+                <div class="d-table gap-2 w-100">
+                  <CodeBlock metadata={this.payout.metadata} />
+                </div>
+              ]}
             </div>
           </justifi-details>
         )}

--- a/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details-core.spec.tsx.snap
@@ -136,6 +136,15 @@ exports[`payout-details-core fetches payout details on connected callback 1`] = 
           </span>
         </div>
       </div>
+      <h2 class="border-bottom fs-5 mt-4 pb-3" part="heading-2 heading text color font-family">
+        Metadata
+      </h2>
+      <div class="d-table gap-2 w-100">
+        <div class="mt-4"><pre aria-label="metadata content" class="p-2"><code>{
+  "customer_payout_id": "cp_12345"
+}</code></pre>
+        </div>
+      </div>
     </div>
   </justifi-details>
 </payout-details-core>

--- a/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details-core.spec.tsx.snap
@@ -136,10 +136,6 @@ exports[`payout-details-core fetches payout details on connected callback 1`] = 
           </span>
         </div>
       </div>
-      <h2 class="border-bottom fs-5 mt-4 pb-3" part="heading-2 heading text color font-family">
-        Metadata
-      </h2>
-      <div class="d-table gap-2 w-100"></div>
     </div>
   </justifi-details>
 </payout-details-core>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         version: 8.6.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@8.6.12(prettier@3.5.3))
       '@storybook/builder-vite':
         specifier: ^8.6.12
-        version: 8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0))
+        version: 8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0))
       '@storybook/manager-api':
         specifier: ^8.6.12
         version: 8.6.12(storybook@8.6.12(prettier@3.5.3))
@@ -81,13 +81,13 @@ importers:
         version: 8.6.12(lit@3.2.1)(storybook@8.6.12(prettier@3.5.3))
       '@storybook/web-components-vite':
         specifier: ^8.6.12
-        version: 8.6.12(lit@3.2.1)(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0))
+        version: 8.6.12(lit@3.2.1)(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0))
       '@types/node':
-        specifier: 22.15.3
-        version: 22.15.3
+        specifier: 22.15.17
+        version: 22.15.17
       '@vitejs/plugin-react':
         specifier: ^4.4.1
-        version: 4.4.1(vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0))
+        version: 4.4.1(vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0))
       chromatic:
         specifier: ^11.28.2
         version: 11.28.2
@@ -111,7 +111,7 @@ importers:
         version: 5.8.3
       vite:
         specifier: ^6.3.5
-        version: 6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0)
+        version: 6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0)
 
   packages/webcomponents:
     dependencies:
@@ -184,16 +184,16 @@ importers:
         version: 16.4.7
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.15.3)
+        version: 29.7.0(@types/node@22.15.17)
       jest-cli:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.15.3)
+        version: 29.7.0(@types/node@22.15.17)
       jest-environment-node:
         specifier: ^29.7.0
         version: 29.7.0
       ts-jest:
         specifier: ^29.1.2
-        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@22.15.3))(typescript@5.8.3)
+        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@22.15.17))(typescript@5.8.3)
 
 packages:
 
@@ -1602,8 +1602,8 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
-  '@types/node@22.15.3':
-    resolution: {integrity: sha512-lX7HFZeHf4QG/J7tBZqrCAXwz9J5RD56Y6MpP0eJkka8p+K0RY/yBTW7CYFJ4VGCclxqOLKmiGP5juQc6MKgcw==}
+  '@types/node@22.15.17':
+    resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
 
   '@types/react-dom@19.0.4':
     resolution: {integrity: sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==}
@@ -5143,7 +5143,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -5156,14 +5156,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.15.3)
+      jest-config: 29.7.0(@types/node@22.15.17)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -5188,7 +5188,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -5206,7 +5206,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -5228,7 +5228,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -5298,7 +5298,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -5604,13 +5604,13 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/builder-vite@8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0))':
+  '@storybook/builder-vite@8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0))':
     dependencies:
       '@storybook/csf-plugin': 8.6.12(storybook@8.6.12(prettier@3.5.3))
       browser-assert: 1.2.1
       storybook: 8.6.12(prettier@3.5.3)
       ts-dedent: 2.2.0
-      vite: 6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0)
+      vite: 6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0)
 
   '@storybook/components@8.6.12(storybook@8.6.12(prettier@3.5.3))':
     dependencies:
@@ -5667,9 +5667,9 @@ snapshots:
     dependencies:
       storybook: 8.6.12(prettier@3.5.3)
 
-  '@storybook/web-components-vite@8.6.12(lit@3.2.1)(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0))':
+  '@storybook/web-components-vite@8.6.12(lit@3.2.1)(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0))':
     dependencies:
-      '@storybook/builder-vite': 8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0))
+      '@storybook/builder-vite': 8.6.12(storybook@8.6.12(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0))
       '@storybook/web-components': 8.6.12(lit@3.2.1)(storybook@8.6.12(prettier@3.5.3))
       magic-string: 0.30.17
       storybook: 8.6.12(prettier@3.5.3)
@@ -5714,7 +5714,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -5737,7 +5737,7 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
-  '@types/node@22.15.3':
+  '@types/node@22.15.17':
     dependencies:
       undici-types: 6.21.0
 
@@ -5761,14 +5761,14 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0))':
+  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0)
+      vite: 6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6181,13 +6181,13 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  create-jest@29.7.0(@types/node@22.15.3):
+  create-jest@29.7.0(@types/node@22.15.17):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.15.3)
+      jest-config: 29.7.0(@types/node@22.15.17)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -6906,7 +6906,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -6926,16 +6926,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.15.3):
+  jest-cli@29.7.0(@types/node@22.15.17):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.15.3)
+      create-jest: 29.7.0(@types/node@22.15.17)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.15.3)
+      jest-config: 29.7.0(@types/node@22.15.17)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -6945,7 +6945,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@22.15.3):
+  jest-config@29.7.0(@types/node@22.15.17):
     dependencies:
       '@babel/core': 7.26.10
       '@jest/test-sequencer': 29.7.0
@@ -6970,7 +6970,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6999,7 +6999,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -7009,7 +7009,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7048,7 +7048,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -7083,7 +7083,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -7111,7 +7111,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -7157,7 +7157,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -7176,7 +7176,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -7185,17 +7185,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.15.3):
+  jest@29.7.0(@types/node@22.15.17):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.15.3)
+      jest-cli: 29.7.0(@types/node@22.15.17)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -8121,12 +8121,12 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@22.15.3))(typescript@5.8.3):
+  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@22.15.17))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.15.3)
+      jest: 29.7.0(@types/node@22.15.17)
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -8260,7 +8260,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@6.3.5(@types/node@22.15.3)(sass-embedded@1.86.0):
+  vite@6.3.5(@types/node@22.15.17)(sass-embedded@1.86.0):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -8269,7 +8269,7 @@ snapshots:
       rollup: 4.40.1
       tinyglobby: 0.2.13
     optionalDependencies:
-      '@types/node': 22.15.3
+      '@types/node': 22.15.17
       fsevents: 2.3.3
       sass-embedded: 1.86.0
 


### PR DESCRIPTION
### `payment-details` and `payout-details`: conditionally render Metadata section

This PR commits the following:

- Hides metadata section on payment and payout detail components if metadata is null or falsy
- Updates snapshots


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/374

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------

- [x] Component library builds and runs as expected
- [x] Test suites pass
- [x] `payment-details` shows metadata if present. Example payment id: `py_6RSEWQGSTwpwUYjCDB8SZP`
- [x] `payment-details` hides metadata if not present. Example payment id: `py_X1cFoNPqeFjhJ4sINcWYq`
- [x] `payout-details` hides metadata if not present. Example payout id: `po_7k8EcLPm7eDmAyCaMcyAc9`
- [x] `payout-details` shows metadata if present. 
  - [x] I cannot actually find a payout that has metadata available - but I added metadata to `mockPayoutDetailsSuccess.json`. You may verify in the snapshot file that it renders the meta data section, or you may use the json mock data in the component to test out the hiding the metadata.

