### PR TITLE
Component Docs: Consistent component example syntax

### DIFF
--- a/apps/docs/stories/components/BusinessDetails/example.ts
+++ b/apps/docs/stories/components/BusinessDetails/example.ts
@@ -23,10 +23,9 @@ ${codeExampleHead(
 
 <body>
   <justifi-business-details
-    business-id="123" 
-    auth-token="your-auth-token"
-  >
-  </justifi-business-details>
+    business-id="biz_123"
+    auth-token="authToken"
+  />
 </body>
 
 <script>

--- a/apps/docs/stories/components/BusinessDetails/example.ts
+++ b/apps/docs/stories/components/BusinessDetails/example.ts
@@ -23,8 +23,10 @@ ${codeExampleHead(
 
 <body>
   <justifi-business-details
-    business-id="123" auth-token="your-auth-token"
-  ></justifi-business-details>
+    business-id="123" 
+    auth-token="your-auth-token"
+  >
+  </justifi-business-details>
 </body>
 
 <script>

--- a/apps/docs/stories/components/BusinessForm/example.ts
+++ b/apps/docs/stories/components/BusinessForm/example.ts
@@ -82,7 +82,7 @@ ${codeExampleHead(
 
 <body>
   <justifi-business-form
-    business-id="businessId"
+    business-id="biz_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/BusinessForm/example.ts
+++ b/apps/docs/stories/components/BusinessForm/example.ts
@@ -82,9 +82,9 @@ ${codeExampleHead(
 
 <body>
   <justifi-business-form
-    business-id="<BUSINESS_ID>"
-    auth-token="<WEBCOMPONENT_AUTH_TOKEN>">
-  </justifi-business-form>
+    business-id="businessId"
+    auth-token="authToken"
+  />
 </body>
 
 <script>

--- a/apps/docs/stories/components/Checkout/example.ts
+++ b/apps/docs/stories/components/Checkout/example.ts
@@ -111,7 +111,7 @@ ${codeExampleHead(
 
 <body>
   <justifi-checkout 
-    checkout-id="abc123"
+    checkout-id="cho_123"
     auth-token="authToken"
   >
     <!-- Optional: add the insurance slot and component -->

--- a/apps/docs/stories/components/Checkout/example.ts
+++ b/apps/docs/stories/components/Checkout/example.ts
@@ -110,7 +110,10 @@ ${codeExampleHead(
 )}
 
 <body>
-  <justifi-checkout auth-token="token" checkout-id="abc123">
+  <justifi-checkout 
+    checkout-id="abc123"
+    auth-token="authToken"
+  >
     <!-- Optional: add the insurance slot and component -->
     <div slot="insurance">
       <!-- see the insurance component docs for the full list of props -->

--- a/apps/docs/stories/components/CheckoutsList/example.ts
+++ b/apps/docs/stories/components/CheckoutsList/example.ts
@@ -38,7 +38,7 @@ ${codeExampleHead(
   <!-- Optional: add the filters component -->
   <justifi-checkouts-list-filters />
   <justifi-checkouts-list
-    account-id="accountId"
+    account-id="acc_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/CheckoutsList/example.ts
+++ b/apps/docs/stories/components/CheckoutsList/example.ts
@@ -36,8 +36,11 @@ ${codeExampleHead(
 
 <body>
   <!-- Optional: add the filters component -->
-  <justifi-checkouts-list-filters></justifi-checkouts-list-filters>
-  <justifi-checkouts-list></justifi-checkouts-list>
+  <justifi-checkouts-list-filters />
+  <justifi-checkouts-list
+    account-id="accountId"
+    auth-token="authToken"
+  />
 </body>
 
 </html>

--- a/apps/docs/stories/components/DisputeManagement/example.ts
+++ b/apps/docs/stories/components/DisputeManagement/example.ts
@@ -48,7 +48,7 @@ ${codeExampleHead(
 
 <body>
   <justifi-dispute-management 
-    dispute-id="disputeId" 
+    dispute-id="dp_123" 
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/DisputeManagement/example.ts
+++ b/apps/docs/stories/components/DisputeManagement/example.ts
@@ -47,8 +47,10 @@ ${codeExampleHead(
 )}
 
 <body>
-  <justifi-dispute-management dispute-id="disputeId" auth-token="authToken">
-  </justifi-dispute-management>
+  <justifi-dispute-management 
+    dispute-id="disputeId" 
+    auth-token="authToken"
+  />
 </body>
 
 <script>

--- a/apps/docs/stories/components/DisputeManagement/example.ts
+++ b/apps/docs/stories/components/DisputeManagement/example.ts
@@ -47,7 +47,7 @@ ${codeExampleHead(
 )}
 
 <body>
-  <justifi-dispute-management disputeId="disputeId" authToken="authToken">
+  <justifi-dispute-management dispute-id="disputeId" auth-token="authToken">
   </justifi-dispute-management>
 </body>
 

--- a/apps/docs/stories/components/GrossPaymentChart/example.ts
+++ b/apps/docs/stories/components/GrossPaymentChart/example.ts
@@ -7,7 +7,7 @@ ${codeExampleHead('justifi-gross-payment-chart')}
 
 <body>
   <justifi-gross-payment-chart
-    account-id="accountId"
+    account-id="acc_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/GrossPaymentChart/example.ts
+++ b/apps/docs/stories/components/GrossPaymentChart/example.ts
@@ -6,7 +6,10 @@ export default `<DOCTYPE html>
 ${codeExampleHead('justifi-gross-payment-chart')}
 
 <body>
-  <justifi-gross-payment-chart></justifi-gross-payment-chart>
+  <justifi-gross-payment-chart
+    account-id="accountId"
+    auth-token="authToken"
+  />
 </body>
 
 <script>

--- a/apps/docs/stories/components/PaymentDetails/example.ts
+++ b/apps/docs/stories/components/PaymentDetails/example.ts
@@ -22,7 +22,10 @@ ${codeExampleHead(
 )}
 
 <body>
-  <justifi-payment-details payment-id="123" auth-token="your-auth-token"></justifi-payment-details>
+  <justifi-payment-details 
+    payment-id="123" 
+    auth-token="your-auth-token"
+  />
 </body>
 
 <script>

--- a/apps/docs/stories/components/PaymentDetails/example.ts
+++ b/apps/docs/stories/components/PaymentDetails/example.ts
@@ -23,8 +23,8 @@ ${codeExampleHead(
 
 <body>
   <justifi-payment-details 
-    payment-id="123" 
-    auth-token="your-auth-token"
+    payment-id="py_123" 
+    auth-token="authToken"
   />
 </body>
 

--- a/apps/docs/stories/components/PaymentProvisioning/example.ts
+++ b/apps/docs/stories/components/PaymentProvisioning/example.ts
@@ -82,9 +82,9 @@ ${codeExampleHead(
 
 <body>
   <justifi-payment-provisioning
-    business-id="<BUSINESS_ID>"
-    auth-token="<WEBCOMPONENT_AUTH_TOKEN>">
-  </justifi-payment-provisioning>
+    business-id="businessId"
+    auth-token="authToken"
+  />
 </body>
 
 <script>

--- a/apps/docs/stories/components/PaymentProvisioning/example.ts
+++ b/apps/docs/stories/components/PaymentProvisioning/example.ts
@@ -82,7 +82,7 @@ ${codeExampleHead(
 
 <body>
   <justifi-payment-provisioning
-    business-id="businessId"
+    business-id="biz_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/PaymentsList/example.ts
+++ b/apps/docs/stories/components/PaymentsList/example.ts
@@ -41,7 +41,10 @@ ${codeExampleHead(
 <body>
   <!-- Optional: add the filters component -->
   <justifi-payments-list-filters></justifi-payments-list-filters>
-  <justifi-payments-list></justifi-payments-list>
+  <justifi-payments-list 
+    account-id="accountId"
+    auth-token="authToken"
+  />
 </body>
 
 </html>

--- a/apps/docs/stories/components/PaymentsList/example.ts
+++ b/apps/docs/stories/components/PaymentsList/example.ts
@@ -42,7 +42,7 @@ ${codeExampleHead(
   <!-- Optional: add the filters component -->
   <justifi-payments-list-filters></justifi-payments-list-filters>
   <justifi-payments-list 
-    account-id="accountId"
+    account-id="acc_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/PayoutDetails/example.ts
+++ b/apps/docs/stories/components/PayoutDetails/example.ts
@@ -23,7 +23,7 @@ ${codeExampleHead(
 
 <body>
   <justifi-payout-details 
-    payout-id="po123" 
+    payout-id="po_123" 
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/PayoutDetails/example.ts
+++ b/apps/docs/stories/components/PayoutDetails/example.ts
@@ -22,7 +22,10 @@ ${codeExampleHead(
 )}
 
 <body>
-  <justifi-payout-details payout-id="123" auth-token="your-auth-token"></justifi-payout-details>
+  <justifi-payout-details 
+    payout-id="po123" 
+    auth-token="authToken"
+  />
 </body>
 
 <script>

--- a/apps/docs/stories/components/PayoutsList/example.ts
+++ b/apps/docs/stories/components/PayoutsList/example.ts
@@ -41,7 +41,10 @@ ${codeExampleHead(
 <body>
   <!-- Optional: add the filters component -->
   <justifi-payouts-list-filters></justifi-payouts-list-filters>
-  <justifi-payouts-list></justifi-payouts-list>
+  <justifi-payouts-list 
+    account-id="accountId"
+    auth-token="authToken"
+  />
 </body>
 
 </html>

--- a/apps/docs/stories/components/PayoutsList/example.ts
+++ b/apps/docs/stories/components/PayoutsList/example.ts
@@ -42,7 +42,7 @@ ${codeExampleHead(
   <!-- Optional: add the filters component -->
   <justifi-payouts-list-filters></justifi-payouts-list-filters>
   <justifi-payouts-list 
-    account-id="accountId"
+    account-id="acc_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/TerminalOrdersList/example.ts
+++ b/apps/docs/stories/components/TerminalOrdersList/example.ts
@@ -41,7 +41,10 @@ ${codeExampleHead(
 <body>
   <!-- Optional: add the filters component -->
   <justifi-terminal-orders-list-filters></justifi-terminal-orders-list-filters>
-  <justifi-terminal-orders-list></justifi-terminal-orders-list>
+  <justifi-terminal-orders-list 
+    account-id="accountId"
+    auth-token="authToken"
+  />
 </body>
 
 </html>

--- a/apps/docs/stories/components/TerminalOrdersList/example.ts
+++ b/apps/docs/stories/components/TerminalOrdersList/example.ts
@@ -41,8 +41,8 @@ ${codeExampleHead(
 <body>
   <!-- Optional: add the filters component -->
   <justifi-terminal-orders-list-filters></justifi-terminal-orders-list-filters>
-  <justifi-terminal-orders-list 
-    account-id="accountId"
+  <justifi-terminal-orders-list
+    account-id="acc_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/TerminalsList/example.ts
+++ b/apps/docs/stories/components/TerminalsList/example.ts
@@ -41,7 +41,10 @@ ${codeExampleHead(
 <body>
   <!-- Optional: add the filters component -->
   <justifi-terminals-list-filters></justifi-terminals-list-filters>
-  <justifi-terminals-list></justifi-terminals-list>
+  <justifi-terminals-list 
+    account-id="accountId"
+    auth-token="authToken"
+  />
 </body>
 
 </html>

--- a/apps/docs/stories/components/TerminalsList/example.ts
+++ b/apps/docs/stories/components/TerminalsList/example.ts
@@ -41,8 +41,8 @@ ${codeExampleHead(
 <body>
   <!-- Optional: add the filters component -->
   <justifi-terminals-list-filters></justifi-terminals-list-filters>
-  <justifi-terminals-list 
-    account-id="accountId"
+  <justifi-terminals-list
+    account-id="acc_123"
     auth-token="authToken"
   />
 </body>

--- a/apps/docs/stories/components/TokenizePaymentMethod/example.ts
+++ b/apps/docs/stories/components/TokenizePaymentMethod/example.ts
@@ -111,13 +111,9 @@ ${codeExampleHead(
 
   <body>
     <justifi-tokenize-payment-method
-      auth-token="your-auth-token"
+      auth-token="authToken"
       account-id="acc_5Et9iXrSSAZR2KSouQGAWi"
-      hide-submit-button
-    >
-    </justifi-tokenize-payment-method>
-    <button id="tokenize-button">Tokenize</button>
-    <button id="fill-billing-form">Fill Billing Form</button>
+    />
   </body>
 
   <script>
@@ -148,7 +144,7 @@ ${codeExampleHead(
         address_state: "NY",
         address_postal_code: "12345",
       });
-}); 
+    }); 
 
   </script>
 

--- a/apps/docs/stories/components/TokenizePaymentMethod/example.ts
+++ b/apps/docs/stories/components/TokenizePaymentMethod/example.ts
@@ -111,8 +111,8 @@ ${codeExampleHead(
 
   <body>
     <justifi-tokenize-payment-method
+      account-id="acc_123"
       auth-token="authToken"
-      account-id="acc_5Et9iXrSSAZR2KSouQGAWi"
     />
   </body>
 


### PR DESCRIPTION
### Component Docs: Consistent component example syntax

This PR commits the following:

- Updates several example files to use consistent syntax in regards to showing props in `kebab-case` and using self-closing component tags
- Changes props in example files that were written as `business-id="businessId"` => `business-id="biz_123"`. Using actual ID prefixes in example files now. 


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/312



Developer QA steps
--------------------

- [ ] Component documentation examples now use consistent syntax for props, id attributes with prefixes, and self-closing tags where possible.

