### PR TITLE
Modular Checkout: Saved Payment Methods workflow

### DIFF
--- a/packages/webcomponents/src/api/ComponentError.ts
+++ b/packages/webcomponents/src/api/ComponentError.ts
@@ -5,6 +5,7 @@ export enum ComponentErrorCodes {
   POST_ERROR = 'post-error',
   UNKNOWN_ERROR = 'unknown-error',
   TOKENIZE_ERROR = 'tokenize-error',
+  COMPLETE_CHECKOUT_ERROR = 'complete-checkout-error',
   NOT_AUTHENTICATED = 'not-authenticated',
   INVALID_PARAMETER = 'invalid-parameter',
   PROVISIONING_REQUESTED = 'provisioning-already-requested',

--- a/packages/webcomponents/src/api/PaymentMethod.ts
+++ b/packages/webcomponents/src/api/PaymentMethod.ts
@@ -1,0 +1,28 @@
+export interface ISavedPaymentMethod {
+  payment_method_group_id?: string;
+}
+
+export interface IPaymentMethodCard {
+  address_postal_code: number;
+  number: string;
+  month: string;
+  year: string;
+  verification: string;
+}
+
+export interface IPaymentMethodBankAccount {
+  account_number: string;
+  routing_number: string;
+  account_type: string;
+  account_holder_name: string;
+  account_holder_type: string;
+  country: string;
+  currency: string;
+}
+
+export type IPaymentMethodMetadata = ISavedPaymentMethod &
+  (IPaymentMethodCard | IPaymentMethodBankAccount);
+
+export type ISubmitCheckout = {
+  savePaymentMethod?: boolean;
+} & IPaymentMethodMetadata;

--- a/packages/webcomponents/src/components/modular-checkout-parts/saved-payment-methods.tsx
+++ b/packages/webcomponents/src/components/modular-checkout-parts/saved-payment-methods.tsx
@@ -1,0 +1,45 @@
+import { Component, h } from "@stencil/core";
+import { StyledHost } from "../../ui-components";
+import checkoutStore from "../../store/checkout.store";
+import { radioListItem } from "../../styles/parts";
+import { CardBrandLabels } from "../checkout/payment-method-option-utils";
+
+@Component({
+  tag: 'justifi-saved-payment-methods',
+  shadow: true,
+})
+export class SavedPaymentMethods {
+  componentWillLoad() {
+    if (!checkoutStore.paymentMethods.length) {
+      console.warn('No saved payment methods available.');
+    }
+  }
+
+  onPaymentMethodOptionClick = (paymentMethodId: string) => (e: Event) => {
+    e.preventDefault();
+    checkoutStore.selectedPaymentMethod = paymentMethodId;
+  };
+
+  render() {
+    return (
+      <StyledHost>
+        <div class="saved-payment-methods">
+          {checkoutStore.paymentMethods.length ? checkoutStore.paymentMethods.map((paymentMethod) => (
+            <div
+              class="radio-list-item p-3"
+              part={radioListItem}
+              onClick={this.onPaymentMethodOptionClick(paymentMethod?.id)}
+            >
+              <form-control-radio
+                name="paymentMethodType"
+                value={paymentMethod?.id}
+                checked={checkoutStore.selectedPaymentMethod === paymentMethod?.id}
+                label={`${CardBrandLabels[paymentMethod?.brand] || ''} *${paymentMethod?.acct_last_four}`}
+              />
+            </div>
+          )) : null}
+        </div>
+      </StyledHost>
+    );
+  }
+}

--- a/packages/webcomponents/src/components/modular-checkout-parts/summary.tsx
+++ b/packages/webcomponents/src/components/modular-checkout-parts/summary.tsx
@@ -1,0 +1,28 @@
+import { Component, h } from "@stencil/core";
+import { text } from "../../styles/parts";
+import { formatCurrency } from "../../utils/utils";
+import checkoutStore from "../../store/checkout.store";
+import { StyledHost } from "../../ui-components";
+
+@Component({
+  tag: 'justifi-checkout-summary',
+  shadow: true,
+})
+export class Summary {
+  render() {
+    return (
+      <StyledHost>
+        <section>
+          <div>
+            <div part={text}>{checkoutStore?.paymentDescription}</div>
+            <div>
+              <span part={text}>Total</span>&nbsp;
+              <span part={text}>{formatCurrency(+checkoutStore?.totalAmount)}</span>
+            </div>
+          </div>
+        </section>
+      </StyledHost>
+    );
+  }
+}
+

--- a/packages/webcomponents/src/store/checkout.store.ts
+++ b/packages/webcomponents/src/store/checkout.store.ts
@@ -7,6 +7,7 @@ const { state, onChange } = createStore({
   paymentMethodGroupId: '',
   paymentDescription: '',
   totalAmount: 0,
+  selectedPaymentMethod: '',
 });
 
 onChange('authToken', (newValue) => {
@@ -23,6 +24,18 @@ onChange('paymentDescription', (newValue) => {
 
 onChange('totalAmount', (newValue) => {
   state.totalAmount = newValue;
+});
+
+onChange('paymentMethods', (newValue) => {
+  state.paymentMethods = newValue;
+});
+
+onChange('paymentMethodGroupId', (newValue) => {
+  state.paymentMethodGroupId = newValue;
+});
+
+onChange('selectedPaymentMethod', (newValue) => {
+  state.selectedPaymentMethod = newValue;
 });
 
 export default state;

--- a/packages/webcomponents/src/store/checkout.store.ts
+++ b/packages/webcomponents/src/store/checkout.store.ts
@@ -3,6 +3,10 @@ import { createStore } from '@stencil/store';
 const { state, onChange } = createStore({
   authToken: '',
   accountId: '',
+  paymentMethods: [],
+  paymentMethodGroupId: '',
+  paymentDescription: '',
+  totalAmount: 0,
 });
 
 onChange('authToken', (newValue) => {
@@ -11,6 +15,14 @@ onChange('authToken', (newValue) => {
 
 onChange('accountId', (newValue) => {
   state.accountId = newValue;
+});
+
+onChange('paymentDescription', (newValue) => {
+  state.paymentDescription = newValue;
+});
+
+onChange('totalAmount', (newValue) => {
+  state.totalAmount = newValue;
 });
 
 export default state;

--- a/packages/webcomponents/src/ui-components/form/iframe-input.tsx
+++ b/packages/webcomponents/src/ui-components/form/iframe-input.tsx
@@ -6,6 +6,7 @@ import packageJson from '../../../package.json';
 import { iframeInputStyles } from "./iframe-input-styles-state";
 import { MessageEventType } from "../../components/checkout/message-event-types";
 import { input, inputFocused, inputInvalid, inputInvalidAndFocused, label } from "../../styles/parts";
+import { IPaymentMethodMetadata } from "../../api/PaymentMethod";
 
 @Component({
   tag: "iframe-input",
@@ -45,7 +46,7 @@ export class IframeInput {
   @Method()
   async tokenize(
     clientId: string,
-    paymentMethodMetadata: any,
+    paymentMethodMetadata: IPaymentMethodMetadata,
     account?: string,
   ) {
     return this.frameService.postMessageWithResponseListener(MessageEventType.tokenize, {

--- a/packages/webcomponents/src/ui-components/form/readme.md
+++ b/packages/webcomponents/src/ui-components/form/readme.md
@@ -21,17 +21,17 @@
 
 ## Methods
 
-### `tokenize(clientId: string, paymentMethodMetadata: any, account?: string) => Promise<any>`
+### `tokenize(clientId: string, paymentMethodMetadata: IPaymentMethodMetadata, account?: string) => Promise<any>`
 
 
 
 #### Parameters
 
-| Name                    | Type     | Description |
-| ----------------------- | -------- | ----------- |
-| `clientId`              | `string` |             |
-| `paymentMethodMetadata` | `any`    |             |
-| `account`               | `string` |             |
+| Name                    | Type                                                                      | Description |
+| ----------------------- | ------------------------------------------------------------------------- | ----------- |
+| `clientId`              | `string`                                                                  |             |
+| `paymentMethodMetadata` | `ISavedPaymentMethod & (IPaymentMethodCard \| IPaymentMethodBankAccount)` |             |
+| `account`               | `string`                                                                  |             |
 
 #### Returns
 


### PR DESCRIPTION
**This PR commits the following**

`justifi-checkout-wrapper`:
* Adds `savePaymentMethod` prop (optional).
* Adds `completeCheckout` logic.
* Adds `checkout-complete-event`.

`justifi-saved-payment-methods`
* Creates the `justifi-saved-payment-methods` component.
* This component only reads and writes to the `checkoutStore`.

Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/97

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
To test the saved payment method component in a real-world-like setup, follow the steps below:

**Local Setup:**
1  - **Run iframe components locally**
* Navigate to `iframe-components`.
* Run: `npm run build` && `npm run dev`.
* This should start the server on `localhost:3003` and avoid `Not Authorized` errors during `payment-methods` API calls.

2  - **Configure environment for web component library**
* In `web-component-library`, set `.env`:
```
IFRAME_ORIGIN=http://localhost:3003
```
3 - **Build and link the component package.**
* Run: `pnpm build && pnpm dev`.
* Then: `cd packages/webcomponents && pnpm link --global`.

4 - **Clone and set up the test app**
* Run: 
```
git clone https://github.com/TiagoFuelber/example-react-app-nextless.git
cd example-react-app-nextless
npm install
npm link @justifi/webcomponents
npm run build && npm run dev
```
* The app should be available at `localhost:3420`.

**QA Scenarios.**
(In order to save new payment methods with success, the [iframe-components counterpart PR](https://github.com/justifi-tech/iframe-components/pull/26) should be merged and deployed first).
- [ ] - Select "Saved Payment Method". `justifi-saved-payment-methods` component should render a list of saved payment methods.
- [ ] - It should be possible to complete a checkout with one of the saved payment methods. 
- [ ] - Select payment method "Card", check the "Save payment method" checkbox below the card form, fill the card form, complete a checkout, reload the page. You should see the new card saved in the list. Card numbers: https://developer.justifi.ai/api-spec#section/Testing
- [ ] - Repeat the same steps above ⬆️ , but with payment method:  Bank Account. 