### PR TITLE
Enhance theme styles and update insurance component logic for dynamic date handling

### DIFF
--- a/apps/component-examples/css/theme.css
+++ b/apps/component-examples/css/theme.css
@@ -19,6 +19,10 @@ body {
   color: darkslategray;
 }
 
+::part(text-danger) {
+  color: #8a2a35;
+}
+
 ::part(background-color) {
   background-color: transparent;
 }
@@ -74,6 +78,12 @@ body {
   background-color: #333;
   border-color: #333;
   box-shadow: 0 0 0 0.25rem rgba(0, 0, 0, 0.25);
+}
+
+::part(input-radio-invalid) {
+  background-color: #fff;
+  border-color: #8a2a35;
+  box-shadow: 0 0 0 0.25rem rgba(244, 67, 54, 0.25);
 }
 
 ::part(input-radio-checked-focused) {

--- a/apps/component-examples/examples/checkout-with-insurance.js
+++ b/apps/component-examples/examples/checkout-with-insurance.js
@@ -19,6 +19,13 @@ app.use(
 );
 app.use('/styles', express.static(__dirname + '/../css/'));
 
+const startDate = new Date();
+const startDateString = startDate.toISOString().split('T')[0];
+
+const endDate = new Date();
+endDate.setFullYear(endDate.getFullYear() + 1);
+const endDateString = endDate.toISOString().split('T')[0];
+
 const insurance = {
   primary_identity: {
     state: 'MN',
@@ -30,8 +37,8 @@ const insurance = {
   },
   policy_attributes: {
     insurable_amount: 1000,
-    start_date: '2025-05-15',
-    end_date: '2026-05-15',
+    start_date: startDateString,
+    end_date: endDateString,
     covered_identity: {
       first_name: 'John',
       last_name: 'Doe',

--- a/packages/webcomponents/src/components/insurance/season-interruption/season-interruption-insurance-core.tsx
+++ b/packages/webcomponents/src/components/insurance/season-interruption/season-interruption-insurance-core.tsx
@@ -8,6 +8,7 @@ import SeasonInterruptionInsuranceLoading from "./season-interruption-insurance-
 
 @Component({
   tag: 'justifi-season-interruption-insurance-core',
+  shadow: true,
 })
 export class SeasonInterruptionInsuranceCore {
   @Prop() checkoutId: string;
@@ -134,6 +135,8 @@ export class SeasonInterruptionInsuranceCore {
             value={'true'}
             checked={this.accepted === 'true'}
             inputHandler={this.onChangeHandler.bind(this)}
+            // don't wanna show error message, but need to show the red border
+            errorText={this.error ? ' ' : undefined}
           />
           <form-control-radio
             label="Decline coverage"
@@ -141,6 +144,7 @@ export class SeasonInterruptionInsuranceCore {
             value={'false'}
             checked={this.accepted === 'false'}
             inputHandler={this.onChangeHandler.bind(this)}
+            errorText={this.error ? ' ' : undefined}
           />
           <div
             class="invalid-feedback"

--- a/packages/webcomponents/src/components/insurance/season-interruption/test/__snapshots__/season-interruption-insurance-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/insurance/season-interruption/test/__snapshots__/season-interruption-insurance-core.spec.tsx.snap
@@ -2,100 +2,106 @@
 
 exports[`justifi-season-interruption-insurance-core loads and sets the quote to state correctly 1`] = `
 <justifi-season-interruption-insurance-core auth-token="123" class="body" style="display: block;">
-  <style></style>
-  <div>
-    <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
-      Add Registration Protection
-    </h2>
-    <small part="text color font-family">
-      <p>
-        Protect your registration and get your money back in the event of unforeseen circumstances that prevent participation, including sickness (including COVID-19), injury, inclement weather, transportation, job loss and other covered reasons.
-      </p>
-    </small>
-    <form-control-radio label="Accept coverage for $0.79" name="opt-in" value="true"></form-control-radio>
-    <form-control-radio label="Decline coverage" name="opt-in" value="false"></form-control-radio>
-    <div class="invalid-feedback" part="text-danger text color font-family" style="display: none;">
-      Please select an option
+  <template shadowrootmode="open">
+    <style></style>
+    <div>
+      <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
+        Add Registration Protection
+      </h2>
+      <small part="text color font-family">
+        <p>
+          Protect your registration and get your money back in the event of unforeseen circumstances that prevent participation, including sickness (including COVID-19), injury, inclement weather, transportation, job loss and other covered reasons.
+        </p>
+      </small>
+      <form-control-radio label="Accept coverage for $0.79" name="opt-in" value="true"></form-control-radio>
+      <form-control-radio label="Decline coverage" name="opt-in" value="false"></form-control-radio>
+      <div class="invalid-feedback" part="text-danger text color font-family" style="display: none;">
+        Please select an option
+      </div>
+      <small part="text color font-family">
+        <p>
+          Selecting yes constitutes my electronic signature. I confirm that I have read, understand and agree to the
+          <a href="https://partner.battleface.com/library/vertical-insure-season-cancellation-and-interruption-es" part="text color font-family" target="_blank">
+            policy terms and conditions
+          </a>
+          , and
+          <a href="https://legal.verticalinsure.com/Important-Notices-and-Disclosures-Everspan-Season-Can.pdf" part="text color font-family" target="_blank">
+            important notices and disclosures
+          </a>
+          , which includes fraud warnings, privacy notice, and consent to electronic signature and delivery.
+        </p>
+        <p>
+          battleface Travel Insurance plans are underwritten by Everspan Insurance Company (an AZ Corporation, NAIC# 24961), with administrative office at One World Trade Center, 41st Floor, New York, NY 10007. Plans are offered and administered by battleface Insurance Services LLC, 45 East Lincoln Street, Columbus, OH 43215, National Producer Number 18731960 (FL License number L107363/CA License number 0M75381).
+        </p>
+      </small>
     </div>
-    <small part="text color font-family">
-      <p>
-        Selecting yes constitutes my electronic signature. I confirm that I have read, understand and agree to the
-        <a href="https://partner.battleface.com/library/vertical-insure-season-cancellation-and-interruption-es" part="text color font-family" target="_blank">
-          policy terms and conditions
-        </a>
-        , and
-        <a href="https://legal.verticalinsure.com/Important-Notices-and-Disclosures-Everspan-Season-Can.pdf" part="text color font-family" target="_blank">
-          important notices and disclosures
-        </a>
-        , which includes fraud warnings, privacy notice, and consent to electronic signature and delivery.
-      </p>
-      <p>
-        battleface Travel Insurance plans are underwritten by Everspan Insurance Company (an AZ Corporation, NAIC# 24961), with administrative office at One World Trade Center, 41st Floor, New York, NY 10007. Plans are offered and administered by battleface Insurance Services LLC, 45 East Lincoln Street, Columbus, OH 43215, National Producer Number 18731960 (FL License number L107363/CA License number 0M75381).
-      </p>
-    </small>
-  </div>
+  </template>
 </justifi-season-interruption-insurance-core>
 `;
 
 exports[`justifi-season-interruption-insurance-core should display loading state correctly 1`] = `
 <justifi-season-interruption-insurance-core auth-token="123" class="body" style="display: block;">
-  <style></style>
-  <div class="gap-3 row">
-    <div class="col-12">
-      <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 35%; height: 30px;"></div>
+  <template shadowrootmode="open">
+    <style></style>
+    <div class="gap-3 row">
+      <div class="col-12">
+        <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 35%; height: 30px;"></div>
+      </div>
+      <div class="col-12">
+        <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 70%;"></div>
+      </div>
+      <div class="col-12">
+        <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
+      </div>
+      <div class="col-12">
+        <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
+      </div>
+      <div class="col-12">
+        <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 100%;"></div>
+      </div>
+      <div class="col-12">
+        <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 80%;"></div>
+      </div>
     </div>
-    <div class="col-12">
-      <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 70%;"></div>
-    </div>
-    <div class="col-12">
-      <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
-    </div>
-    <div class="col-12">
-      <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
-    </div>
-    <div class="col-12">
-      <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 100%;"></div>
-    </div>
-    <div class="col-12">
-      <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 80%;"></div>
-    </div>
-  </div>
+  </template>
 </justifi-season-interruption-insurance-core>
 `;
 
 exports[`justifi-season-interruption-insurance-core validates that a selection was made 1`] = `
 <justifi-season-interruption-insurance-core auth-token="123" class="body" style="display: block;">
-  <style></style>
-  <div>
-    <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
-      Add Registration Protection
-    </h2>
-    <small part="text color font-family">
-      <p>
-        Protect your registration and get your money back in the event of unforeseen circumstances that prevent participation, including sickness (including COVID-19), injury, inclement weather, transportation, job loss and other covered reasons.
-      </p>
-    </small>
-    <form-control-radio label="Accept coverage for $0.79" name="opt-in" value="true"></form-control-radio>
-    <form-control-radio label="Decline coverage" name="opt-in" value="false"></form-control-radio>
-    <div class="invalid-feedback" part="text-danger text color font-family" style="display: block;">
-      Please select an option
+  <template shadowrootmode="open">
+    <style></style>
+    <div>
+      <h2 class="fs-5 fw-bold header-2 pb-3" part="heading-2 heading text color font-family">
+        Add Registration Protection
+      </h2>
+      <small part="text color font-family">
+        <p>
+          Protect your registration and get your money back in the event of unforeseen circumstances that prevent participation, including sickness (including COVID-19), injury, inclement weather, transportation, job loss and other covered reasons.
+        </p>
+      </small>
+      <form-control-radio errortext=" " label="Accept coverage for $0.79" name="opt-in" value="true"></form-control-radio>
+      <form-control-radio errortext=" " label="Decline coverage" name="opt-in" value="false"></form-control-radio>
+      <div class="invalid-feedback" part="text-danger text color font-family" style="display: block;">
+        Please select an option
+      </div>
+      <small part="text color font-family">
+        <p>
+          Selecting yes constitutes my electronic signature. I confirm that I have read, understand and agree to the
+          <a href="https://partner.battleface.com/library/vertical-insure-season-cancellation-and-interruption-es" part="text color font-family" target="_blank">
+            policy terms and conditions
+          </a>
+          , and
+          <a href="https://legal.verticalinsure.com/Important-Notices-and-Disclosures-Everspan-Season-Can.pdf" part="text color font-family" target="_blank">
+            important notices and disclosures
+          </a>
+          , which includes fraud warnings, privacy notice, and consent to electronic signature and delivery.
+        </p>
+        <p>
+          battleface Travel Insurance plans are underwritten by Everspan Insurance Company (an AZ Corporation, NAIC# 24961), with administrative office at One World Trade Center, 41st Floor, New York, NY 10007. Plans are offered and administered by battleface Insurance Services LLC, 45 East Lincoln Street, Columbus, OH 43215, National Producer Number 18731960 (FL License number L107363/CA License number 0M75381).
+        </p>
+      </small>
     </div>
-    <small part="text color font-family">
-      <p>
-        Selecting yes constitutes my electronic signature. I confirm that I have read, understand and agree to the
-        <a href="https://partner.battleface.com/library/vertical-insure-season-cancellation-and-interruption-es" part="text color font-family" target="_blank">
-          policy terms and conditions
-        </a>
-        , and
-        <a href="https://legal.verticalinsure.com/Important-Notices-and-Disclosures-Everspan-Season-Can.pdf" part="text color font-family" target="_blank">
-          important notices and disclosures
-        </a>
-        , which includes fraud warnings, privacy notice, and consent to electronic signature and delivery.
-      </p>
-      <p>
-        battleface Travel Insurance plans are underwritten by Everspan Insurance Company (an AZ Corporation, NAIC# 24961), with administrative office at One World Trade Center, 41st Floor, New York, NY 10007. Plans are offered and administered by battleface Insurance Services LLC, 45 East Lincoln Street, Columbus, OH 43215, National Producer Number 18731960 (FL License number L107363/CA License number 0M75381).
-      </p>
-    </small>
-  </div>
+  </template>
 </justifi-season-interruption-insurance-core>
 `;

--- a/packages/webcomponents/src/components/insurance/season-interruption/test/__snapshots__/season-interruption-insurance.spec.tsx.snap
+++ b/packages/webcomponents/src/components/insurance/season-interruption/test/__snapshots__/season-interruption-insurance.spec.tsx.snap
@@ -4,27 +4,29 @@ exports[`justifi-season-interruption-insurance renders loading 1`] = `
 <justifi-season-interruption-insurance auth-token="123">
   <template shadowrootmode="open">
     <justifi-season-interruption-insurance-core class="body" style="display: block;">
-      <style></style>
-      <div class="gap-3 row">
-        <div class="col-12">
-          <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 35%; height: 30px;"></div>
+      <template shadowrootmode="open">
+        <style></style>
+        <div class="gap-3 row">
+          <div class="col-12">
+            <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 35%; height: 30px;"></div>
+          </div>
+          <div class="col-12">
+            <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 70%;"></div>
+          </div>
+          <div class="col-12">
+            <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
+          </div>
+          <div class="col-12">
+            <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
+          </div>
+          <div class="col-12">
+            <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 100%;"></div>
+          </div>
+          <div class="col-12">
+            <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 80%;"></div>
+          </div>
         </div>
-        <div class="col-12">
-          <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 70%;"></div>
-        </div>
-        <div class="col-12">
-          <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
-        </div>
-        <div class="col-12">
-          <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 40%;"></div>
-        </div>
-        <div class="col-12">
-          <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 100%;"></div>
-        </div>
-        <div class="col-12">
-          <div aria-hidden="true" class="skeleton undefined" part="skeleton" style="width: 80%;"></div>
-        </div>
-      </div>
+      </template>
     </justifi-season-interruption-insurance-core>
   </template>
 </justifi-season-interruption-insurance>


### PR DESCRIPTION
**This PR commits the following changes**

* `justifi-season-interruption-insurance`: Provide empty string to `errorText` prop on radio buttons so it can apply correct CSS part.
* theme.css - Add styles for `input-radio-invalid` part.
* Add logic to set dynamic insurance `start_date` and `end_date` on example file to avoid having to update it everytime.

Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/405

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

- [ ] - `pnpm dev:checkout-with-insurance`: Shouldn't need to update `start_date` property to fetch quotes.
- [ ] - Clicking "Submit" without selecting an insurance option should trigger validation and set error styles.

