### PR TITLE
Enhance validation methods to return error details alongside validity status (#1051)

### DIFF
--- a/.changeset/shy-pianos-fall.md
+++ b/.changeset/shy-pianos-fall.md
@@ -1,5 +1,0 @@
----
-"@justifi/webcomponents": patch
----
-
-Return the validation error message on the error-event from the justifi-tokenize-payment-method component

--- a/apps/component-examples/CHANGELOG.md
+++ b/apps/component-examples/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @repo/component-examples
 
+## 1.0.20
+
+### Patch Changes
+
+- Updated dependencies [56b7253]
+  - @justifi/webcomponents@5.7.2
+
 ## 1.0.19
 
 ### Patch Changes

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/component-examples",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "",
   "main": "index.js",
   "private": true,

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @repo/docs
 
+## 0.3.18
+
+### Patch Changes
+
+- Updated dependencies [56b7253]
+  - @justifi/webcomponents@5.7.2
+
 ## 0.3.17
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/docs",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webcomponents/CHANGELOG.md
+++ b/packages/webcomponents/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+## 5.7.2
+
+### Patch Changes
+
+- 56b7253: Return the validation error message on the error-event from the justifi-tokenize-payment-method component
+
 ## 5.7.1
 
 ### Patch Changes

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
* Enhance validation methods to return error details alongside validity status

* Refactor validation schema for improved readability and consistency

* Add validation error message to error-event in justifi-tokenize-payment-method component

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

