### PR TITLE
`payment-provisioning`: Conditional document upload requirements

### DIFF
--- a/.changeset/heavy-goats-smell.md
+++ b/.changeset/heavy-goats-smell.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Update the document upload requirements in `justifi-payment-provisioning`. Users now only need to upload either a `voided_check` or a `bank_statement` document to complete the form. Users are no longer required to upload both documents to proceed.

--- a/packages/webcomponents/src/components/business-forms/schemas/business-bank-account-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-bank-account-schema.ts
@@ -1,26 +1,57 @@
-import { object } from 'yup';
+import { object, mixed } from 'yup';
+import { EntityDocumentType } from '../../../api/Document';
 import { 
   accountNumberValidation,
   accountTypeValidation,
   bankNameValidation,
   identityNameValidation,
   nicknameValidation,
-  routingNumberValidation,
-  voidedCheckValidation,
-  bankStatementValidation
+  routingNumberValidation
 } from './schema-validations';
 
+const checkExistingDocs = (documents: any[], documentType: EntityDocumentType) => {
+  return documents.some((doc) => doc.document_type === documentType);
+}
+
+const documentErrorText = 'Please upload either a voided check or a bank statement. Only one is required.';
+
 export const businessBankAccountSchema = (documents: any[], allowOptionalFields?: boolean) => {
-  const schema = object({
-    bank_name: bankNameValidation.required('Enter bank name'),
-    nickname: nicknameValidation.required('Enter nickname'),
-    account_owner_name: identityNameValidation.required('Enter account owner name'),
-    account_type: accountTypeValidation.required('Select account type'),
-    account_number: accountNumberValidation.required('Enter account number'),
-    routing_number: routingNumberValidation.required('Enter routing number'),
-    voided_check: voidedCheckValidation(documents, allowOptionalFields),
-    bank_statement: bankStatementValidation(documents, allowOptionalFields)
-  });
+  const existingVoidedCheck = checkExistingDocs(documents, EntityDocumentType.voidedCheck);
+  const existingBankStatement = checkExistingDocs(documents, EntityDocumentType.bankStatement);
+  const existingDocument = existingVoidedCheck || existingBankStatement;
+
+  const schema = object().shape(
+    {
+      bank_name: bankNameValidation.required('Enter bank name'),
+      nickname: nicknameValidation.required('Enter nickname'),
+      account_owner_name: identityNameValidation.required('Enter account owner name'),
+      account_type: accountTypeValidation.required('Select account type'),
+      account_number: accountNumberValidation.required('Enter account number'),
+      routing_number: routingNumberValidation.required('Enter routing number'),
+      voided_check: mixed().when('bank_statement', {
+        is: (val: any) => {
+          return !val && !existingDocument;
+        },
+        then: (schema) => {
+          return schema.required(documentErrorText);
+        },
+        otherwise: (schema) => {
+          return schema.notRequired();
+        }}
+      ),
+      bank_statement: mixed().when('voided_check', {
+        is: (val: any) => {
+          return !val && !existingDocument;
+        },
+        then: (schema) => {
+          return schema.required(documentErrorText);
+        },
+        otherwise: (schema) => {
+          return schema.notRequired();
+        }}
+      ),
+    }, [['voided_check', 'bank_statement']]
+  );
 
   const easySchema = object({
     bank_name: bankNameValidation.nullable(),
@@ -29,8 +60,8 @@ export const businessBankAccountSchema = (documents: any[], allowOptionalFields?
     account_type: accountTypeValidation.nullable(),
     account_number: accountNumberValidation.nullable(),
     routing_number: routingNumberValidation.nullable(),
-    voided_check: voidedCheckValidation(documents, allowOptionalFields),
-    bank_statement: bankStatementValidation(documents, allowOptionalFields)
+    voided_check: mixed().nullable(),
+    bank_statement: mixed().nullable(),
   });
 
   return allowOptionalFields ? easySchema : schema;

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -1,4 +1,4 @@
-import { mixed, string } from 'yup';
+import { string } from 'yup';
 import StateOptions from '../../../utils/state-options';
 import {
   businessServiceReceivedOptions,
@@ -16,7 +16,6 @@ import {
   urlRegex,
   validateRoutingNumber,
 } from './schema-helpers';
-import { EntityDocumentType } from '../../../api/Document';
 
 // Common Validations
 
@@ -235,78 +234,3 @@ export const routingNumberValidation = string()
   })
   .transform(transformEmptyString);
 
-// Document Upload Validations
-
-const documentUploadValidation = mixed();
-
-export const ss4Validation = documentUploadValidation;
-
-export const governmentIdValidation = documentUploadValidation;
-
-export const otherDocumentValidation = documentUploadValidation;
-
-export const voidedCheckValidation = (
-  documents: any[],
-  allowOptionalFields: boolean
-) => {
-  const existingDoc = documents.some(
-    (doc) => doc.document_type === EntityDocumentType.voidedCheck
-  );
-
-  if (existingDoc || allowOptionalFields) {
-    return documentUploadValidation.nullable();
-  } else {
-    return documentUploadValidation.required('Please select one or more files');
-  }
-};
-
-export const bankStatementValidation = (
-  documents: any[],
-  allowOptionalFields: boolean
-) => {
-  const existingDoc = documents.some(
-    (doc) => doc.document_type === EntityDocumentType.bankStatement
-  );
-
-  if (existingDoc || allowOptionalFields) {
-    return documentUploadValidation.nullable();
-  } else {
-    return documentUploadValidation.required('Please select one or more files');
-  }
-};
-
-export const balanceSheetValidation = (
-  volume: string,
-  documents: any[],
-  allowOptionalFields: boolean
-) => {
-  const vol = parseInt(volume);
-  const balanceSheetRequiredAmount = 1000000;
-  const existingDoc = documents.some(
-    (doc) => doc.document_type === EntityDocumentType.balanceSheet
-  );
-
-  if (existingDoc || allowOptionalFields) {
-    return documentUploadValidation.nullable();
-  } else if (vol >= balanceSheetRequiredAmount && !allowOptionalFields) {
-    return documentUploadValidation.required('Please select one or more files');
-  }
-};
-
-export const profitAndLossStatementValidation = (
-  volume: string,
-  documents: any[],
-  allowOptionalFields: boolean
-) => {
-  const vol = parseInt(volume);
-  const profitLossRequiredAmount = 1000000;
-  const existingDoc = documents.some(
-    (doc) => doc.document_type === EntityDocumentType.profitAndLossStatement
-  );
-
-  if (existingDoc || allowOptionalFields) {
-    return documentUploadValidation.nullable();
-  } else if (vol >= profitLossRequiredAmount && !allowOptionalFields) {
-    return documentUploadValidation.required('Please select one or more files');
-  }
-};


### PR DESCRIPTION
### `payment-provisioning`: Conditional document upload requirements


This PR commits the following changes:

- Updates the schema for the bank account / doc upload form step of `justifi-payment-provisioning` - users only need to upload a voided_check OR a bank_statement to proceed. 
  - Validation error only triggers if both inputs are empty and no documents have been uploaded previously


Links
-----

Closes https://github.com/justifi-tech/engineering-artifacts/issues/460

Developer considerations
--------------

- On any task
  - [X] Previous unit and e2e tests are passing
  - [X] Perform dev QA on Chrome, Firefox, and Safari



Developer QA steps
--------------------


- [ ] component library builds and runs
- [ ] test suites pass


To test these changes you will need to fill out the payment-provisioning component up to the bank account / document upload form step. 

I've prepared some businesses to make QA easier. Both businesses have completed the first several steps of the form so you will not need to spend the time filling out the form again

Pineapple Joint: `biz_5KBgZBhbgyQPdIxCjMCmIu` 

Edit line 82 of the example file and set the businessId to ^^^^

- [ ] Once the bank account / document page is loaded, click `Next` to trigger validation. Verify that both document upload inputs trigger error validation with the following message: `Please upload either a voided check or a bank statement. Only one is required.`
- [ ] Choose either document upload input, upload any file to either input, and click `Next` to trigger validation. Neither document input should trigger error validation. 

Raspberry Stall: `biz_1ZKhCXQ0GPzcZy8rSYXSxl`

For this business, I've uploaded a document but did not add a bank account. 

Edit line 82 of the example file and set the businessId to ^^^^

- [ ] Once the bank account / document page is loaded, click `Next` to trigger validation. The bank account form inputs should trigger error validation, but the document inputs should NOT trigger validation because an valid document has already been uploaded. 
- [ ] Completing the bank account section should allow you to proceed to the final step. 
