### PR TITLE
[Fix] Tokenize payment method component hide billing form props not working (fixes #695)

### DIFF
--- a/packages/webcomponents/src/components/checkout/billing-form/billing-form.tsx
+++ b/packages/webcomponents/src/components/checkout/billing-form/billing-form.tsx
@@ -70,61 +70,76 @@ export class BillingForm {
     const billingFormDefaultValue = this.formController.getInitialValues();
     const showHeader = !this.isPostalOnlyMode && !this.hideAllBillingFields;
 
+    // Don't render anything if all fields should be hidden
+    if (this.hideAllBillingFields) {
+      return <Host></Host>;
+    }
+
     return (
       <Host>
-        <div part={billingForm} class="mt-4" hidden={this.hideAllBillingFields}>
+        <div part={billingForm} class="mt-4">
           {showHeader && <Header3 text="Billing address" class="fs-6 fw-bold lh-lg mb-4" />}
           <form>
             <fieldset>
               {this.legend && <legend>{this.legend}</legend>}
               <div class="row gy-3">
-                <div class="col-12" hidden={this.isPostalOnlyMode}>
-                  <form-control-text
-                    name='name'
-                    label='Full Name'
-                    defaultValue={billingFormDefaultValue.name}
-                    errorText={this.errors.name}
-                    inputHandler={this.inputHandler}
-                  />
-                </div>
-                <div class="col-12" hidden={this.isPostalOnlyMode}>
-                  <form-control-text
-                    name='address_line1'
-                    label='Street Address'
-                    defaultValue={billingFormDefaultValue.address_line1}
-                    errorText={this.errors.address_line1}
-                    inputHandler={this.inputHandler}
-                  />
-                </div>
-                <div class="col-12" hidden={this.isPostalOnlyMode}>
-                  <form-control-text
-                    name='address_line2'
-                    label="Apartment, Suite, etc. (optional)"
-                    defaultValue={billingFormDefaultValue.address_line2}
-                    errorText={this.errors.address_line2}
-                    inputHandler={this.inputHandler}
-                  />
-                </div>
-                <div class="col-12" hidden={this.isPostalOnlyMode}>
-                  <form-control-text
-                    name='address_city'
-                    label="City"
-                    defaultValue={billingFormDefaultValue.address_city}
-                    errorText={this.errors.address_city}
-                    inputHandler={this.inputHandler}
-                  />
-                </div>
-                <div class="col-12" hidden={this.isPostalOnlyMode}>
-                  <form-control-select
-                    name='address_state'
-                    label='State'
-                    options={StateOptions}
-                    defaultValue={billingFormDefaultValue.address_state}
-                    errorText={this.errors.address_state}
-                    inputHandler={this.inputHandler}
-                  />
-                </div>
-                <div class="col-12" hidden={this.hideAllBillingFields}>
+                {!this.isPostalOnlyMode && (
+                  <div class="col-12">
+                    <form-control-text
+                      name='name'
+                      label='Full Name'
+                      defaultValue={billingFormDefaultValue.name}
+                      errorText={this.errors.name}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                )}
+                {!this.isPostalOnlyMode && (
+                  <div class="col-12">
+                    <form-control-text
+                      name='address_line1'
+                      label='Street Address'
+                      defaultValue={billingFormDefaultValue.address_line1}
+                      errorText={this.errors.address_line1}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                )}
+                {!this.isPostalOnlyMode && (
+                  <div class="col-12">
+                    <form-control-text
+                      name='address_line2'
+                      label="Apartment, Suite, etc. (optional)"
+                      defaultValue={billingFormDefaultValue.address_line2}
+                      errorText={this.errors.address_line2}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                )}
+                {!this.isPostalOnlyMode && (
+                  <div class="col-12">
+                    <form-control-text
+                      name='address_city'
+                      label="City"
+                      defaultValue={billingFormDefaultValue.address_city}
+                      errorText={this.errors.address_city}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                )}
+                {!this.isPostalOnlyMode && (
+                  <div class="col-12">
+                    <form-control-select
+                      name='address_state'
+                      label='State'
+                      options={StateOptions}
+                      defaultValue={billingFormDefaultValue.address_state}
+                      errorText={this.errors.address_state}
+                      inputHandler={this.inputHandler}
+                    />
+                  </div>
+                )}
+                <div class="col-12">
                   <form-control-text
                     name='address_postal_code'
                     label="ZIP"

--- a/packages/webcomponents/src/components/checkout/billing-form/test/billing-form.spec.tsx
+++ b/packages/webcomponents/src/components/checkout/billing-form/test/billing-form.spec.tsx
@@ -70,4 +70,150 @@ describe('billing-form', () => {
 
     expect(values).toEqual(fields);
   });
+
+  it('should be in postal-only mode when hideCardBillingForm is true and paymentMethodType is card', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-card-billing-form="true" payment-method-type="card"></justifi-billing-form>`,
+    });
+
+    const instance: any = page.rootInstance;
+
+    await page.waitForChanges();
+
+    expect(instance.hideCardBillingForm).toBe(true);
+    expect(instance.paymentMethodType).toBe('card');
+    expect(instance.isPostalOnlyMode).toBe(true);
+    expect(instance.hideAllBillingFields).toBe(false);
+  });
+
+  it('should hide all billing fields when hideBankAccountBillingForm is true and paymentMethodType is bankAccount', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-bank-account-billing-form="true" payment-method-type="bankAccount"></justifi-billing-form>`,
+    });
+
+    const instance: any = page.rootInstance;
+
+    await page.waitForChanges();
+
+    expect(instance.hideBankAccountBillingForm).toBe(true);
+    expect(instance.paymentMethodType).toBe('bankAccount');
+    expect(instance.isPostalOnlyMode).toBe(false);
+    expect(instance.hideAllBillingFields).toBe(true);
+  });
+
+  it('should render only ZIP field when hideCardBillingForm is true (postal-only mode)', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-card-billing-form="true" payment-method-type="card"></justifi-billing-form>`,
+    });
+
+    await page.waitForChanges();
+
+    // In postal-only mode, only ZIP field should be rendered
+    const nameField = page.root?.querySelector('[name="name"]');
+    const addressField = page.root?.querySelector('[name="address_line1"]'); 
+    const zipField = page.root?.querySelector('[name="address_postal_code"]');
+
+    expect(nameField).toBeFalsy(); // Should not be rendered at all
+    expect(addressField).toBeFalsy(); // Should not be rendered at all
+    expect(zipField).toBeTruthy(); // Should be rendered
+  });
+
+  it('should render nothing when hideBankAccountBillingForm is true', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-bank-account-billing-form="true" payment-method-type="bankAccount"></justifi-billing-form>`,
+    });
+
+    await page.waitForChanges();
+
+    // When hideBankAccountBillingForm is true, nothing should be rendered inside Host
+    const billingFormDiv = page.root?.querySelector('[part="billing-form"]');
+    const zipField = page.root?.querySelector('[name="address_postal_code"]');
+    
+    expect(billingFormDiv).toBeFalsy(); // Should not be rendered at all
+    expect(zipField).toBeFalsy(); // Should not be rendered at all
+  });
+
+  it('should render all fields by default when no hide props are set', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form payment-method-type="card"></justifi-billing-form>`,
+    });
+
+    await page.waitForChanges();
+
+    // All fields should be present when no hide props are set
+    const nameField = page.root?.querySelector('[name="name"]');
+    const addressField = page.root?.querySelector('[name="address_line1"]');
+    const address2Field = page.root?.querySelector('[name="address_line2"]');
+    const cityField = page.root?.querySelector('[name="address_city"]');
+    const stateField = page.root?.querySelector('[name="address_state"]');
+    const zipField = page.root?.querySelector('[name="address_postal_code"]');
+    const billingFormDiv = page.root?.querySelector('[part="billing-form"]');
+    const header = page.root?.querySelector('h3');
+
+    expect(billingFormDiv).toBeTruthy();
+    expect(header).toBeTruthy(); // Header should be visible
+    expect(nameField).toBeTruthy();
+    expect(addressField).toBeTruthy();
+    expect(address2Field).toBeTruthy();
+    expect(cityField).toBeTruthy();
+    expect(stateField).toBeTruthy();
+    expect(zipField).toBeTruthy();
+  });
+
+  it('should not render billing address header in postal-only mode', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-card-billing-form="true" payment-method-type="card"></justifi-billing-form>`,
+    });
+
+    await page.waitForChanges();
+
+    // Header should be hidden in postal-only mode
+    const header = page.root?.querySelector('h3');
+    expect(header).toBeFalsy();
+  });
+
+  it('should handle form methods correctly even when fields are hidden', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-card-billing-form="true" payment-method-type="card"></justifi-billing-form>`,
+    });
+
+    const instance: any = page.rootInstance;
+    await page.waitForChanges();
+
+    // Form methods should still work even in postal-only mode
+    const testData = { address_postal_code: '12345' };
+    await instance.fill(testData);
+    
+    const values = await instance.getValues();
+    expect(values.address_postal_code).toBe('12345');
+
+    const validation = await instance.validate();
+    expect(validation).toHaveProperty('isValid');
+    expect(validation).toHaveProperty('errors');
+  });
+
+  it('should handle form methods correctly when all fields are hidden', async () => {
+    const page = await newSpecPage({
+      components: [BillingForm],  
+      html: `<justifi-billing-form hide-bank-account-billing-form="true" payment-method-type="bankAccount"></justifi-billing-form>`,
+    });
+
+    const instance: any = page.rootInstance;
+    await page.waitForChanges();
+
+    // Form methods should still work even when no fields are rendered
+    const values = await instance.getValues();
+    expect(values).toBeDefined();
+
+    const validation = await instance.validate();
+    expect(validation).toHaveProperty('isValid');
+    expect(validation).toHaveProperty('errors');
+  });
 });

--- a/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
+++ b/packages/webcomponents/src/components/checkout/test/__snapshots__/checkout-core.spec.tsx.snap
@@ -230,21 +230,6 @@ exports[`justifi-checkout-core should render the postal form if hideCardBillingF
                         <form>
                           <fieldset>
                             <div class="gy-3 row">
-                              <div class="col-12" hidden="">
-                                <form-control-text label="Full Name" name="name"></form-control-text>
-                              </div>
-                              <div class="col-12" hidden="">
-                                <form-control-text label="Street Address" name="address_line1"></form-control-text>
-                              </div>
-                              <div class="col-12" hidden="">
-                                <form-control-text label="Apartment, Suite, etc. (optional)" name="address_line2"></form-control-text>
-                              </div>
-                              <div class="col-12" hidden="">
-                                <form-control-text label="City" name="address_city"></form-control-text>
-                              </div>
-                              <div class="col-12" hidden="">
-                                <form-control-select label="State" name="address_state"></form-control-select>
-                              </div>
                               <div class="col-12">
                                 <form-control-text label="ZIP" maxlength="5" name="address_postal_code"></form-control-text>
                               </div>

--- a/packages/webcomponents/src/components/tokenize-payment-method/test/tokenize-payment-method.spec.tsx
+++ b/packages/webcomponents/src/components/tokenize-payment-method/test/tokenize-payment-method.spec.tsx
@@ -1,0 +1,149 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { TokenizePaymentMethod } from '../tokenize-payment-method';
+import { PaymentMethodOptions } from '../../checkout/payment-method-options';
+import { NewPaymentMethod } from '../../checkout/new-payment-method';
+import { BillingForm } from '../../checkout/billing-form/billing-form';
+
+describe('tokenize-payment-method', () => {
+  it('should pass hideCardBillingForm prop to payment method options', async () => {
+    const page = await newSpecPage({
+      components: [TokenizePaymentMethod, PaymentMethodOptions, NewPaymentMethod, BillingForm],
+      html: `<justifi-tokenize-payment-method hide-card-billing-form="true"></justifi-tokenize-payment-method>`,
+    });
+
+    await page.waitForChanges();
+
+    const tokenizePaymentMethod = page.rootInstance;
+    const paymentMethodOptions = page.root.shadowRoot.querySelector('justifi-payment-method-options');
+    
+    expect(paymentMethodOptions).toBeTruthy();
+    expect(tokenizePaymentMethod.hideCardBillingForm).toBe(true);
+  });
+
+  it('should pass hideBankAccountBillingForm prop to payment method options', async () => {
+    const page = await newSpecPage({
+      components: [TokenizePaymentMethod, PaymentMethodOptions, NewPaymentMethod, BillingForm],
+      html: `<justifi-tokenize-payment-method hide-bank-account-billing-form="true"></justifi-tokenize-payment-method>`,
+    });
+
+    await page.waitForChanges();
+
+    const tokenizePaymentMethod = page.rootInstance;
+    const paymentMethodOptions = page.root.shadowRoot.querySelector('justifi-payment-method-options');
+    
+    expect(paymentMethodOptions).toBeTruthy();
+    expect(tokenizePaymentMethod.hideBankAccountBillingForm).toBe(true);
+  });
+
+  it('should pass hideCardBillingForm prop to billing form through the chain', async () => {
+    const page = await newSpecPage({
+      components: [TokenizePaymentMethod, PaymentMethodOptions, NewPaymentMethod, BillingForm],
+      html: `<justifi-tokenize-payment-method hide-card-billing-form="true" auth-token="test-token" account-id="test-account"></justifi-tokenize-payment-method>`,
+    });
+
+    await page.waitForChanges();
+
+    // Find the payment method options and verify the prop is passed
+    const paymentMethodOptions = page.root.shadowRoot.querySelector('justifi-payment-method-options');
+    const paymentMethodOptionsInstance = paymentMethodOptions as any;
+    
+    expect(paymentMethodOptions).toBeTruthy();
+    expect(paymentMethodOptionsInstance.hideCardBillingForm).toBe(true);
+  });
+
+  it('should pass hideBankAccountBillingForm prop to billing form through the chain', async () => {
+    const page = await newSpecPage({
+      components: [TokenizePaymentMethod, PaymentMethodOptions, NewPaymentMethod, BillingForm],
+      html: `<justifi-tokenize-payment-method hide-bank-account-billing-form="true" disable-credit-card="true" auth-token="test-token" account-id="test-account"></justifi-tokenize-payment-method>`,
+    });
+
+    await page.waitForChanges();
+
+    // Find the payment method options and verify the prop is passed
+    const paymentMethodOptions = page.root.shadowRoot.querySelector('justifi-payment-method-options');
+    const paymentMethodOptionsInstance = paymentMethodOptions as any;
+    
+    expect(paymentMethodOptions).toBeTruthy();
+    expect(paymentMethodOptionsInstance.hideBankAccountBillingForm).toBe(true);
+  });
+
+  it('should not render billing form fields except postal_code when hideCardBillingForm is true', async () => {
+    // Test the billing form behavior directly (since integration tests have shadow DOM complexities)
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-card-billing-form="true" payment-method-type="card"></justifi-billing-form>`,
+    });
+
+    await page.waitForChanges();
+
+    const instance: any = page.rootInstance;
+    
+    // Verify the component is configured correctly for postal-only mode
+    expect(instance.hideCardBillingForm).toBe(true);
+    expect(instance.paymentMethodType).toBe('card');
+    expect(instance.isPostalOnlyMode).toBe(true);
+    expect(instance.hideAllBillingFields).toBe(false);
+
+    // Verify only ZIP field is rendered
+    const nameField = page.root?.querySelector('[name="name"]');
+    const addressField = page.root?.querySelector('[name="address_line1"]');
+    const postalCodeField = page.root?.querySelector('[name="address_postal_code"]');
+
+    expect(nameField).toBeFalsy(); // Should not be in DOM
+    expect(addressField).toBeFalsy(); // Should not be in DOM  
+    expect(postalCodeField).toBeTruthy(); // Should be in DOM
+  });
+
+  it('should not render billing form fields when hideBankAccountBillingForm is true', async () => {
+    // Test the billing form behavior directly (since integration tests have shadow DOM complexities)
+    const page = await newSpecPage({
+      components: [BillingForm],
+      html: `<justifi-billing-form hide-bank-account-billing-form="true" payment-method-type="bankAccount"></justifi-billing-form>`,
+    });
+
+    await page.waitForChanges();
+
+    const instance: any = page.rootInstance;
+    
+    // Verify the component is configured correctly to hide all fields
+    expect(instance.hideBankAccountBillingForm).toBe(true);
+    expect(instance.paymentMethodType).toBe('bankAccount');
+    expect(instance.isPostalOnlyMode).toBe(false);
+    expect(instance.hideAllBillingFields).toBe(true);
+
+    // Verify no billing form content is rendered
+    const billingFormDiv = page.root?.querySelector('[part="billing-form"]');
+    const postalCodeField = page.root?.querySelector('[name="address_postal_code"]');
+
+    expect(billingFormDiv).toBeFalsy(); // Should not be in DOM
+    expect(postalCodeField).toBeFalsy(); // Should not be in DOM
+  });
+
+  it('should correctly validate that props flow through component hierarchy', async () => {
+    // Test that the tokenize-payment-method component properly accepts and stores the props
+    const cardPage = await newSpecPage({
+      components: [TokenizePaymentMethod],
+      html: `<justifi-tokenize-payment-method hide-card-billing-form="true" auth-token="test" account-id="test"></justifi-tokenize-payment-method>`,
+    });
+
+    const bankPage = await newSpecPage({
+      components: [TokenizePaymentMethod],
+      html: `<justifi-tokenize-payment-method hide-bank-account-billing-form="true" auth-token="test" account-id="test"></justifi-tokenize-payment-method>`,
+    });
+
+    await cardPage.waitForChanges();
+    await bankPage.waitForChanges();
+
+    const cardInstance = cardPage.rootInstance as any;
+    const bankInstance = bankPage.rootInstance as any;
+
+    // Verify props are correctly set on tokenize-payment-method instances
+    expect(cardInstance.hideCardBillingForm).toBe(true);
+    expect(cardInstance.hideBankAccountBillingForm).toBeUndefined();
+
+    expect(bankInstance.hideBankAccountBillingForm).toBe(true);  
+    expect(bankInstance.hideCardBillingForm).toBeUndefined();
+  });
+
+
+});


### PR DESCRIPTION
## Summary

Fixes an issue where the `hideCardBillingForm` and `hideBankAccountBillingForm` props were not working correctly in the tokenize payment method component. The billing form was still rendering hidden fields in the DOM instead of conditionally rendering them.

## Changes Made

- **Refactored billing form rendering logic**: Changed from using `hidden` attributes to conditional rendering with JSX expressions
- **Fixed postal-only mode**: When `hideCardBillingForm=true`, only the ZIP code field is rendered (not hidden in DOM)
- **Fixed complete hiding**: When `hideBankAccountBillingForm=true`, no billing form content is rendered at all
- **Updated tests**: Added comprehensive test coverage for both hiding scenarios and prop propagation
- **Updated snapshots**: Fixed test snapshots to reflect the new conditional rendering approach

## Comparison

https://github.com/justifi-tech/web-component-library/compare/main...695-tokenize-payment-method-component-hide-billing-form-props-not-working

## Manual QA Checklist

- [ ] Tokenize payment method with `hideCardBillingForm="true"` shows only ZIP field
- [ ] Tokenize payment method with `hideBankAccountBillingForm="true"` shows no billing fields
- [ ] Default behavior (no hide props) shows all billing fields
- [ ] Form validation still works correctly in all scenarios
- [ ] Props are correctly passed through component hierarchy

🤖 Generated with [Claude Code](https://claude.ai/code)