### PR TITLE
Fix dropdown field styles (also reset styles in Safari and Firefox)

### DIFF
--- a/apps/docs/stories/components/ModularCheckout/Complete Examples/Layout1/example.ts
+++ b/apps/docs/stories/components/ModularCheckout/Complete Examples/Layout1/example.ts
@@ -138,11 +138,31 @@ ${codeExampleHead(
     .form-select {
       width: 100%;
       padding: 0.475rem 0.75rem;
+      padding-right: 2.5rem;
       border: 1px solid #e0e0e0;
       border-radius: 6px;
       font-size: 1rem;
       background-color: white;
       color: #333;
+      /* Reset Safari default styles */
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      /* Ensure consistent styling */
+      font-family: inherit;
+      line-height: 1.5;
+      /* Remove Safari's default focus outline */
+      outline: none;
+      /* Custom dropdown arrow */
+      background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23333' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+      background-repeat: no-repeat;
+      background-position: right 0.75rem center;
+      background-size: 1em;
+    }
+
+    /* Custom dropdown arrow for webkit browsers */
+    .form-select::-ms-expand {
+      display: none;
     }
 
     .submit-button {

--- a/apps/docs/stories/components/ModularCheckout/Complete Examples/Layout1/styles.css
+++ b/apps/docs/stories/components/ModularCheckout/Complete Examples/Layout1/styles.css
@@ -118,21 +118,47 @@
 }
 
 .form-label {
+  font-family: -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
   display: block;
   margin-bottom: 10px;
-  font-size: 1.1rem;
+  font-size: 1rem;
   color: #333;
   font-weight: 500;
+  line-height: 1.5;
 }
 
 .form-select {
   width: 100%;
-  padding: 0.475rem 0.75rem;
+  padding: 0.325rem 0.75rem;
+  padding-right: 2.5rem;
   border: 1px solid #e0e0e0;
   border-radius: 6px;
   font-size: 1rem;
   background-color: white;
   color: #333;
+  /* Reset Safari default styles */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  /* Ensure consistent styling */
+  font-family: inherit;
+  line-height: 1.5;
+  /* Remove Safari's default focus outline */
+  outline: none;
+  /* Custom dropdown arrow */
+  background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23333' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6,9 12,15 18,9'%3e%3c/polyline%3e%3c/svg%3e");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  background-size: 1em;
+}
+
+/* Custom dropdown arrow for webkit browsers */
+.form-select::-ms-expand {
+  display: none;
 }
 
 .submit-button {


### PR DESCRIPTION

<img width="655" height="619" alt="image" src="https://github.com/user-attachments/assets/caff9375-8790-4eb5-8017-0c037ea342fd" />


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

