### PR TITLE
feat: Canadian BN support; centralize country constants; 9-digit tax ID (no masks)

### DIFF
--- a/packages/webcomponents/src/api/Business.ts
+++ b/packages/webcomponents/src/api/Business.ts
@@ -2,6 +2,7 @@ import { Identity, Representative } from './Identity';
 import { IDocument } from './Document';
 import { IBankAccount } from './BankAccount';
 import { getStateAbbreviation } from '../components/business-forms/utils/helpers';
+import { DEFAULT_COUNTRY } from '../utils/constants';
 
 export enum BusinessFormServerErrors {
   fetchData = 'Error retrieving business data',
@@ -51,7 +52,7 @@ export class Address implements IAddress {
     this.postal_code = address.postal_code;
     this.city = address.city;
     this.state = getStateAbbreviation(address.state);
-    this.country = address.country || 'USA';
+    this.country = address.country || DEFAULT_COUNTRY;
     this.created_at = address.created_at;
     this.updated_at = address.updated_at;
   }

--- a/packages/webcomponents/src/api/Business.ts
+++ b/packages/webcomponents/src/api/Business.ts
@@ -2,7 +2,7 @@ import { Identity, Representative } from './Identity';
 import { IDocument } from './Document';
 import { IBankAccount } from './BankAccount';
 import { getStateAbbreviation } from '../components/business-forms/utils/helpers';
-import { DEFAULT_COUNTRY } from '../utils/constants';
+import { DEFAULT_COUNTRY } from '../utils/address-form-helpers';
 
 export enum BusinessFormServerErrors {
   fetchData = 'Error retrieving business data',

--- a/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
@@ -2,7 +2,7 @@ import { Component, Host, h, Prop, State } from '@stencil/core';
 import { businessClassificationOptions } from '../../utils/business-form-options';
 import { FormController } from '../../../../ui-components/form/form';
 import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
-import { DEFAULT_COUNTRY } from '../../../../utils/constants';
+import { DEFAULT_COUNTRY, CountryCode } from '../../../../utils/address-form-helpers';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { heading2 } from '../../../../styles/parts';
 
@@ -57,7 +57,7 @@ export class BusinessCoreInfo {
   }
 
   private setLabelsAndMaskForCountry() {
-    const isCanadian = this.country === 'CAN';
+    const isCanadian = this.country === CountryCode.CAN;
     if (isCanadian) {
       this.taxIdLabel = TAX_ID_LABEL_CAN;
       this.taxIdHelpText = TAX_ID_HELP_CAN;

--- a/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
@@ -2,6 +2,7 @@ import { Component, Host, h, Prop, State } from '@stencil/core';
 import { businessClassificationOptions } from '../../utils/business-form-options';
 import { FormController } from '../../../../ui-components/form/form';
 import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
+import { DEFAULT_COUNTRY } from '../../../../utils/constants';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { heading2 } from '../../../../styles/parts';
 
@@ -25,7 +26,7 @@ export class BusinessCoreInfo {
   @Prop() formController: FormController;
   @State() errors: any = {};
   @State() coreInfo: ICoreBusinessInfo = {};
-  @State() country: string = 'USA';
+  @State() country: string = DEFAULT_COUNTRY;
   @State() taxIdLabel: string = TAX_ID_LABEL_US;
   @State() taxIdHelpText: string = TAX_ID_HELP_US;
   @State() taxIdMask: string = TAX_ID_MASKS.US;
@@ -38,7 +39,7 @@ export class BusinessCoreInfo {
     this.formController.values.subscribe(
       values => {
         this.coreInfo = { ...new CoreBusinessInfo(values) };
-        const nextCountry = values?.legal_address?.country || 'USA';
+        const nextCountry = values?.legal_address?.country || DEFAULT_COUNTRY;
         if (nextCountry !== this.country) {
           this.country = nextCountry;
           this.setLabelsAndMaskForCountry();
@@ -51,7 +52,7 @@ export class BusinessCoreInfo {
 
     // Initialize once with initial values
     const initial = this.formController.getInitialValues();
-    this.country = initial?.legal_address?.country || 'USA';
+    this.country = initial?.legal_address?.country || DEFAULT_COUNTRY;
     this.setLabelsAndMaskForCountry();
   }
 

--- a/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
@@ -1,7 +1,7 @@
 import { Component, Host, h, Prop, State } from '@stencil/core';
 import { businessClassificationOptions } from '../../utils/business-form-options';
 import { FormController } from '../../../../ui-components/form/form';
-import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
+import { PHONE_MASKS } from '../../../../utils/form-input-masks';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { heading2 } from '../../../../styles/parts';
 
@@ -95,13 +95,14 @@ export class BusinessCoreInfo {
               />
             </div>
             <div class="col-12 col-md-6">
-              <form-control-number-masked
+              <form-control-text
                 name="tax_id"
-                label="Tax ID"
+                label="Tax ID / Business Number"
                 defaultValue={coreInfoDefaultValue.tax_id}
                 errorText={this.errors.tax_id}
                 inputHandler={this.inputHandler}
-                mask={TAX_ID_MASKS.US}
+                maxLength={9}
+                helpText="Enter your tax identification number (9 digits, no dashes)"
               />
             </div>
             <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
+++ b/packages/webcomponents/src/components/business-forms/business-form/business-core-info/business-core-info.tsx
@@ -1,7 +1,8 @@
 import { Component, Host, h, Prop, State } from '@stencil/core';
 import { businessClassificationOptions } from '../../utils/business-form-options';
 import { FormController } from '../../../../ui-components/form/form';
-import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
+import { PHONE_MASKS } from '../../../../utils/form-input-masks';
+import { numberOnlyHandler } from '../../../../ui-components/form/utils';
 import { DEFAULT_COUNTRY, CountryCode } from '../../../../utils/address-form-helpers';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { heading2 } from '../../../../styles/parts';
@@ -29,7 +30,7 @@ export class BusinessCoreInfo {
   @State() country: string = DEFAULT_COUNTRY;
   @State() taxIdLabel: string = TAX_ID_LABEL_US;
   @State() taxIdHelpText: string = TAX_ID_HELP_US;
-  @State() taxIdMask: string = TAX_ID_MASKS.US;
+  // No mask for tax ID; enforce digits-only via key handlers and schema
 
   constructor() {
     this.inputHandler = this.inputHandler.bind(this);
@@ -61,11 +62,11 @@ export class BusinessCoreInfo {
     if (isCanadian) {
       this.taxIdLabel = TAX_ID_LABEL_CAN;
       this.taxIdHelpText = TAX_ID_HELP_CAN;
-      this.taxIdMask = TAX_ID_MASKS.CA;
+      // No input mask; handled via number-only and validation
     } else {
       this.taxIdLabel = TAX_ID_LABEL_US;
       this.taxIdHelpText = TAX_ID_HELP_US;
-      this.taxIdMask = TAX_ID_MASKS.US;
+      // No input mask; handled via number-only and validation
     }
   }
 
@@ -131,14 +132,15 @@ export class BusinessCoreInfo {
               />
             </div>
             <div class="col-12 col-md-6">
-              <form-control-number-masked
+              <form-control-text
                 name="tax_id"
                 label={this.taxIdLabel}
                 defaultValue={coreInfoDefaultValue.tax_id}
                 errorText={this.errors.tax_id}
                 inputHandler={this.inputHandler}
-                mask={this.taxIdMask}
                 helpText={this.taxIdHelpText}
+                maxLength={9}
+                keyDownHandler={numberOnlyHandler}
               />
             </div>
             <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -4,7 +4,8 @@ import { FormController } from '../../../../ui-components/form/form';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
 import { BusinessFormStep, businessClassificationOptions } from '../../utils';
-import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
+import { PHONE_MASKS } from '../../../../utils/form-input-masks';
+import { numberOnlyHandler } from '../../../../ui-components/form/utils';
 import { DEFAULT_COUNTRY, CountryCode } from '../../../../utils/address-form-helpers';
 import { heading2 } from '../../../../styles/parts';
 import { PaymentProvisioningLoading } from '../payment-provisioning-loading';
@@ -19,7 +20,7 @@ export class BusinessCoreInfoFormStepCore {
   @State() country: string = DEFAULT_COUNTRY;
   @State() taxIdLabel: string = 'Tax ID (EIN or SSN)';
   @State() taxIdHelpText: string = 'Enter your EIN or SSN (9 digits, no dashes)';
-  @State() taxIdMask: string = TAX_ID_MASKS.US;
+  // No mask for tax ID; enforce digits-only via key handlers and schema
   @State() isLoading: boolean = false;
 
   @Prop() businessId: string;
@@ -91,11 +92,9 @@ export class BusinessCoreInfoFormStepCore {
     if (isCanadian) {
       this.taxIdLabel = 'Business Number';
       this.taxIdHelpText = 'Enter your Business Number (9 digits)';
-      this.taxIdMask = TAX_ID_MASKS.CA;
     } else {
       this.taxIdLabel = 'Tax ID (EIN or SSN)';
       this.taxIdHelpText = 'Enter your EIN or SSN (9 digits, no dashes)';
-      this.taxIdMask = TAX_ID_MASKS.US;
     }
   }
 
@@ -195,14 +194,15 @@ export class BusinessCoreInfoFormStepCore {
               />
             </div>
             <div class="col-12 col-md-6">
-              <form-control-number-masked
+              <form-control-text
                 name="tax_id"
                 label={this.taxIdLabel}
                 defaultValue={coreInfoDefaultValue.tax_id}
                 errorText={this.errors.tax_id}
                 inputHandler={this.inputHandler}
-                mask={this.taxIdMask}
                 helpText={this.taxIdHelpText}
+                maxLength={9}
+                keyDownHandler={numberOnlyHandler}
               />
             </div>
             <div class="col-12">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -4,8 +4,7 @@ import { FormController } from '../../../../ui-components/form/form';
 import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
 import { BusinessFormStep, businessClassificationOptions } from '../../utils';
-import { PHONE_MASKS } from '../../../../utils/form-input-masks';
-import { numberOnlyHandler } from '../../../../ui-components/form/utils';
+import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
 import { heading2 } from '../../../../styles/parts';
 import { PaymentProvisioningLoading } from '../payment-provisioning-loading';
 
@@ -19,6 +18,7 @@ export class BusinessCoreInfoFormStepCore {
   @State() country: string = 'USA';
   @State() taxIdLabel: string = 'Tax ID (EIN or SSN)';
   @State() taxIdHelpText: string = 'Enter your EIN or SSN (9 digits, no dashes)';
+  @State() taxIdMask: string = TAX_ID_MASKS.US;
   @State() isLoading: boolean = false;
 
   @Prop() businessId: string;
@@ -85,14 +85,16 @@ export class BusinessCoreInfoFormStepCore {
   }
 
   private setLabelsForCountry() {
-    const isCanadian = this.country.toUpperCase() === 'CAN';
+    const isCanadian = this.country === 'CAN';
     
     if (isCanadian) {
       this.taxIdLabel = 'Business Number';
       this.taxIdHelpText = 'Enter your Business Number (9 digits)';
+      this.taxIdMask = TAX_ID_MASKS.CA;
     } else {
       this.taxIdLabel = 'Tax ID (EIN or SSN)';
       this.taxIdHelpText = 'Enter your EIN or SSN (9 digits, no dashes)';
+      this.taxIdMask = TAX_ID_MASKS.US;
     }
   }
 
@@ -192,14 +194,13 @@ export class BusinessCoreInfoFormStepCore {
               />
             </div>
             <div class="col-12 col-md-6">
-              <form-control-text
+              <form-control-number-masked
                 name="tax_id"
                 label={this.taxIdLabel}
                 defaultValue={coreInfoDefaultValue.tax_id}
                 errorText={this.errors.tax_id}
                 inputHandler={this.inputHandler}
-                keyDownHandler={numberOnlyHandler}
-                maxLength={9}
+                mask={this.taxIdMask}
                 helpText={this.taxIdHelpText}
               />
             </div>

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -5,6 +5,7 @@ import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
 import { BusinessFormStep, businessClassificationOptions } from '../../utils';
 import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
+import { DEFAULT_COUNTRY } from '../../../../utils/constants';
 import { heading2 } from '../../../../styles/parts';
 import { PaymentProvisioningLoading } from '../payment-provisioning-loading';
 
@@ -15,7 +16,7 @@ export class BusinessCoreInfoFormStepCore {
   @State() formController: FormController;
   @State() errors: any = {};
   @State() coreInfo: ICoreBusinessInfo = {};
-  @State() country: string = 'USA';
+  @State() country: string = DEFAULT_COUNTRY;
   @State() taxIdLabel: string = 'Tax ID (EIN or SSN)';
   @State() taxIdHelpText: string = 'Enter your EIN or SSN (9 digits, no dashes)';
   @State() taxIdMask: string = TAX_ID_MASKS.US;
@@ -64,7 +65,7 @@ export class BusinessCoreInfoFormStepCore {
       this.isLoading = true;
       this.getBusiness({
         onSuccess: (response) => {
-          this.country = response.data.legal_address?.country || 'USA';
+          this.country = response.data.legal_address?.country || DEFAULT_COUNTRY;
           this.coreInfo = new CoreBusinessInfo(response.data);
           resolve();
         },

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step-core.tsx
@@ -5,7 +5,7 @@ import { CoreBusinessInfo, ICoreBusinessInfo } from '../../../../api/Business';
 import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
 import { BusinessFormStep, businessClassificationOptions } from '../../utils';
 import { PHONE_MASKS, TAX_ID_MASKS } from '../../../../utils/form-input-masks';
-import { DEFAULT_COUNTRY } from '../../../../utils/constants';
+import { DEFAULT_COUNTRY, CountryCode } from '../../../../utils/address-form-helpers';
 import { heading2 } from '../../../../styles/parts';
 import { PaymentProvisioningLoading } from '../payment-provisioning-loading';
 
@@ -86,7 +86,7 @@ export class BusinessCoreInfoFormStepCore {
   }
 
   private setLabelsForCountry() {
-    const isCanadian = this.country === 'CAN';
+    const isCanadian = this.country === CountryCode.CAN;
     
     if (isCanadian) {
       this.taxIdLabel = 'Business Number';

--- a/packages/webcomponents/src/components/business-forms/schemas/business-address-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-address-schema.ts
@@ -6,6 +6,7 @@ import {
 } from './schema-validations';
 import StateOptions from '../../../utils/state-options';
 import CanadianProvinceOptions from '../../../utils/canadian-province-options';
+import { CountryCode } from '../../../utils/address-form-helpers';
 import { transformEmptyString } from './schema-helpers';
 
 // Multi-country state/province validation
@@ -16,9 +17,9 @@ export const multiCountryRegionValidation = string()
     // Let yup handle empty values - return true to allow .nullable() and .required() to work properly
     if (!value) return true;
     
-    if (country === 'USA') {
+    if (country === CountryCode.USA) {
       return StateOptions.some(option => option.value === value);
-    } else if (country === 'CAN') {
+    } else if (country === CountryCode.CAN) {
       return CanadianProvinceOptions.some(option => option.value === value);
     }
     
@@ -35,10 +36,10 @@ export const multiCountryPostalValidation = string()
     // Let yup handle empty values - return true to allow .nullable() and .required() to work properly
     if (!value) return true;
     
-    if (country === 'USA') {
+    if (country === CountryCode.USA) {
       // US postal code: 12345 or 12345-6789
       return /^[0-9]{5}(-[0-9]{4})?$/.test(value);
-    } else if (country === 'CAN') {
+    } else if (country === CountryCode.CAN) {
       // Canadian postal code: A1A 1A1 or A1A1A1
       return /^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/.test(value);
     }

--- a/packages/webcomponents/src/components/business-forms/schemas/business-address-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-address-schema.ts
@@ -18,7 +18,7 @@ export const multiCountryRegionValidation = string()
     
     if (country === 'USA') {
       return StateOptions.some(option => option.value === value);
-    } else if (country === 'CA') {
+    } else if (country === 'CAN') {
       return CanadianProvinceOptions.some(option => option.value === value);
     }
     
@@ -38,7 +38,7 @@ export const multiCountryPostalValidation = string()
     if (country === 'USA') {
       // US postal code: 12345 or 12345-6789
       return /^[0-9]{5}(-[0-9]{4})?$/.test(value);
-    } else if (country === 'CA') {
+    } else if (country === 'CAN') {
       // Canadian postal code: A1A 1A1 or A1A1A1
       return /^[A-Za-z]\d[A-Za-z][ -]?\d[A-Za-z]\d$/.test(value);
     }

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -5,13 +5,20 @@ import {
   industryValidation,
   businessNameValidation, 
   phoneValidation, 
-  taxIdValidation, 
+  createCountrySpecificTaxIdValidation,
   websiteUrlValidation,
   dateOfIncorporationValidation,
   businessClassificationValidation
 } from './schema-validations';
 
-export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
+export const businessCoreInfoSchema = (allowOptionalFields?: boolean, country?: string) => {
+  const isCanadian = country?.toUpperCase() === 'CAN' || country?.toUpperCase() === 'CANADA';
+  const taxIdRequiredMessage = isCanadian
+    ? 'Enter valid Business Number without dashes'
+    : 'Enter valid tax ID (SSN or EIN) without dashes';
+
+  const countrySpecificTaxIdValidation = createCountrySpecificTaxIdValidation(country);
+
   const schema = object({
     legal_name: businessNameValidation.required('Enter legal name'),
     website_url: websiteUrlValidation.required('Enter business website url'),
@@ -20,7 +27,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     doing_business_as: doingBusinessAsValidation.nullable(),
     classification: businessClassificationValidation.required('Select business classification'),
     industry: industryValidation.required('Enter a business industry'),
-    tax_id: taxIdValidation.required('Enter valid tax ID (SSN or EIN) without dashes'),
+    tax_id: countrySpecificTaxIdValidation.required(taxIdRequiredMessage),
     date_of_incorporation: dateOfIncorporationValidation.required('Enter date of incorporation'),
   });
 
@@ -32,7 +39,7 @@ export const businessCoreInfoSchema = (allowOptionalFields?: boolean) => {
     doing_business_as: doingBusinessAsValidation.nullable(),
     classification: businessClassificationValidation.nullable(),
     industry: industryValidation.nullable(),
-    tax_id: taxIdValidation.nullable(),
+    tax_id: countrySpecificTaxIdValidation.nullable(),
     date_of_incorporation: dateOfIncorporationValidation.nullable(),
   });
 

--- a/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-core-info-schema.ts
@@ -12,7 +12,7 @@ import {
 } from './schema-validations';
 
 export const businessCoreInfoSchema = (allowOptionalFields?: boolean, country?: string) => {
-  const isCanadian = country?.toUpperCase() === 'CAN' || country?.toUpperCase() === 'CANADA';
+  const isCanadian = country === 'CAN';
   const taxIdRequiredMessage = isCanadian
     ? 'Enter valid Business Number without dashes'
     : 'Enter valid tax ID (SSN or EIN) without dashes';

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -56,14 +56,32 @@ export const industryValidation = string()
   .transform(transformEmptyString);
 
 export const taxIdValidation = string()
-  .matches(numbersOnlyRegex, 'Enter valid tax id, SSN, or EIN')
-  .test('not-repeat', 'Enter valid tax id, SSN, or EIN', (value) => {
+  .matches(numbersOnlyRegex, 'Enter valid tax ID or business number')
+  .test('not-repeat', 'Enter valid tax ID or business number', (value) => {
     return !/^(\d)\1+$/.test(value);
   })
-  .test('not-seq', 'Enter valid tax id, SSN, or EIN', (value) => {
+  .test('not-seq', 'Enter valid tax ID or business number', (value) => {
     return value !== '123456789';
   })
   .transform(transformEmptyString);
+
+export const createCountrySpecificTaxIdValidation = (country?: string) => {
+  const isCanadian = country?.toUpperCase() === 'CAN' || country?.toUpperCase() === 'CANADA';
+  
+  const errorMessage = isCanadian 
+    ? 'Enter valid Business Number'
+    : 'Enter valid tax ID (SSN or EIN)';
+
+  return string()
+    .matches(numbersOnlyRegex, errorMessage)
+    .test('not-repeat', errorMessage, (value) => {
+      return !/^(\d)\1+$/.test(value);
+    })
+    .test('not-seq', errorMessage, (value) => {
+      return value !== '123456789';
+    })
+    .transform(transformEmptyString);
+};
 
 export const dateOfIncorporationValidation = string()
   .test(

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -1,4 +1,5 @@
 import { string } from 'yup';
+import { CountryCode } from '../../../utils/address-form-helpers';
 import StateOptions from '../../../utils/state-options';
 import {
   businessServiceReceivedOptions,
@@ -66,13 +67,13 @@ export const taxIdValidation = string()
   .transform(transformEmptyString);
 
 export const createCountrySpecificTaxIdValidation = (country?: string) => {
-  const isCanadian = country === 'CAN';
-  
-  const errorMessage = isCanadian 
+  const isCanadian = country === CountryCode.CAN;
+  const errorMessage = isCanadian
     ? 'Enter valid Business Number'
     : 'Enter valid tax ID (SSN or EIN)';
 
   return string()
+    .length(9, errorMessage)
     .matches(numbersOnlyRegex, errorMessage)
     .test('not-repeat', errorMessage, (value) => {
       return !/^(\d)\1+$/.test(value);

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -66,7 +66,7 @@ export const taxIdValidation = string()
   .transform(transformEmptyString);
 
 export const createCountrySpecificTaxIdValidation = (country?: string) => {
-  const isCanadian = country?.toUpperCase() === 'CAN' || country?.toUpperCase() === 'CANADA';
+  const isCanadian = country === 'CAN';
   
   const errorMessage = isCanadian 
     ? 'Enter valid Business Number'

--- a/packages/webcomponents/src/components/business-forms/utils/country-form-helpers.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/country-form-helpers.ts
@@ -14,7 +14,7 @@ export interface CountryFormConfig {
 
 /**
  * Gets country-specific form configuration including region options, labels, and postal code settings
- * @param country - The country code (e.g., 'US', 'CA')
+ * @param country - The country code (e.g., 'USA', 'CAN')
  * @returns Object containing regionOptions, regionLabel, postalCodeLabel, and postalCodeConfig
  */
 export function getCountryFormConfig(country?: string): CountryFormConfig {
@@ -23,7 +23,7 @@ export function getCountryFormConfig(country?: string): CountryFormConfig {
   const postalCodeLabel = getPostalCodeLabel(country);
 
   // Configure postal code input based on country
-  const postalCodeConfig = country === 'CA' ? {
+  const postalCodeConfig = country === 'CAN' ? {
     maxLength: 7, // A1A 1A1 with space
     keyDownHandler: undefined, // Allow letters for Canadian postal codes
   } : {
@@ -32,7 +32,7 @@ export function getCountryFormConfig(country?: string): CountryFormConfig {
   };
 
   // Configure help text based on country
-  const postalCodeHelpText = country === 'CA' ? 'Format: A1A 1A1' : 'Format: 12345 or 12345-6789';
+  const postalCodeHelpText = country === 'CAN' ? 'Format: A1A 1A1' : 'Format: 12345 or 12345-6789';
 
   return {
     regionOptions,

--- a/packages/webcomponents/src/components/business-forms/utils/country-form-helpers.ts
+++ b/packages/webcomponents/src/components/business-forms/utils/country-form-helpers.ts
@@ -1,4 +1,4 @@
-import { getRegionOptions, getRegionLabel, getPostalCodeLabel } from '../../../utils/address-form-helpers';
+import { getRegionOptions, getRegionLabel, getPostalCodeLabel, CountryCode } from '../../../utils/address-form-helpers';
 import { numberOnlyHandler } from '../../../ui-components/form/utils';
 
 export interface CountryFormConfig {
@@ -23,7 +23,7 @@ export function getCountryFormConfig(country?: string): CountryFormConfig {
   const postalCodeLabel = getPostalCodeLabel(country);
 
   // Configure postal code input based on country
-  const postalCodeConfig = country === 'CAN' ? {
+  const postalCodeConfig = country === CountryCode.CAN ? {
     maxLength: 7, // A1A 1A1 with space
     keyDownHandler: undefined, // Allow letters for Canadian postal codes
   } : {
@@ -32,7 +32,7 @@ export function getCountryFormConfig(country?: string): CountryFormConfig {
   };
 
   // Configure help text based on country
-  const postalCodeHelpText = country === 'CAN' ? 'Format: A1A 1A1' : 'Format: 12345 or 12345-6789';
+  const postalCodeHelpText = country === CountryCode.CAN ? 'Format: A1A 1A1' : 'Format: 12345 or 12345-6789';
 
   return {
     regionOptions,

--- a/packages/webcomponents/src/utils/address-form-helpers.ts
+++ b/packages/webcomponents/src/utils/address-form-helpers.ts
@@ -1,18 +1,27 @@
 import StateOptions from './state-options';
 import CanadianProvinceOptions from './canadian-province-options';
 
+// Country codes used across forms and validation
+export enum CountryCode {
+  USA = 'USA',
+  CAN = 'CAN',
+}
+
+// Default country used when data omits a country
+export const DEFAULT_COUNTRY: CountryCode = CountryCode.USA;
+
 // Focused country options for payment provisioning (US and Canada only)
 export const PaymentProvisioningCountryOptions = [
-  { label: 'United States', value: 'USA' },
-  { label: 'Canada', value: 'CAN' },
+  { label: 'United States', value: CountryCode.USA },
+  { label: 'Canada', value: CountryCode.CAN },
 ];
 
 // Get appropriate state/province options based on selected country
 export function getRegionOptions(countryCode: string) {
   switch (countryCode) {
-    case 'USA':
+    case CountryCode.USA:
       return StateOptions;
-    case 'CAN':
+    case CountryCode.CAN:
       return CanadianProvinceOptions;
     default:
       return StateOptions; // Default to US states
@@ -22,9 +31,9 @@ export function getRegionOptions(countryCode: string) {
 // Get appropriate region label based on selected country
 export function getRegionLabel(countryCode: string) {
   switch (countryCode) {
-    case 'USA':
+    case CountryCode.USA:
       return 'State';
-    case 'CAN':
+    case CountryCode.CAN:
       return 'Province/Territory';
     default:
       return 'State';
@@ -34,9 +43,9 @@ export function getRegionLabel(countryCode: string) {
 // Get appropriate postal code label based on selected country
 export function getPostalCodeLabel(countryCode: string) {
   switch (countryCode) {
-    case 'USA':
+    case CountryCode.USA:
       return 'ZIP Code';
-    case 'CAN':
+    case CountryCode.CAN:
       return 'Postal Code';
     default:
       return 'Postal Code';

--- a/packages/webcomponents/src/utils/address-form-helpers.ts
+++ b/packages/webcomponents/src/utils/address-form-helpers.ts
@@ -4,7 +4,7 @@ import CanadianProvinceOptions from './canadian-province-options';
 // Focused country options for payment provisioning (US and Canada only)
 export const PaymentProvisioningCountryOptions = [
   { label: 'United States', value: 'USA' },
-  { label: 'Canada', value: 'CA' },
+  { label: 'Canada', value: 'CAN' },
 ];
 
 // Get appropriate state/province options based on selected country
@@ -12,7 +12,7 @@ export function getRegionOptions(countryCode: string) {
   switch (countryCode) {
     case 'USA':
       return StateOptions;
-    case 'CA':
+    case 'CAN':
       return CanadianProvinceOptions;
     default:
       return StateOptions; // Default to US states
@@ -24,7 +24,7 @@ export function getRegionLabel(countryCode: string) {
   switch (countryCode) {
     case 'USA':
       return 'State';
-    case 'CA':
+    case 'CAN':
       return 'Province/Territory';
     default:
       return 'State';
@@ -36,7 +36,7 @@ export function getPostalCodeLabel(countryCode: string) {
   switch (countryCode) {
     case 'USA':
       return 'ZIP Code';
-    case 'CA':
+    case 'CAN':
       return 'Postal Code';
     default:
       return 'Postal Code';

--- a/packages/webcomponents/src/utils/constants.ts
+++ b/packages/webcomponents/src/utils/constants.ts
@@ -1,0 +1,9 @@
+// Centralized application-wide constants
+
+/**
+ * Default country code used when backend payloads omit a country.
+ * Historically this was hardcoded as 'USA' in multiple places.
+ */
+export const DEFAULT_COUNTRY = 'USA';
+
+

--- a/packages/webcomponents/src/utils/constants.ts
+++ b/packages/webcomponents/src/utils/constants.ts
@@ -1,9 +1,0 @@
-// Centralized application-wide constants
-
-/**
- * Default country code used when backend payloads omit a country.
- * Historically this was hardcoded as 'USA' in multiple places.
- */
-export const DEFAULT_COUNTRY = 'USA';
-
-

--- a/packages/webcomponents/src/utils/form-input-masks.ts
+++ b/packages/webcomponents/src/utils/form-input-masks.ts
@@ -2,7 +2,7 @@ export const PHONE_MASKS = {
   US: '(000) 000-0000',
 };
 
-export const TAX_ID_MASKS = { US: '00-0000000' };
+export const TAX_ID_MASKS = { US: '00-0000000', CA: '000000000' };
 
 export const SSN_MASK = '000-00-0000';
 


### PR DESCRIPTION
## Summary
- Introduces Canadian Business Number support and country-aware labels/help.
- Centralizes country codes via CountryCode enum and DEFAULT_COUNTRY.
- Replaces USA fallbacks with DEFAULT_COUNTRY.
- Simplifies tax ID input: digits-only, 9-digit validation; removes masks.

## Changes
- utils/address-form-helpers: add CountryCode enum, DEFAULT_COUNTRY; update helpers and options.
- business-core-info.tsx + form-step-core: switch tax_id to form-control-text with numberOnlyHandler and maxLength=9; keep labels per country.
- schema-validations.ts: enforce 9-digit numeric via createCountrySpecificTaxIdValidation; use CountryCode.CAN.
- api/Business.ts: use DEFAULT_COUNTRY for fallback.
- Remove utils/constants.ts.

## Steps for Testing/QA
- USA flow:
  - Ensure "Tax ID (EIN or SSN)" label and help text display.
  - Non-digits are blocked; 9+ digits invalid; exactly 9 digits accepted.
- CAN flow:
  - Ensure "Business Number" label and help text display.
  - Digits-only enforced; exactly 9 digits required.
- Defaults:
  - When country is missing, defaults to USA behavior.
- Regression:
  - Phone masks unchanged.
  - Address region/postal logic matches selected country.