### PR TITLE
Add GitHub Actions workflow for publishing release candidate components

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Publish Release Candidate Components
 on:
   workflow_dispatch:

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -1,0 +1,39 @@
+name: Publish Release Candidate Components
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build RC
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8.7.5
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Create .env file from secrets
+        shell: bash
+        run: |
+          echo "IFRAME_ORIGIN=${{ secrets.IFRAME_ORIGIN }}" >> .env
+          echo "PROXY_API_ORIGIN=${{ secrets.PROXY_API_ORIGIN }}" >> .env
+          echo "API_ORIGIN=${{ secrets.API_ORIGIN }}" >> .env
+
+      - name: Build packages
+        working-directory: ./packages/webcomponents
+        run: pnpm build
+
+      - name: Publish Release Candidate to NPM Registry
+        run: |
+          pnpm version-packages --preid rc
+          pnpm release --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.JUSTIFI_SUPPORT_NPM_TOKEN }}


### PR DESCRIPTION
This will prevent RC versions to be downloaded when `npm install @justifi/webcomponents` is run without a specified version. 

**Key Changes for Release Candidates:**
1 - Workflow Name: "Publish Release Candidate Components" to clearly distinguish it
2 - Job Name: "Build RC" for clarity
3 - Versioning: Uses pnpm version-packages --preid rc to create pre-release versions (e.g., 1.0.0-rc.1)
4 - NPM Tag: Uses pnpm release --tag next to publish with the next tag instead of latest

**How it works:**
* Manual Trigger: Like your main workflow, this runs on workflow_dispatch so you can manually trigger it when you want to publish an RC
* Pre-release Versioning: The --preid rc flag creates version numbers like 1.0.0-rc.1, 1.0.0-rc.2, etc.
* Next Tag: Packages are published with the next tag, so users can install them with npm install package@next

**Usage:**
Users can now install your release candidate packages using:
```
npm install @your-scope/package@next
# or
pnpm add @your-scope/package@next
```
This workflow maintains the same build process and environment setup as your main publish workflow, ensuring consistency between stable releases and release candidates.


Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/786
<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

