### PR TITLE
Payment Provisioning Canada: Split terms and conditions

### DIFF
--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/ENHANCEMENT-PLAN-canada.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/ENHANCEMENT-PLAN-canada.md
@@ -73,7 +73,7 @@ Acceptance:
 Acceptance:
 - USA unchanged; CAN shows SIN and BN fields as specified.
 
-### 6) Bank account step split — Status: Not started
+### 6) Bank account step split — Status: Completed
 - Create `justifi-business-bank-account-form-step-core-canada` with CAN-specific fields and validations.
 - In `payment-provisioning-form-steps.tsx`, derive step 5 component from country via a small factory to avoid inline branching, e.g., `getBankAccountStepFor(country)`.
 

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-form-steps.tsx
@@ -59,13 +59,23 @@ export class PaymentProvisioningFormSteps {
       allowOptionalFields={this.allowOptionalFields}
       country={this.country}
     />,
-    6: () => <justifi-business-terms-conditions-form-step
-      businessId={this.businessId}
-      authToken={this.authToken}
-      ref={(el) => this.refs[6] = el}
-      onFormLoading={this.handleFormLoading}
-      allowOptionalFields={this.allowOptionalFields}
-    />,
+    6: () => this.country === CountryCode.CAN ? (
+      <justifi-business-terms-conditions-form-step-canada
+        businessId={this.businessId}
+        authToken={this.authToken}
+        ref={(el) => this.refs[6] = el}
+        onFormLoading={this.handleFormLoading}
+        allowOptionalFields={this.allowOptionalFields}
+      />
+    ) : (
+      <justifi-business-terms-conditions-form-step
+        businessId={this.businessId}
+        authToken={this.authToken}
+        ref={(el) => this.refs[6] = el}
+        onFormLoading={this.handleFormLoading}
+        allowOptionalFields={this.allowOptionalFields}
+      />
+    ),
   };
 
   

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/readme.md
@@ -30,6 +30,7 @@
 - [justifi-business-representative-form-step](business-representative)
 - [justifi-business-owners-form-step](business-owners)
 - [justifi-business-bank-account-form-step](bank-account)
+- [justifi-business-terms-conditions-form-step-canada](terms-and-conditions)
 - [justifi-business-terms-conditions-form-step](terms-and-conditions)
 
 ### Graph
@@ -41,6 +42,7 @@ graph TD;
   justifi-payment-provisioning-form-steps --> justifi-business-representative-form-step
   justifi-payment-provisioning-form-steps --> justifi-business-owners-form-step
   justifi-payment-provisioning-form-steps --> justifi-business-bank-account-form-step
+  justifi-payment-provisioning-form-steps --> justifi-business-terms-conditions-form-step-canada
   justifi-payment-provisioning-form-steps --> justifi-business-terms-conditions-form-step
   justifi-business-core-info-form-step --> justifi-business-core-info-form-step-core
   justifi-business-core-info-form-step-core --> form-control-text
@@ -91,6 +93,7 @@ graph TD;
   bank-account-form-inputs --> form-control-select
   bank-account-document-form-inputs --> form-control-file
   form-control-file --> form-control-tooltip
+  justifi-business-terms-conditions-form-step-canada --> form-control-checkbox
   justifi-business-terms-conditions-form-step --> form-control-checkbox
   justifi-payment-provisioning-core --> justifi-payment-provisioning-form-steps
   style justifi-payment-provisioning-form-steps fill:#f9f,stroke:#333,stroke-width:4px

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step-canada.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/terms-and-conditions/business-terms-conditions-form-step-canada.tsx
@@ -1,0 +1,179 @@
+import { Component, h, Prop, State, Method, Event, EventEmitter } from '@stencil/core';
+import { FormController } from '../../../../ui-components/form/form';
+import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
+import { businessTermsConditionsSchema } from '../../schemas/business-terms-conditions-schema';
+import { Api, IApiResponse } from '../../../../api';
+import { IBusiness } from '../../../../api/Business';
+import { ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
+import { heading2 } from '../../../../styles/parts';
+import { BusinessFormStep } from '../../utils';
+
+@Component({
+  tag: 'justifi-business-terms-conditions-form-step-canada'
+})
+export class BusinessTermsConditionsFormStepCanada {
+  @State() formController: FormController;
+  @State() errors: any = {};
+  @State() acceptedTermsBefore: boolean;
+  @State() acceptedTerms: boolean;
+
+  @Prop() authToken: string;
+  @Prop() businessId: string;
+  @Prop() allowOptionalFields?: boolean;
+
+  @Event({ eventName: 'complete-form-step-event', bubbles: true }) stepCompleteEvent: EventEmitter<ComponentFormStepCompleteEvent>;
+  @Event({ eventName: 'error-event', bubbles: true }) errorEvent: EventEmitter<ComponentErrorEvent>;
+
+  // internal loading events
+  @Event() formLoading: EventEmitter<boolean>;
+  @Event({ bubbles: true }) formCompleted: EventEmitter<any>;
+
+  private api: any;
+
+  get businessEndpoint() {
+    return `entities/business/${this.businessId}`
+  }
+
+  get termsConditionsEndpoint() {
+    return 'entities/terms_and_conditions'
+  }
+
+  get formHelperText() {
+    return this.acceptedTermsBefore ? 'You have already accepted the terms and conditions.' : null
+  }
+
+  get termsPayload() {
+    return {
+      business_id: this.businessId,
+      accepted: this.formController.values.getValue().accepted,
+      user_agent: window.navigator.userAgent
+    }
+  }
+
+  async componentWillLoad() {
+    this.api = Api();
+    this.formController = new FormController(businessTermsConditionsSchema(this.allowOptionalFields));
+    if (this.businessId && this.authToken) {
+      this.fetchData();
+    }
+  }
+
+  private fetchData = async () => {
+    this.formLoading.emit(true);
+    try {
+      const response: IApiResponse<IBusiness> = await this.api.get({ endpoint: this.businessEndpoint,  authToken: this.authToken });
+      this.acceptedTermsBefore = response.data.terms_conditions_accepted;
+    } catch (error) {
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.FETCH_ERROR,
+        message: error.message,
+        severity: ComponentErrorSeverity.ERROR,
+        data: error,
+      })
+    } finally {
+      this.formLoading.emit(false);
+    }
+  }
+
+  private sendData = async (onSuccess?: () => void) => {
+    this.formLoading.emit(true);
+    try {
+      const payload = this.termsPayload;
+      const response = await this.api.post({ endpoint: this.termsConditionsEndpoint, body: payload, authToken: this.authToken });
+      this.handleResponse(response, onSuccess);
+    } catch (error) {
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.POST_ERROR,
+        message: error.message,
+        severity: ComponentErrorSeverity.ERROR,
+        data: error,
+      })
+    } finally {
+      this.formLoading.emit(false);
+    }
+  }
+
+  handleResponse(response, onSuccess) {
+    if (response.error) {
+      this.errorEvent.emit({
+        errorCode: ComponentErrorCodes.POST_ERROR,
+        message: response.error.message,
+        severity: ComponentErrorSeverity.ERROR,
+        data: response.error,
+      })
+    } else {
+      onSuccess();
+    }
+    this.stepCompleteEvent.emit({ response: response, formStep: BusinessFormStep.termsAndConditions });
+    this.formCompleted.emit();
+  }
+
+  @Method()
+  async validateAndSubmit({ onSuccess }) {
+    if (this.acceptedTermsBefore) {
+      this.stepCompleteEvent.emit({ response: null, formStep: BusinessFormStep.termsAndConditions, metadata: 'no data submitted' });
+      this.formCompleted.emit();
+      onSuccess();
+    } else {
+      this.formController.validateAndSubmit(() => this.sendData(onSuccess));
+    }
+  };
+
+  componentDidLoad() {
+    this.formController.errors.subscribe(errors => {
+      this.errors = { ...errors };
+    });
+  }
+
+  inputHandler = (name: string, value: boolean) => {
+    this.acceptedTerms = value;
+    this.formController.setValues({
+      ...this.formController.values.getValue(),
+      [name]: value,
+    });
+  }
+
+  get merchantAgreementLink() {
+    return (
+      <a
+        href="https://justifi.tech/merchant-agreement/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        merchant agreement
+      </a>
+    )
+  }
+
+  render() {
+    return (
+      <form>
+        <fieldset>
+          <legend part={heading2}>Terms and Conditions (Canada)</legend>
+          <hr />
+          <div>
+            <p>
+              Please read and accept the {this.merchantAgreementLink} to submit your provisioning request.
+            </p>
+          </div>
+          <br />
+          <div class="row-gy-3">
+            <div class="col-12">
+              <form-control-checkbox
+                name="accepted"
+                label="I agree to the terms and conditions"
+                inputHandler={this.inputHandler}
+                errorText={this.errors.accepted}
+                disabled={this.acceptedTermsBefore}
+                helpText={this.formHelperText}
+                checked={this.acceptedTerms}
+              />
+            </div>
+          </div>
+        </fieldset>
+      </form>
+    );
+  }
+}
+
+


### PR DESCRIPTION
### Summary
- Introduces CAN-specific Terms & Conditions component: `justifi-business-terms-conditions-form-step-canada`.
- Updates `justifi-payment-provisioning-form-steps` to select the CAN component when `country === CAN`; USA remains unchanged.
- No API changes; schema and submission payload reused.

Links
-----
*  Implements [justifi-tech/engineering-artifacts#838](https://github.com/justifi-tech/engineering-artifacts/issues/838)

Developer considerations
--------------
- On any task
  - [x] Previous unit and e2e tests are passing
  - [x] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests (N/A - existing tests cover input behavior)
  - [ ] Add e2e tests (N/A - masking is a UI enhancement, not a functional change)
  - [ ] Add documentation (N/A - internal implementation detail)
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart (N/A)
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again (N/A)