### PR TITLE
fix: Change Skeleton to rely on isLoading instead of isReady

### DIFF
--- a/packages/webcomponents/src/components/modular-checkout/sub-components/apple-pay-skeleton.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/apple-pay-skeleton.tsx
@@ -2,15 +2,15 @@ import { FunctionalComponent, h } from "@stencil/core";
 import { Skeleton } from "../../../ui-components";
 
 interface ApplePaySkeletonProps {
-  isReady: boolean;
+  isLoading: boolean;
 }
 
 const ApplePaySkeleton: FunctionalComponent<ApplePaySkeletonProps> = (
   props
 ) => {
-  const { isReady } = props;
+  const { isLoading } = props;
 
-  if (isReady) {
+  if (!isLoading) {
     return null;
   }
 

--- a/packages/webcomponents/src/components/modular-checkout/sub-components/apple-pay.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/apple-pay.tsx
@@ -258,7 +258,7 @@ export class ApplePay {
           ></script>
         )}
         <div class='apple-pay-container'>
-          <ApplePaySkeleton isReady={isReady} />
+          <ApplePaySkeleton isLoading={this.isLoading} />
 
           {isReady && (
             <ApplePayButton


### PR DESCRIPTION
This pull request updates the Apple Pay skeleton loading logic in the modular checkout web component to improve clarity and consistency. The main change is renaming the prop controlling the skeleton display from `isReady` to `isLoading`, and updating its usage accordingly.

**Apple Pay Skeleton Loading Logic Update:**

* Renamed the `ApplePaySkeleton` prop from `isReady` to `isLoading` for clearer intent and updated the logic to render the skeleton only while loading (`apple-pay-skeleton.tsx`).
* Updated the parent component to pass the new `isLoading` prop to `ApplePaySkeleton` instead of the old `isReady` prop (`apple-pay.tsx`).

Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------


https://github.com/user-attachments/assets/87aa48eb-806c-4e84-a022-8d154eb42a66



<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

