### PR TITLE
Fix no selected payment method

### DIFF
--- a/.changeset/loud-flowers-mix.md
+++ b/.changeset/loud-flowers-mix.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix justifi-modular-checkout to prevent submiting a checkout without a selected payment method

--- a/.changeset/loud-flowers-mix.md
+++ b/.changeset/loud-flowers-mix.md
@@ -2,4 +2,4 @@
 "@justifi/webcomponents": patch
 ---
 
-Fix justifi-modular-checkout to prevent submiting a checkout without a selected payment method
+Fix justifi-modular-checkout to prevent submitting a checkout without a selected payment method

--- a/.changeset/thick-bananas-trade.md
+++ b/.changeset/thick-bananas-trade.md
@@ -1,5 +1,5 @@
 ---
-"@justifi/webcomponents": major
+'@justifi/webcomponents': patch
 ---
 
 Added justifi-modular-checkout and sub-components for a more flexible checkout experience

--- a/apps/docs/stories/components/ModularCheckout/Docs.mdx
+++ b/apps/docs/stories/components/ModularCheckout/Docs.mdx
@@ -134,6 +134,8 @@ You can also trigger validation manually by calling the `validate` method on the
 
 You can programmatically set the selected payment method by calling the `setSelectedPaymentMethod` method on the `justifi-modular-checkout` wrapper component. This method accepts either a saved payment method object or an object with a `type` field.
 
+> Important: The wrapper does not automatically select a default payment method. If you want a default to be selected (for example, the first saved method or a new card), explicitly call `setSelectedPaymentMethod` after initialization (e.g., on the first `checkout-changed` event).
+
 ```javascript
 import { PAYMENT_METHODS } from '@justifi/webcomponents';
 

--- a/apps/docs/stories/components/ModularCheckout/introduction.mdx
+++ b/apps/docs/stories/components/ModularCheckout/introduction.mdx
@@ -150,7 +150,7 @@ New payment methods or features can be added as individual components without mo
 
 - **`validate()`**: Validates all sub components and returns a boolean result
 - **`submitCheckout(billingInformation?)`**: Submits the checkout with optional billing information override
-- **`setSelectedPaymentMethod(paymentMethod)`**: Programmatically sets the selected payment method; accepts `{ type: 'card' | 'bankAccount' | ... }` or a saved method object
+- **`setSelectedPaymentMethod(paymentMethod)`**: Programmatically sets the selected payment method; accepts `{ type: 'card' | 'bankAccount' | ... }` or a saved method object. Note: no default is selected automatically; call this to set a default.
 
 ## Getting Started
 

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "5.7.7",
+  "version": "6.0.1-rc.0",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.0.1-rc.0",
+  "version": "6.0.0",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",

--- a/packages/webcomponents/src/api/services/apple-pay.service.ts
+++ b/packages/webcomponents/src/api/services/apple-pay.service.ts
@@ -187,7 +187,7 @@ export class ApplePayService implements IApplePayService {
           return reject({
             success: false,
             error: {
-              code: ApplePayServiceErrorCode.APPLE_PAY_UNAVAILABLE,
+              code: ApplePayServiceErrorCode.UNAVAILABLE,
               message:
                 'ApplePaySession API is not available in this environment',
             },

--- a/packages/webcomponents/src/components/modular-checkout/modular-checkout.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/modular-checkout.tsx
@@ -350,12 +350,21 @@ export class ModularCheckout {
   async submitCheckout(submitCheckoutArgs?: BillingFormFields): Promise<void> {
     const isValid = await this.validate();
 
+    if (!checkoutStore.selectedPaymentMethod) {
+      this.errorEvent.emit({
+        message: 'No payment method selected.',
+        errorCode: ComponentErrorCodes.VALIDATION_ERROR,
+        severity: ComponentErrorSeverity.ERROR,
+      });
+      return;
+    }
+
     const isNewCard =
       checkoutStore.selectedPaymentMethod?.type === PAYMENT_METHODS.NEW_CARD
     const isNewBankAccount =
       checkoutStore.selectedPaymentMethod?.type === PAYMENT_METHODS.NEW_BANK_ACCOUNT
 
-    const isPlaid = checkoutStore.selectedPaymentMethod.type === PAYMENT_METHODS.PLAID;
+    const isPlaid = checkoutStore.selectedPaymentMethod?.type === PAYMENT_METHODS.PLAID;
 
     const shouldTokenize = isNewCard || isNewBankAccount;
 


### PR DESCRIPTION


This pull request focuses on improving the `justifi-modular-checkout` component in `@justifi/webcomponents` by preventing checkout submission without a selected payment method and clarifying related documentation. It also includes a minor bug fix and updates the package version.

**Checkout validation and error handling:**

* Prevents the checkout from being submitted if no payment method is selected, and emits an error event if this occurs (`modular-checkout.tsx`).
* Updates the changelog to reflect this validation fix.

**Documentation updates:**

* Clarifies in the docs that no default payment method is selected automatically, and developers must explicitly set a default using `setSelectedPaymentMethod`. [[1]](diffhunk://#diff-59418e837565890ef98a44755d3f9f20159c2f558da65c94196026ddc68f992dR137-R138) [[2]](diffhunk://#diff-ed727a126ab477030f6be38cb995b8c53dd7597ca7298e2bbbb4d850b0110348L153-R153)

**Bug fix:**

* Corrects the Apple Pay error code to use `UNAVAILABLE` instead of `APPLE_PAY_UNAVAILABLE` for unavailable environments (`apple-pay.service.ts`).

**Release and changelog:**

* Updates the package version to `6.0.1-rc.0` and corrects the changeset type to `patch` for recent modular checkout changes. [[1]](diffhunk://#diff-d6c8832c37ac58d1d96ba6f9a6315bb2e73a1300e7ec6290ddf959111af46a4aL3-R3) [[2]](diffhunk://#diff-34d78d2f87e4586b9e48c38174703555ac2157f60cb0d649af8aec732bf50a74L2-R2)
Links
-----

[#977](https://github.com/justifi-tech/engineering-artifacts/issues/977)

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

This is avaiable for testing in staging: 
- Select a checkout using the dashboard link. https://app.justifi-staging.com/account/acc_2W3RlDGOG8htSHxMvI6uKp/payments/checkouts
- [ ] You should be able to complete a checkout on hosted-checkout without errors. 