### PR TITLE
Fix dispute notification to display due date instead of dispute ID

### DIFF
--- a/mockData/mockDisputeResponse.json
+++ b/mockData/mockDisputeResponse.json
@@ -8,7 +8,7 @@
     "account_id": "acc_1A2B3C4D5E6F7G8H9I0J",
     "amount": 12000,
     "currency": "USD",
-    "due_date": null,
+    "due_date": "2025-01-20",
     "reason": "general",
     "status": "needs_response",
     "metadata": null,
@@ -16,3 +16,4 @@
     "updated_at": "2024-12-19T16:09:20.747Z"
   }
 }
+

--- a/packages/webcomponents/src/components/dispute-management/dispute-notification.tsx
+++ b/packages/webcomponents/src/components/dispute-management/dispute-notification.tsx
@@ -82,10 +82,10 @@ export class DisputeNotification {
               </div>
               <div class="d-table-row gap-2">
                 <span part="detail-section-item-title" class="fw-bold d-table-cell pe-4">
-                  Dispute ID
+                  Due Date
                 </span>
                 <span part="detail-section-item-data" class="flex-1 d-table-cell text-wrap">
-                  {this.dispute?.id}
+                  {this.dispute?.due_date}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
Replaced the Dispute ID with the Due Date.

Links
-----
<img width="2258" height="670" alt="CleanShot 2025-10-16 at 11 29 51@2x" src="https://github.com/user-attachments/assets/73666d78-28a1-49c4-90bb-4d38b4f3a6ea" />

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [x] Previous unit and e2e tests are passing
  - [x] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [x] Add unit tests
  - [x] Add e2e tests
  - [x] Add documentation
  - [x] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

