### PR TITLE
docs: Remove Coming Soon banner from ApplePay page

### DIFF
--- a/apps/docs/stories/components/ModularCheckout/Sub-components/ApplePay/Docs.mdx
+++ b/apps/docs/stories/components/ModularCheckout/Sub-components/ApplePay/Docs.mdx
@@ -14,11 +14,6 @@ import { setUpMocks } from '../../../../utils/mockAllServices';
 
 # Apple Pay
 
-<Banner
-  title="Coming soon!"
-  message="This is a preview of what is to come in an upcoming version."
-/>
-
 ---
 
 Renders an Apple Pay button for eligible devices and orchestrates the Apple Pay flow. Designed to be used within `justifi-modular-checkout`.


### PR DESCRIPTION
This pull request removes the "Coming soon!" banner from the Apple Pay documentation. The page now directly describes the Apple Pay component without the preview notice.

Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [x] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

