### PR TITLE
feat: Add Apple Pay contact information capture

### DIFF
--- a/packages/webcomponents/src/api/ApplePay.ts
+++ b/packages/webcomponents/src/api/ApplePay.ts
@@ -28,6 +28,25 @@ export enum ApplePayMerchantCapability {
   SUPPORTS_DEBIT = 'supportsDebit',
 }
 
+export type ApplePayContactField = 'postalAddress' | 'name' | 'phone' | 'email';
+
+export interface IApplePayContact {
+  phoneNumber?: string;
+  emailAddress?: string;
+  givenName?: string;
+  familyName?: string;
+  phoneticGivenName?: string;
+  phoneticFamilyName?: string;
+  addressLines?: string[];
+  locality?: string;           // City
+  administrativeArea?: string; // State/Province
+  postalCode?: string;
+  country?: string;
+  countryCode?: string;
+  subLocality?: string;
+  subAdministrativeArea?: string;
+}
+
 export interface IApplePayLineItem {
   label: string;
   amount: string;
@@ -51,6 +70,9 @@ export interface IApplePayPaymentRequest {
   shippingMethods?: IApplePayShippingMethod[];
   applicationData?: string;
   supportedCountries?: string[];
+  requiredBillingContactFields?: ApplePayContactField[];
+  requiredShippingContactFields?: ApplePayContactField[];
+  shippingType?: 'shipping' | 'delivery' | 'storePickup' | 'servicePickup';
 }
 
 export interface IApplePaySession {
@@ -150,6 +172,8 @@ export interface IApplePayPaymentProcessRequest {
     description: string;
   };
   description?: string;
+  billingContact?: IApplePayContact;
+  shippingContact?: IApplePayContact;
 }
 
 export interface IApplePayPaymentResponse {
@@ -211,6 +235,9 @@ export class ApplePayPaymentRequest implements IApplePayPaymentRequest {
   public shippingMethods?: IApplePayShippingMethod[];
   public applicationData?: string;
   public supportedCountries?: string[];
+  public requiredBillingContactFields?: ApplePayContactField[];
+  public requiredShippingContactFields?: ApplePayContactField[];
+  public shippingType?: 'shipping' | 'delivery' | 'storePickup' | 'servicePickup';
 
   constructor(data: IApplePayPaymentRequest) {
     this.countryCode = data.countryCode;
@@ -222,6 +249,9 @@ export class ApplePayPaymentRequest implements IApplePayPaymentRequest {
     this.shippingMethods = data.shippingMethods;
     this.applicationData = data.applicationData;
     this.supportedCountries = data.supportedCountries;
+    this.requiredBillingContactFields = data.requiredBillingContactFields;
+    this.requiredShippingContactFields = data.requiredShippingContactFields;
+    this.shippingType = data.shippingType;
   }
 
   public get isValid(): boolean {

--- a/packages/webcomponents/src/api/services/apple-pay.service.ts
+++ b/packages/webcomponents/src/api/services/apple-pay.service.ts
@@ -14,6 +14,7 @@ import {
   IApplePayPaymentResponse,
   IApplePayCancelEvent,
   IApplePayToken,
+  IApplePayContact,
 } from '../ApplePay';
 
 // Centralized error codes for Apple Pay service
@@ -119,7 +120,7 @@ export class ApplePayService implements IApplePayService {
   }
 
   /**
-   * Start Apple Pay session
+   * Start Apple Pay session with optional contact field collection
    */
   public async startPaymentSession(
     paymentRequest: IApplePayPaymentRequest,
@@ -129,6 +130,8 @@ export class ApplePayService implements IApplePayService {
     success: boolean;
     token?: IApplePayToken;
     paymentMethodId?: string;
+    billingContact?: IApplePayContact;
+    shippingContact?: IApplePayContact;
     error?: IApplePayError;
   }> {
     // Begin session
@@ -228,6 +231,8 @@ export class ApplePayService implements IApplePayService {
       success: boolean;
       token?: IApplePayToken;
       paymentMethodId?: string;
+      billingContact?: IApplePayContact;
+      shippingContact?: IApplePayContact;
       error?: IApplePayError;
     }) => void,
     reject: (reason: { success: boolean; error: IApplePayError }) => void,
@@ -306,6 +311,8 @@ export class ApplePayService implements IApplePayService {
             ),
             description: this.currentPaymentRequest!.total.label,
           },
+          ...(payment.billingContact && { billingContact: payment.billingContact }),
+          ...(payment.shippingContact && { shippingContact: payment.shippingContact }),
         };
 
         const paymentResult = await this.processPayment(
@@ -322,6 +329,8 @@ export class ApplePayService implements IApplePayService {
             success: true,
             token: payment.token,
             paymentMethodId: paymentResult.data.id,
+            billingContact: payment.billingContact,
+            shippingContact: payment.shippingContact,
           });
         } else {
           console.error('PSP reported payment failure:', paymentResult.data);

--- a/packages/webcomponents/src/components/modular-checkout/modular-checkout.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/modular-checkout.tsx
@@ -227,11 +227,23 @@ export class ModularCheckout {
   }
 
   private handleApplePayCompleted = (event: CustomEvent) => {
-    const { success, token, paymentMethodId, error } = event.detail;
+    const { success, token, paymentMethodId, billingContact, shippingContact, error } = event.detail;
 
     if (success && token) {
       checkoutStore.paymentToken = paymentMethodId;
       checkoutStore.selectedPaymentMethod = { type: PAYMENT_METHODS.APPLE_PAY };
+
+      // Log contact information if captured (for debugging/verification)
+      if (billingContact || shippingContact) {
+        console.log('Apple Pay contact information captured:', {
+          billingContact,
+          shippingContact,
+        });
+      }
+
+      // Note: Contact information is available in event.detail for parent components to use
+      // Future enhancement: Could store in checkoutStore if needed
+
       this.submitCheckout();
     } else {
       console.error("Apple Pay completed but failed:", error);

--- a/packages/webcomponents/src/components/modular-checkout/sub-components/apple-pay.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/apple-pay.tsx
@@ -16,6 +16,8 @@ import {
   ApplePayHelpers,
   IApplePayToken,
   ApplePayMerchantCapability,
+  ApplePayContactField,
+  IApplePayContact,
 } from "../../../api/ApplePay";
 import { StyledHost } from "../../../ui-components";
 import ApplePaySkeleton from "./apple-pay-skeleton";
@@ -39,6 +41,9 @@ export class ApplePay {
   @Prop() showSkeleton: boolean = true;
   @Prop() width: string = "100%";
   @Prop() height: string = "48px";
+  @Prop() requiredBillingContactFields?: ApplePayContactField[];
+  @Prop() requiredShippingContactFields?: ApplePayContactField[];
+  @Prop() shippingType?: 'shipping' | 'delivery' | 'storePickup' | 'servicePickup';
 
   @State() isLoading: boolean = true;
   @State() isProcessing: boolean = false;
@@ -52,6 +57,8 @@ export class ApplePay {
     success: boolean;
     token?: IApplePayToken;
     paymentMethodId?: string;
+    billingContact?: IApplePayContact;
+    shippingContact?: IApplePayContact;
     error?: any;
   }>;
   @Event() applePayCancelled: EventEmitter<void>;
@@ -162,6 +169,13 @@ export class ApplePay {
           checkoutStore.paymentDescription,
           checkoutStore.paymentAmount
         ),
+        ...(this.requiredBillingContactFields && {
+          requiredBillingContactFields: this.requiredBillingContactFields
+        }),
+        ...(this.requiredShippingContactFields && {
+          requiredShippingContactFields: this.requiredShippingContactFields
+        }),
+        ...(this.shippingType && { shippingType: this.shippingType }),
       };
 
       const result = await this.applePayService.startPaymentSession(
@@ -175,6 +189,8 @@ export class ApplePay {
           success: true,
           token: result.token,
           paymentMethodId: result.paymentMethodId,
+          billingContact: result.billingContact,
+          shippingContact: result.shippingContact,
         });
       } else {
         this.applePayCompleted.emit({


### PR DESCRIPTION
## Summary

This PR implements the ability to capture billing and shipping contact information from Apple Pay payments, addressing issue #1192.

Currently, users must manually enter billing addresses, shipping addresses, email, and phone numbers even though this information is already available in their Apple Pay wallet. This PR reduces checkout friction by allowing merchants to optionally request this information directly from Apple Pay.

## Changes

### Type Definitions (`ApplePay.ts`)
- Added `ApplePayContactField` type for contact field options
- Added `IApplePayContact` interface for contact data structure
- Extended `IApplePayPaymentRequest` with:
  - `requiredBillingContactFields?: ApplePayContactField[]`
  - `requiredShippingContactFields?: ApplePayContactField[]`
  - `shippingType?: 'shipping' | 'delivery' | 'storePickup' | 'servicePickup'`
- Extended `IApplePayPaymentProcessRequest` to include contact fields

### Service Layer (`apple-pay.service.ts`)
- Updated `startPaymentSession` return type to include contact information
- Modified `onpaymentauthorized` handler to extract `billingContact` and `shippingContact` from payment event
- Updated payment payload to send contact info to backend

### Component Props (`apple-pay.tsx`)
- Added three new optional props:
  - `requiredBillingContactFields` - Request billing contact information
  - `requiredShippingContactFields` - Request shipping contact information
  - `shippingType` - Specify the type of shipping
- Updated `applePayCompleted` event to include contact data

### Integration (`modular-checkout.tsx`)
- Updated event handler to receive and log contact information
- Added comments for future enhancement opportunities

## Usage Example

```html
<justifi-apple-pay
  required-billing-contact-fields='["postalAddress", "name"]'
  required-shipping-contact-fields='["postalAddress", "name", "email", "phone"]'
  shipping-type="shipping"
></justifi-apple-pay>
```

## Available Contact Fields
- `"postalAddress"` - Full address details
- `"name"` - Given name and family name
- `"phone"` - Phone number
- `"email"` - Email address

## Data Flow
1. Component props configure which fields to request
2. Apple Pay sheet displays requested fields to user
3. User authorizes payment
4. Service extracts contact info from payment event
5. Contact info sent to backend in payment processing request
6. Contact info available in `applePayCompleted` event for parent components

## Breaking Changes
✅ **None** - This is a fully backward-compatible enhancement. All new props are optional, and existing implementations will continue to work without modification.

## Testing
- ✅ TypeScript compilation successful
- ✅ Build completes without errors
- ✅ Type definitions generated correctly
- ✅ All changes are backward compatible

## Known Issues
⚠️ There's a known Apple Pay bug where `phone` and `email` may not be reliably returned when requested via `requiredBillingContactFields`. The workaround is to request email and phone via `requiredShippingContactFields` instead.

Reference: [Apple Developer Forums](https://forums.developer.apple.com/forums/thread/61802)

## References
- [Apple Pay JS API - ApplePayPaymentRequest](https://developer.apple.com/documentation/apple_pay_on_the_web/applepaypaymentrequest)
- [W3C Payment Request API](https://www.w3.org/TR/payment-request/#paymentoptions-dictionary)
- [Apple Pay Demo](https://applepaydemo.apple.com/)

Closes #1192

🤖 Generated with [Claude Code](https://claude.com/claude-code)