### PR TITLE
Fix autoscroll on the HiddenInput. Checkout - Card and Bank Account forms. 

### DIFF
--- a/.changeset/gold-snakes-knock.md
+++ b/.changeset/gold-snakes-knock.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix autoscroll on the Checkout component (UFC)

--- a/packages/webcomponents/src/ui-components/form/hidden-input.tsx
+++ b/packages/webcomponents/src/ui-components/form/hidden-input.tsx
@@ -11,6 +11,19 @@ export class HiddenInput {
   @State() isFocused: boolean = false;
   @State() errorText: string = '';
 
+  private focusWithoutPageScroll(input: HTMLInputElement) {
+    if (!input) return;
+    try {
+      // Use preventScroll where supported
+      (input as any).focus({ preventScroll: true });
+    } catch (_e) {
+      // Fallback for older browsers
+      const { scrollX, scrollY } = window;
+      input.focus();
+      window.scrollTo(scrollX, scrollY);
+    }
+  }
+
   async componentDidLoad() {
     const fontStyles = await this.getBaseFontStyles();
     iframeInputStylesSet('fontStyles', fontStyles);
@@ -43,7 +56,7 @@ export class HiddenInput {
 
   private async getFocusedStyles() {
     return new Promise((resolve, _reject) => {
-      this.hiddenInput.focus();
+      this.focusWithoutPageScroll(this.hiddenInput);
       setTimeout(() => {
         this.hiddenInput.blur();
         let computedStyles = getComputedStyle(this.hiddenInput);
@@ -57,7 +70,7 @@ export class HiddenInput {
 
   private async getFocusedAndInvalidStyles() {
     return new Promise((resolve, _reject) => {
-      this.hiddenInput.focus();
+      this.focusWithoutPageScroll(this.hiddenInput);
       this.errorText = 'Error';
 
       setTimeout(() => {


### PR DESCRIPTION
The hidden input grabs focus to get the styles and apply to the iframe fields. 

This was causing the page to scroll to the hidden-input position.

Added `.focus({ preventScroll: true })` so it still get focused but doesn't scroll the page. 


Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/1330

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------
Run `pnpm dev`

Go to the http://localhost:6006/?path=/docs/payment-facilitation-unified-fintech-checkout%E2%84%A2--docs

- [ ] The page should load without scrolling to the checkout component. 

