### PR TITLE
Update documentation to dynamically reference webcomponents version

### DIFF
--- a/packages/webcomponents/docs/entities/businessdetails/index.mdx
+++ b/packages/webcomponents/docs/entities/businessdetails/index.mdx
@@ -7,6 +7,7 @@ sidebar_position: 10
 ---
 
 import { PropsTable, UsageSnippet, PartsTable, BusinessDetailsExample } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -25,8 +26,8 @@ Component to render detailed information about a business. You will need to firs
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-business-details</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       ::part(font-family) {
         font-family: georgia;   

--- a/packages/webcomponents/docs/entities/businessform/index.mdx
+++ b/packages/webcomponents/docs/entities/businessform/index.mdx
@@ -7,6 +7,7 @@ sidebar_position: 11
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -25,8 +26,8 @@ Component to render a business onboarding form. You will need to first create a 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-business-form</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       ::part(font-family) {
         font-family: georgia;   

--- a/packages/webcomponents/docs/frameworks/angular/index.mdx
+++ b/packages/webcomponents/docs/frameworks/angular/index.mdx
@@ -5,20 +5,20 @@ description: Registering and using JustiFi web components inside Angular project
 sidebar_position: 2
 ---
 
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
+
 Angular can render the JustiFi custom elements once you load the library and allow custom schemas.
 
 ## Usage
 
 ### Load the bundle
 
-```html
-<head>
+<pre><code className="language-html">{`<head>
   <script
     type="module"
-    src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+    src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"
   ></script>
-</head>
-```
+</head>`}</code></pre>
 
 Or install locally:
 

--- a/packages/webcomponents/docs/frameworks/react/index.mdx
+++ b/packages/webcomponents/docs/frameworks/react/index.mdx
@@ -5,21 +5,21 @@ description: How to consume JustiFi web components inside React applications.
 sidebar_position: 1
 ---
 
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
+
 React treats JustiFi web components like any other custom element. Load the bundle, optionally declare types, and use refs for method calls or event wiring.
 
 ## Usage
 
 ### Load the components
 
-```html
-<head>
+<pre><code className="language-html">{`<head>
   <script
     async
     type="module"
-    src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+    src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"
   ></script>
-</head>
-```
+</head>`}</code></pre>
 
 Or install the package:
 

--- a/packages/webcomponents/docs/frameworks/vue/index.mdx
+++ b/packages/webcomponents/docs/frameworks/vue/index.mdx
@@ -5,20 +5,20 @@ description: Consume the JustiFi web components inside modern Vue applications.
 sidebar_position: 3
 ---
 
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
+
 Vue treats the JustiFi custom elements like native HTML tags. Load the script, import what you need, and wire up refs/events.
 
 ## Integration steps
 
 ### Load the components
 
-```html
-<head>
+<pre><code className="language-html">{`<head>
   <script
     type="module"
-    src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+    src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"
   ></script>
-</head>
-```
+</head>`}</code></pre>
 
 Or install locally and import the desired module:
 

--- a/packages/webcomponents/docs/helpers/BusinessDetailsExample.tsx
+++ b/packages/webcomponents/docs/helpers/BusinessDetailsExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentExample } from './ComponentExample';
 import mockBusinessDetails from './mockData/mockBusinessDetails.json';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 export const BusinessDetailsExample: React.FC = () => {
   // Match API endpoint pattern: any origin + /v1/entities/business/{businessId}
@@ -10,7 +11,7 @@ export const BusinessDetailsExample: React.FC = () => {
     <ComponentExample
       componentName="Business Details"
       componentTag="justifi-business-details"
-      scriptUrl="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+      scriptUrl={`https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js`}
       mockData={mockBusinessDetails}
       mockEndpoints={[
         {

--- a/packages/webcomponents/docs/helpers/CheckoutsListExample.tsx
+++ b/packages/webcomponents/docs/helpers/CheckoutsListExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentExample } from './ComponentExample';
 import mockGetCheckoutsListSuccess from './mockData/mockGetCheckoutsListSuccess.json';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 export const CheckoutsListExample: React.FC = () => {
   // Match API endpoint pattern: /v1/checkouts (with Account header)
@@ -10,7 +11,7 @@ export const CheckoutsListExample: React.FC = () => {
     <ComponentExample
       componentName="Checkouts List"
       componentTag="justifi-checkouts-list"
-      scriptUrl="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+      scriptUrl={`https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js`}
       mockData={mockGetCheckoutsListSuccess}
       mockEndpoints={[
         {

--- a/packages/webcomponents/docs/helpers/PaymentDetailsExample.tsx
+++ b/packages/webcomponents/docs/helpers/PaymentDetailsExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentExample } from './ComponentExample';
 import mockPaymentDetailSuccess from './mockData/mockPaymentDetailSuccess.json';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 export const PaymentDetailsExample: React.FC = () => {
   // Match API endpoint pattern: /v1/payments/{paymentId}
@@ -10,7 +11,7 @@ export const PaymentDetailsExample: React.FC = () => {
     <ComponentExample
       componentName="Payment Details"
       componentTag="justifi-payment-details"
-      scriptUrl="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+      scriptUrl={`https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js`}
       mockData={mockPaymentDetailSuccess}
       mockEndpoints={[
         {

--- a/packages/webcomponents/docs/helpers/PaymentsListExample.tsx
+++ b/packages/webcomponents/docs/helpers/PaymentsListExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentExample } from './ComponentExample';
 import mockPaymentsSuccess from './mockData/mockPaymentsSuccess.json';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 export const PaymentsListExample: React.FC = () => {
   // Match API endpoint pattern: /v1/account/{accountId}/payments
@@ -10,7 +11,7 @@ export const PaymentsListExample: React.FC = () => {
     <ComponentExample
       componentName="Payments List"
       componentTag="justifi-payments-list"
-      scriptUrl="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+      scriptUrl={`https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js`}
       mockData={mockPaymentsSuccess}
       mockEndpoints={[
         {

--- a/packages/webcomponents/docs/helpers/PayoutDetailsExample.tsx
+++ b/packages/webcomponents/docs/helpers/PayoutDetailsExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentExample } from './ComponentExample';
 import mockPayoutDetailsSuccess from './mockData/mockPayoutDetailsSuccess.json';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 export const PayoutDetailsExample: React.FC = () => {
   // Match API endpoint pattern: /v1/payouts/{payoutId}
@@ -10,7 +11,7 @@ export const PayoutDetailsExample: React.FC = () => {
     <ComponentExample
       componentName="Payout Details"
       componentTag="justifi-payout-details"
-      scriptUrl="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+      scriptUrl={`https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js`}
       mockData={mockPayoutDetailsSuccess}
       mockEndpoints={[
         {

--- a/packages/webcomponents/docs/helpers/PayoutsListExample.tsx
+++ b/packages/webcomponents/docs/helpers/PayoutsListExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentExample } from './ComponentExample';
 import mockPayoutsSuccess from './mockData/mockPayoutsSuccess.json';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 export const PayoutsListExample: React.FC = () => {
   // Match API endpoint pattern: /v1/account/{accountId}/payouts
@@ -10,7 +11,7 @@ export const PayoutsListExample: React.FC = () => {
     <ComponentExample
       componentName="Payouts List"
       componentTag="justifi-payouts-list"
-      scriptUrl="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+      scriptUrl={`https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js`}
       mockData={mockPayoutsSuccess}
       mockEndpoints={[
         {

--- a/packages/webcomponents/docs/helpers/TerminalsListExample.tsx
+++ b/packages/webcomponents/docs/helpers/TerminalsListExample.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentExample } from './ComponentExample';
 import mockTerminalsListSuccess from './mockData/mockTerminalsListSuccess.json';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 export const TerminalsListExample: React.FC = () => {
   // Match API endpoint pattern: /v1/terminals (with Account header)
@@ -10,7 +11,7 @@ export const TerminalsListExample: React.FC = () => {
     <ComponentExample
       componentName="Terminals List"
       componentTag="justifi-terminals-list"
-      scriptUrl="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
+      scriptUrl={`https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js`}
       mockData={mockTerminalsListSuccess}
       mockEndpoints={[
         {

--- a/packages/webcomponents/docs/helpers/index.ts
+++ b/packages/webcomponents/docs/helpers/index.ts
@@ -9,3 +9,4 @@ export { PayoutsListExample } from './PayoutsListExample';
 export { PayoutDetailsExample } from './PayoutDetailsExample';
 export { CheckoutsListExample } from './CheckoutsListExample';
 export { TerminalsListExample } from './TerminalsListExample';
+export { getWebcomponentsVersion } from './version';

--- a/packages/webcomponents/docs/helpers/version.ts
+++ b/packages/webcomponents/docs/helpers/version.ts
@@ -1,0 +1,32 @@
+let cachedVersion: string | null = null;
+
+export const getWebcomponentsVersion = (): string => {
+  if (cachedVersion) {
+    return cachedVersion;
+  }
+  try {
+    // Try to import from the package (works in both Storybook and consumer apps)
+    const packageJson = require('@justifi/webcomponents/package.json');
+    const version = packageJson.version;
+    cachedVersion = version;
+    return version;
+  } catch (error) {
+    // Fallback: try to read from local package.json (for build-time)
+    try {
+      const fs = require('fs');
+      const path = require('path');
+      const packageJsonPath = path.resolve(__dirname, '../../package.json');
+      const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+      const version = packageJson.version;
+      cachedVersion = version;
+      return version;
+    } catch (fallbackError) {
+      // Last resort: return 'latest' if we can't determine the version
+      console.warn(
+        'Could not determine @justifi/webcomponents version, using "latest"'
+      );
+      return 'latest';
+    }
+  }
+};
+

--- a/packages/webcomponents/docs/introduction/index.mdx
+++ b/packages/webcomponents/docs/introduction/index.mdx
@@ -5,6 +5,8 @@ description: Introduction to the JustiFi Web Component Library.
 sidebar_position: 1
 ---
 
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
+
 # Introduction to JustiFi Web Component Library
 
 Welcome to the JustiFi Web Component Library. These components can be used as HTML Web Components or as React components.
@@ -15,12 +17,13 @@ Welcome to the JustiFi Web Component Library. These components can be used as HT
 
 The simplest way to use the Web Components is to include the following script within your HTML. This loads all the components into the browser's custom component registry.
 
-```html
-<script
+<pre>
+  <code className="language-html">{`<script
   type="module"
-  src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@latest/dist/webcomponents/webcomponents.esm.js"
-></script>
-```
+  src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"
+></script>`}</code>
+
+</pre>
 
 Then, you can use the custom elements as normal `HTML` tags.
 

--- a/packages/webcomponents/docs/merchant-tools/payment-details/index.mdx
+++ b/packages/webcomponents/docs/merchant-tools/payment-details/index.mdx
@@ -6,6 +6,7 @@ sidebar_position: 30
 ---
 
 import { PropsTable, UsageSnippet, PartsTable, PaymentDetailsExample } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -24,8 +25,8 @@ Component to display detailed information about a specific payment.
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-payment-details</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       ::part(font-family) {
         font-family: georgia;   

--- a/packages/webcomponents/docs/modular-checkout/sub-components/apple-pay.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/apple-pay.mdx
@@ -6,6 +6,7 @@ sidebar_position: 22
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -23,8 +24,8 @@ Renders an Apple Pay button for eligible devices and orchestrates the Apple Pay 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-apple-pay</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       /** These are the available parts for styling the component. */
       ::part(button) {

--- a/packages/webcomponents/docs/modular-checkout/sub-components/bank-account-form.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/bank-account-form.mdx
@@ -6,6 +6,7 @@ sidebar_position: 28
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -32,8 +33,8 @@ This component exposes **no public methods or properties** and is not intended f
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-bank-account-form</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       /** These are the available parts for styling the component. */
       ::part(skeleton) {

--- a/packages/webcomponents/docs/modular-checkout/sub-components/card-form.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/card-form.mdx
@@ -6,6 +6,7 @@ sidebar_position: 2
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -32,8 +33,8 @@ This component exposes **no public methods or properties** and is not intended f
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-card-form</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       /** These are the available parts for styling the component. */
       ::part(skeleton) {

--- a/packages/webcomponents/docs/modular-checkout/sub-components/plaid-payment-method.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/plaid-payment-method.mdx
@@ -6,6 +6,7 @@ sidebar_position: 23
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -29,8 +30,8 @@ It exposes no public properties for configuration, but does emit Plaid-specific 
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-plaid-payment-method</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       /** These are the available parts for styling the component. */
       ::part(text) {

--- a/packages/webcomponents/docs/modular-checkout/sub-components/saved-payment-methods.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/saved-payment-methods.mdx
@@ -6,6 +6,7 @@ sidebar_position: 26
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -31,8 +32,8 @@ This component exposes **no public methods or properties** and is not intended f
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-saved-payment-methods</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       /** These are the available parts for styling the component. */
       ::part(text) {

--- a/packages/webcomponents/docs/modular-checkout/sub-components/season-interruption-insurance.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/season-interruption-insurance.mdx
@@ -6,6 +6,7 @@ sidebar_position: 25
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -23,8 +24,8 @@ Component to render a formated list of season interruption insurance for the req
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-season-interruption-insurance</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       ::part(font-family) { 
         font-family: georgia;   

--- a/packages/webcomponents/docs/modular-checkout/sub-components/sezzle-payment-method.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/sezzle-payment-method.mdx
@@ -6,6 +6,7 @@ sidebar_position: 24
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -29,8 +30,8 @@ This component exposes **no public methods or properties** and is not intended f
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-sezzle-payment-method</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
       /** These are the available parts for styling the component. */
       ::part(text) {

--- a/packages/webcomponents/docs/modular-checkout/sub-components/summary.mdx
+++ b/packages/webcomponents/docs/modular-checkout/sub-components/summary.mdx
@@ -6,6 +6,7 @@ sidebar_position: 27
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -29,14 +30,23 @@ This component exposes **no public methods or properties** and is not intended f
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-checkout-summary</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
-  <style>
-      /** These are the available parts for styling the component. */
-      ::part(text) {
-        // text styles
-      }
-    </style>
+<script
+  type="module"
+  src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"
+></script>
+
+<script
+  nomodule
+  src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"
+></script>
+
+<style>
+  /** These are the available parts for styling the component. */ ::part(text){' '}
+  {
+    // text styles
+  }
+</style>
+
 </head>
 
 <body>

--- a/packages/webcomponents/docs/payment-facilitation/refund-payment/index.mdx
+++ b/packages/webcomponents/docs/payment-facilitation/refund-payment/index.mdx
@@ -6,6 +6,7 @@ sidebar_position: 33
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -23,8 +24,8 @@ Component to render a form for partially or fully refunding a payment based on a
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-refund-payment</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
     ::part(font-family) {
       font-family: georgia;

--- a/packages/webcomponents/docs/payment-facilitation/tokenize-payment-method/index.mdx
+++ b/packages/webcomponents/docs/payment-facilitation/tokenize-payment-method/index.mdx
@@ -6,6 +6,7 @@ sidebar_position: 1
 ---
 
 import { PropsTable, UsageSnippet, PartsTable } from '../../helpers';
+import { getWebcomponentsVersion } from '@justifi/webcomponents/docs/helpers';
 
 ## Overview
 
@@ -24,8 +25,8 @@ Component to render an entire form including a switch to use a credit card or ba
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0" />
   <title>justifi-tokenize-payment-method</title>
 
-  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.esm.js"></script>
-  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@6.5.0/dist/webcomponents/webcomponents.js"></script>
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.esm.js"></script>
+  <script nomodule src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"></script>
   <style>
     ::part(font-family) {
       font-family: georgia;


### PR DESCRIPTION
This PR introduces helper functions to get the package version dynamically on the CDN script tags on the examples. 

Links
-----

https://github.com/justifi-tech/engineering-artifacts/issues/1405

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

