### PR TITLE
fix: default value of isAddingNewBankAccount state

### DIFF
--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -20,7 +20,7 @@ export class BusinessBankAccountFormStep {
   @State() existingDocuments: any = [];
   @State() documentData: EntityDocumentStorage = new EntityDocumentStorage();
   @State() isLoading: boolean = false;
-  @State() isAddingNewBankAccount: boolean = false;
+  @State() isAddingNewBankAccount: boolean = true;
   @State() getBusiness: Function;
   @State() postBankAccount: Function;
   @State() postDocumentRecord: Function;
@@ -150,6 +150,7 @@ export class BusinessBankAccountFormStep {
           const bankAccounts = response.data.bank_accounts;
           const latestBankAccount = bankAccounts[bankAccounts.length - 1];
           this.bankAccount = new BankAccount(latestBankAccount);
+          this.isAddingNewBankAccount = false;
         } else {
           this.bankAccount = new BankAccount({});
           this.bankAccount.business_id = this.businessId;


### PR DESCRIPTION
This pull request updates the behavior for tracking the addition of new bank accounts in the `BusinessBankAccountFormStep` component. The main change ensures that the `isAddingNewBankAccount` state is initialized to `true` and is set to `false` once a new bank account is successfully added.

Bank account addition flow:

* Changed the initial value of `isAddingNewBankAccount` to `true` to indicate the start of the bank account addition process.
* Set `isAddingNewBankAccount` to `false` after successfully adding a new bank account, ensuring the UI reflects the completed state.

Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

