### PR TITLE
bump webcomponents to 6.7.0

### DIFF
--- a/.changeset/dirty-needles-heal.md
+++ b/.changeset/dirty-needles-heal.md
@@ -1,5 +1,0 @@
----
-"@repo/docs": patch
----
-
-Updated the Storybook examples for the Dispute Component. Updated the existing example to have a far-future due-date so that it always shows the expected view. Added another example Past Dure Example to show what the dispute component looks like when it is past due.

--- a/.changeset/solid-showers-sleep.md
+++ b/.changeset/solid-showers-sleep.md
@@ -1,9 +1,0 @@
----
-'@justifi/webcomponents': minor
----
-
-feat(UFC): Google Pay support
-
-- Add `justifi-google-pay` sub-component and integrate it with the `justifi-modular-checkout` flow.
-- Enable Google Pay as a payment option in `justifi-checkout` (UFC), including eligibility checks, loading states, and error handling.
-- Add docs and examples for configuration and usage.

--- a/.changeset/tidy-bottles-decide.md
+++ b/.changeset/tidy-bottles-decide.md
@@ -1,5 +1,0 @@
----
-"@justifi/webcomponents": minor
----
-
-Add Checkout ID, Created Before, and Created After filters to checkouts list filter component

--- a/apps/component-examples/CHANGELOG.md
+++ b/apps/component-examples/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @repo/component-examples
 
+## 1.1.9
+
+### Patch Changes
+
+- Updated dependencies [bf665ad]
+- Updated dependencies [d11330c]
+  - @justifi/webcomponents@6.7.0
+
 ## 1.1.8
 
 ### Patch Changes

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/component-examples",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "",
   "main": "index.js",
   "private": true,

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @repo/docs
 
+## 0.4.9
+
+### Patch Changes
+
+- 40ae56d: Updated the Storybook examples for the Dispute Component. Updated the existing example to have a far-future due-date so that it always shows the expected view. Added another example Past Dure Example to show what the dispute component looks like when it is past due.
+- Updated dependencies [bf665ad]
+- Updated dependencies [d11330c]
+  - @justifi/webcomponents@6.7.0
+
 ## 0.4.8
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/docs",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webcomponents/CHANGELOG.md
+++ b/packages/webcomponents/CHANGELOG.md
@@ -1,5 +1,17 @@
 ### Changelog
 
+## 6.7.0
+
+### Minor Changes
+
+- bf665ad: feat(UFC): Google Pay support
+
+  - Add `justifi-google-pay` sub-component and integrate it with the `justifi-modular-checkout` flow.
+  - Enable Google Pay as a payment option in `justifi-checkout` (UFC), including eligibility checks, loading states, and error handling.
+  - Add docs and examples for configuration and usage.
+
+- d11330c: Add Checkout ID, Created Before, and Created After filters to checkouts list filter component
+
 ## 6.6.0
 
 ### Minor Changes

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.6.0",
+  "version": "6.7.0",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
# 6.7.0

## Minor Changes

- bf665ad: feat(UFC): Google Pay support

  - Add `justifi-google-pay` sub-component and integrate it with the `justifi-modular-checkout` flow.
  - Enable Google Pay as a payment option in `justifi-checkout` (UFC), including eligibility checks, loading states, and error handling.
  - Add docs and examples for configuration and usage.

- d11330c: Add Checkout ID, Created Before, and Created After filters to checkouts list filter component or pull_request

