### PR TITLE
Bump web components version

### DIFF
--- a/.changeset/ninety-plants-float.md
+++ b/.changeset/ninety-plants-float.md
@@ -1,5 +1,0 @@
----
-"@justifi/webcomponents": patch
----
-
-Include merchant ID in google pay requests

--- a/apps/component-examples/CHANGELOG.md
+++ b/apps/component-examples/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @repo/component-examples
 
+## 1.1.10
+
+### Patch Changes
+
+- Updated dependencies [0c34ce6]
+  - @justifi/webcomponents@6.7.1
+
 ## 1.1.9
 
 ### Patch Changes

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/component-examples",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "",
   "main": "index.js",
   "private": true,

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @repo/docs
 
+## 0.4.10
+
+### Patch Changes
+
+- Updated dependencies [0c34ce6]
+  - @justifi/webcomponents@6.7.1
+
 ## 0.4.9
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/docs",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webcomponents/CHANGELOG.md
+++ b/packages/webcomponents/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Changelog
 
+## 6.7.1
+
+### Patch Changes
+
+- 0c34ce6: Include merchant ID in google pay requests
+
 ## 6.7.0
 
 ### Minor Changes

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.7.0",
+  "version": "6.7.1",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
## 6.7.1

### Patch Changes

- 0c34ce6: Include merchant ID in google pay requests
