### PR TITLE
chore: bump webcomponents version to 6.7.2 and update changelog

### DIFF
--- a/.changeset/cyan-melons-go.md
+++ b/.changeset/cyan-melons-go.md
@@ -1,5 +1,0 @@
----
-"@justifi/webcomponents": patch
----
-
-Fix bug - Format is invalid for parameter: year, must be two digits

--- a/.changeset/old-parks-pay.md
+++ b/.changeset/old-parks-pay.md
@@ -1,7 +1,0 @@
----
-"@justifi/webcomponents": patch
----
-
-Added setup to include a /docs folder in the published package
-Added MDX linter setup and CI workflow
-Added new MDX documentation to replace Storybook in a near future.

--- a/.changeset/tame-doodles-dress.md
+++ b/.changeset/tame-doodles-dress.md
@@ -1,5 +1,0 @@
----
-"@justifi/webcomponents": patch
----
-
-Adds a tentative to void the payment in case the refund is requested within 25 minutes of its creation.

--- a/apps/component-examples/CHANGELOG.md
+++ b/apps/component-examples/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @repo/component-examples
 
+## 1.1.11
+
+### Patch Changes
+
+- Updated dependencies [b67550c]
+- Updated dependencies [be3f80f]
+- Updated dependencies [343d520]
+  - @justifi/webcomponents@6.7.2
+
 ## 1.1.10
 
 ### Patch Changes

--- a/apps/component-examples/package.json
+++ b/apps/component-examples/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/component-examples",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "",
   "main": "index.js",
   "private": true,

--- a/apps/docs/CHANGELOG.md
+++ b/apps/docs/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @repo/docs
 
+## 0.4.11
+
+### Patch Changes
+
+- Updated dependencies [b67550c]
+- Updated dependencies [be3f80f]
+- Updated dependencies [343d520]
+  - @justifi/webcomponents@6.7.2
+
 ## 0.4.10
 
 ### Patch Changes

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/docs",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "private": true,
   "scripts": {

--- a/packages/webcomponents/CHANGELOG.md
+++ b/packages/webcomponents/CHANGELOG.md
@@ -1,5 +1,15 @@
 ### Changelog
 
+## 6.7.2
+
+### Patch Changes
+
+- b67550c: Fix bug - Format is invalid for parameter: year, must be two digits
+- be3f80f: Added setup to include a /docs folder in the published package
+  Added MDX linter setup and CI workflow
+  Added new MDX documentation to replace Storybook in a near future.
+- 343d520: Adds a tentative to void the payment in case the refund is requested within 25 minutes of its creation.
+
 ## 6.7.1
 
 ### Patch Changes

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.7.1",
+  "version": "6.7.2",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
- Fix bug related to year parameter formatting.
- Add setup for a /docs folder in the published package.
- Implement MDX linter setup and CI workflow.
- Introduce new MDX documentation to replace Storybook in the near future.
- Add functionality to void payments if a refund is requested within 25 minutes of creation.

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

