### PR TITLE
use `PartsMarkdownTable` on card-form doc.

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-12-11T22:21:44",
+  "timestamp": "2025-12-15T18:10:25",
   "compiler": {
     "name": "@stencil/core",
     "version": "4.28.2",
@@ -9658,7 +9658,32 @@
       "tag": "justifi-card-form",
       "readme": "# payment-method-option\n\n\n",
       "docs": "",
-      "docsTags": [],
+      "docsTags": [
+        {
+          "name": "part",
+          "text": "skeleton - Skeleton for the card form."
+        },
+        {
+          "name": "part",
+          "text": "input-invalid-and-focused - Style for invalid and focused input."
+        },
+        {
+          "name": "part",
+          "text": "input-invalid - Style for invalid input."
+        },
+        {
+          "name": "part",
+          "text": "input-focused - Style for focused input."
+        },
+        {
+          "name": "part",
+          "text": "input - Style for input."
+        },
+        {
+          "name": "part",
+          "text": "label - Style for label."
+        }
+      ],
       "usage": {},
       "props": [],
       "methods": [
@@ -9723,7 +9748,32 @@
       "listeners": [],
       "styles": [],
       "slots": [],
-      "parts": [],
+      "parts": [
+        {
+          "name": "input",
+          "docs": "Style for input."
+        },
+        {
+          "name": "input-focused",
+          "docs": "Style for focused input."
+        },
+        {
+          "name": "input-invalid",
+          "docs": "Style for invalid input."
+        },
+        {
+          "name": "input-invalid-and-focused",
+          "docs": "Style for invalid and focused input."
+        },
+        {
+          "name": "label",
+          "docs": "Style for label."
+        },
+        {
+          "name": "skeleton",
+          "docs": "Skeleton for the card form."
+        }
+      ],
       "dependents": [
         "internal-tokenize-payment-method"
       ],

--- a/docs/modular-checkout/sub-components/card-form.mdx
+++ b/docs/modular-checkout/sub-components/card-form.mdx
@@ -5,7 +5,13 @@ description: Card entry sub-component for Modular Checkout layouts with shared v
 sidebar_position: 2
 ---
 
-import { PropsTable, PartsTable, getWebcomponentsVersion } from '../../helpers';
+import {
+  PropsTable,
+  PartsMarkdownTable,
+  getWebcomponentsVersion,
+  getPartsFromDocs,
+} from '../../helpers';
+import docsJson from '../../docs.json';
 
 ## Overview
 
@@ -35,34 +41,6 @@ This component exposes **no public methods or properties** and is not intended f
   nomodule
   src="https://cdn.jsdelivr.net/npm/@justifi/webcomponents@${getWebcomponentsVersion()}/dist/webcomponents/webcomponents.js"
 ></script>
-
-<style>
-  /** These are the available parts for styling the component. */
-  ::part(skeleton){' '}
-  {
-    // skeleton styles
-  }
-  ::part(label){' '}
-  {
-    // label styles
-  }
-  ::part(input-invalid-and-focused){' '}
-  {
-    // input invalid and focused styles
-  }
-  ::part(input-invalid){' '}
-  {
-    // input invalid styles
-  }
-  ::part(input-focused){' '}
-  {
-    // input focused styles
-  }
-  ::part(input){' '}
-  {
-    // input styles
-  }
-</style>
 
 </head>
 
@@ -138,37 +116,4 @@ All submit and error events bubble through the parent `<justifi-modular-checkout
 
 ## Theming & Layout
 
-- When embedded inside cards, wrap the host element in your layout container and scope typography overrides via the parts listed below.
-
-<div
-  dangerouslySetInnerHTML={{
-    __html: PartsTable([
-      {
-        name: 'skeleton',
-        description: 'Skeleton loading state styles.',
-      },
-      {
-        name: 'label',
-        description: 'Label styles.',
-      },
-      {
-        name: 'input-invalid-and-focused',
-        description: 'Input styles when invalid and focused.',
-      },
-      {
-        name: 'input-invalid',
-        description: 'Input styles when invalid.',
-      },
-      {
-        name: 'input-focused',
-        description: 'Input styles when focused.',
-      },
-      {
-        name: 'input',
-        description: 'Input field styles.',
-      },
-    ]),
-  }}
-/>
-
-- Use the `card-form` CSS part (`::part(card-form)`) to apply box shadows or wrapper padding.
+<PartsMarkdownTable parts={getPartsFromDocs('justifi-card-form', docsJson)} />

--- a/packages/webcomponents/src/components/modular-checkout/sub-components/card-form.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/card-form.tsx
@@ -6,6 +6,14 @@ import { checkPkgVersion } from "../../../utils/check-pkg-version";
 import { generateTabId } from "../../../utils/utils";
 import { configState, waitForConfig } from "../../config-provider/config-state";
 
+/**
+ * @part skeleton - Skeleton for the card form.
+ * @part input-invalid-and-focused - Style for invalid and focused input.
+ * @part input-invalid - Style for invalid input.
+ * @part input-focused - Style for focused input.
+ * @part input - Style for input.
+ * @part label - Style for label.
+ */
 @Component({
   tag: "justifi-card-form",
   shadow: true,


### PR DESCRIPTION
- Same thing as previous PRs
- [ ] Added JSDocs @parts comments.
- [ ] Remove old parts table in favor of `PartsMarkDownTable`

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

