### PR TITLE
Introduce `PropsMarkdownTable` component

### DIFF
--- a/docs/helpers/PropsMarkdownTable.jsx
+++ b/docs/helpers/PropsMarkdownTable.jsx
@@ -1,0 +1,36 @@
+import { markdownTable } from 'markdown-table';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+/**
+ * React component that renders a markdown table of component props.
+ * @param {Object} props - Component props
+ * @param {Array} props.props - Array of prop objects with name, type, required, defaultValue, and description properties
+ */
+export function PropsMarkdownTable({ props }) {
+  if (!props || props.length === 0) {
+    return null;
+  }
+
+  // Prepare table data for markdown-table
+  const tableData = [
+    ['Name', 'Type', 'Required', 'Default', 'Description'],
+    ...props.map((prop) => [
+      `\`${prop.name}\``,
+      `\`${prop.type}\``,
+      prop.required ? 'Yes' : 'No',
+      prop.defaultValue ? `\`${prop.defaultValue}\`` : '—',
+      prop.description || '',
+    ]),
+  ];
+
+  // Generate markdown table using markdown-table library
+  const markdownTableString = markdownTable(tableData);
+
+  // Render the markdown table
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+      {markdownTableString}
+    </ReactMarkdown>
+  );
+}

--- a/docs/helpers/getPropsFromDocs.js
+++ b/docs/helpers/getPropsFromDocs.js
@@ -1,0 +1,41 @@
+/**
+ * Returns the props array for the specified component from docs.json.
+ * @param {string} componentTag - The component tag name (e.g., 'justifi-checkout')
+ * @param {Object} docsJson - Required parsed docs.json object.
+ * @returns {Array} Array of prop objects with name, type, required, defaultValue, and description properties
+ */
+export function getPropsFromDocs(componentTag, docsJson) {
+  if (!docsJson) {
+    throw new Error('docsJson parameter is required');
+  }
+
+  try {
+    // Find the component in the docs
+    const component = docsJson.components?.find(
+      (comp) => comp.tag === componentTag
+    );
+
+    if (!component) {
+      console.warn(`Component ${componentTag} not found in docs.json`);
+      return [];
+    }
+
+    // Extract props from the component
+    const props = component.props || [];
+
+    // Transform props to match PropsTable format
+    return props.map((prop) => ({
+      name: prop.attr || prop.name,
+      type: prop.type || '',
+      required: prop.required || false,
+      defaultValue: prop.default,
+      description: prop.docs || '',
+    }));
+  } catch (error) {
+    console.error(
+      `Error reading props from docs.json for ${componentTag}:`,
+      error
+    );
+    return [];
+  }
+}

--- a/docs/helpers/index.ts
+++ b/docs/helpers/index.ts
@@ -4,3 +4,5 @@ export { getWebcomponentsVersion } from './version';
 export { getPartsFromDocs } from './getPartsFromDocs';
 export { PartsMarkdownTable } from './PartsMarkdownTable';
 export { getComponentParts } from './getComponentParts';
+export { PropsMarkdownTable } from './PropsMarkdownTable';
+export { getPropsFromDocs } from './getPropsFromDocs';

--- a/docs/modular-checkout/sub-components/sub-components.mdx
+++ b/docs/modular-checkout/sub-components/sub-components.mdx
@@ -16,7 +16,6 @@ implementation details:
 - [Apple Pay](./sub-components/apple-pay)
 - [Saved payment methods](./sub-components/saved-payment-methods)
 - [Season interruption insurance](./sub-components/season-interruption-insurance)
-- [Payment method options](./sub-components/payment-method-options)
 - [Summary](./sub-components/summary)
 
 > Looking for additional rails? Duplicate any of these MDX files, adjust the

--- a/docs/payment-facilitation/unified-fintech-checkout™.mdx
+++ b/docs/payment-facilitation/unified-fintech-checkout™.mdx
@@ -5,8 +5,14 @@ description: Unified Fintech Checkout™ component that orchestrates payment cap
 sidebar_position: 20
 ---
 
-import { PropsTable, PartsMarkdownTable, getComponentParts } from '../helpers';
+import {
+  PropsMarkdownTable,
+  PartsMarkdownTable,
+  getComponentParts,
+  getPropsFromDocs,
+} from '../helpers';
 import componentTreeJson from '../component-tree.json';
+import docsJson from '../docs.json';
 
 ## Overview
 
@@ -25,46 +31,7 @@ import componentTreeJson from '../component-tree.json';
 
 ## Props, Events & Methods
 
-<div
-  dangerouslySetInnerHTML={{
-    __html: PropsTable([
-      {
-        name: 'account-id',
-        type: 'string',
-        required: true,
-        description:
-          'Owning platform account; determines branding + permissions.',
-      },
-      {
-        name: 'auth-token',
-        type: 'string',
-        required: true,
-        description: 'Web Component Token with `write:checkout` scope.',
-      },
-      {
-        name: 'checkout-id',
-        type: 'string',
-        required: true,
-        description:
-          'Server-generated checkout session controlling line items and totals.',
-      },
-      {
-        name: 'require-save-payment-method',
-        type: 'boolean',
-        defaultValue: 'false',
-        description:
-          'When true, forces customers to save the payment method for future use.',
-      },
-      {
-        name: 'locale',
-        type: 'string',
-        defaultValue: 'en-US',
-        description:
-          'Controls currency formatting, copy, and date presentation.',
-      },
-    ]),
-  }}
-/>
+<PropsMarkdownTable props={getPropsFromDocs('justifi-checkout', docsJson)} />
 
 ### Events
 


### PR DESCRIPTION
# This PR adds the following:

- [ ] Introduced `getPropsFromDocs` helper, which is responsible for extracting props details from `docs.json`.
- [ ] Introduced `PropsMarkdownTable.tsx` which renders a table for the props.
- [ ] Added `PropsMarkdownTable` to UFC doc page.

<!--
Describe the rationale and use case for this pull request.  Provide any
background, examples, and images that provide further information to accurately
describe what it is that you are adding to the repo.  Add subsections as
necessary to organize and feel free to link and reference other PRs as
necessary, but also include them in the links section below as a quick
reference.

Keep code changes as short as possible and implementing a single feature/fix/refactoring, when possible
-->


Links
-----

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

