### PR TITLE
1535 web component librarydocs dynamically display the version on the introductionmdx and other files that apply

### DIFF
--- a/docs/helpers/version.js
+++ b/docs/helpers/version.js
@@ -1,25 +1,12 @@
 import localPackageJson from '../package.json';
 
-let cachedVersion = null;
-
 export const getWebcomponentsVersion = () => {
-  if (cachedVersion) {
-    return cachedVersion;
-  }
-
-  // Read from local package.json dependencies
-  // The version is specified in dependencies or devDependencies
   try {
     const deps = localPackageJson?.dependencies || {};
-    const devDeps = localPackageJson?.devDependencies || {};
-    const versionSpec =
-      deps['@justifi/webcomponents'] || devDeps['@justifi/webcomponents'];
+    const versionSpec = deps['@justifi/webcomponents'];
 
     if (versionSpec) {
-      // Remove ^, ~, or other prefix characters to get clean version
-      const cleanVersion = versionSpec.replace(/^[\^~>=<]/, '').trim();
-      cachedVersion = cleanVersion;
-      return cleanVersion;
+      return versionSpec;
     }
   } catch (error) {
     console.error(error);

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.0",
     "miragejs": "^0.1.48",
-    "@justifi/webcomponents": "6.7.2"
+    "@justifi/webcomponents": "6.7.3"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",


### PR DESCRIPTION
The `version.js` logic was not resolving correctly the `web-component-library` package.json.

<img width="1351" height="909" alt="image" src="https://github.com/user-attachments/assets/471ce226-6cfd-4702-9925-42ecceb0273b" />


Links
-----
https://github.com/justifi-tech/engineering-artifacts/issues/1535

<!--
**Examples**

* http://documentation.for/library/that/I/am/adding
* [relevant issue or pull_request](#123)
-->

Developer considerations
--------------

- On any task
  - [ ] Previous unit and e2e tests are passing
  - [ ] Perform dev QA on Chrome, Firefox, and Safari
- On new features
  - [ ] Add unit tests
  - [ ] Add e2e tests
  - [ ] Add documentation
  - [ ] Does the component have exportedparts for styling? If so, add unit a unit test for each exportedpart
- On bugs
  - [ ] Add unit tests to prevent the bug from happening again


Developer QA steps
--------------------

<!--
If minor-moderate changes are made on endpoints covered by integration tests,
automated QA should provide sufficient test coverage. Check the test reports
[here](https://justifi-ai.atlassian.net/wiki/spaces/ENGINEERIN/pages/35782659/Test+Reports)
to see if your changes are covered. If implementing new features/endpoints or if
changes are interacting with a third-party service, most likely manual QA will be desired.

If there are any manual steps that you would like the reviewer(s) to take to
verify your changes, please describe in detail the steps to reproduce the
features added by the pull request, or the bug before and after the change.
-->

