### PR TITLE
Fix payment-provisioning documentation errors

### DIFF
--- a/docs/entities/payment-provisioning.mdx
+++ b/docs/entities/payment-provisioning.mdx
@@ -28,14 +28,12 @@ Component to render a business onboarding form, segmented into multiple steps. Y
 
 <pre>
   <code className="language-html">{`<justifi-payment-provisioning
-  account-id="acc_123"
   auth-token="wct_provisioning"
   business-id="biz_456"
-  on-success-text="Payout method saved"
 />`}</code>
 </pre>
 
-## Props, Events & Methods
+## Props & Events
 
 <PropsMarkdownTable
   props={getPropsFromDocs('justifi-payment-provisioning', docsJson)}
@@ -43,13 +41,18 @@ Component to render a business onboarding form, segmented into multiple steps. Y
 
 ### Events
 
-- `submitted`: Fires when payout information is collected and saved; payload includes the provisioning status.
-- `error-event`: Provides `code`/`message` details when token scopes or API calls fail.
+- `submit-event`: Fires when payout information is collected and saved. Payload includes the API response or error details.
+- `click-event`: Fires on button interactions (Previous/Next step navigation). Payload includes the action name.
+- `error-event`: Fires when errors occur, including:
+  - Missing required props (`auth-token` or `business-id`)
+  - API failures during business data fetch or provisioning submission
+  - When provisioning has already been requested for the business
 
-### Public methods
+  Payload includes `message`, `errorCode`, and `severity` properties.
 
-1. `submit()` – Trigger provisioning if you render external controls.
-2. `focus()` – Move focus to the first interactive element (helpful after displaying a banner).
+### Public Methods
+
+This component does not expose any public methods. Form submission is handled automatically through the multi-step form flow.
 
 ## Theming & Layout
 
@@ -62,7 +65,10 @@ Component to render a business onboarding form, segmented into multiple steps. Y
 ---
 
 <ComponentBox>
-  <justifi-payment-provisioning business-id="123" auth-token="123abc" />
+  <justifi-payment-provisioning
+    business-id="biz_123"
+    auth-token="wct_provisioning"
+  />
 </ComponentBox>
 
 ---


### PR DESCRIPTION
## Summary

Fixes incorrect documentation in `docs/entities/payment-provisioning.mdx` after cross-checking with component source code.

## Changes

- Remove non-existent props from usage examples: `account-id`, `on-success-text`
- Fix event name: `submitted` → `submit-event`
- Add missing `click-event` documentation
- Expand `error-event` documentation with all error scenarios
- Remove non-existent public methods section (`submit()`, `focus()`)
- Update section heading from "Props, Events & Methods" to "Props & Events"
- Fix both code examples to use only valid props

## Related Issues

Fixes justifi-tech/engineering-artifacts#1636

## Test Plan

- [x] Build completes successfully (`pnpm build`)
- [x] All documentation changes verified against component source
- [x] Manual verification: Run `pnpm dev` and check payment-provisioning docs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)