### PR TITLE
Align Google Pay environment with checkout API mode

### DIFF
--- a/.changeset/smart-trains-shine.md
+++ b/.changeset/smart-trains-shine.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": patch
+"@justifi/webcomponents-docs": patch
+---
+
+Introduce `googlePayEnv` optional prop to allow test on Google Pay on Unified Fintech Checkout

--- a/.changeset/vast-forks-guess.md
+++ b/.changeset/vast-forks-guess.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": patch
+"@justifi/webcomponents-docs": patch
+---
+
+Derive `justifi-google-pay` Google Pay environment from checkout API mode (test → TEST, live or unset → PRODUCTION); keep optional `environment` prop to override.

--- a/packages/webcomponents/src/components/checkout/justifi-checkout.tsx
+++ b/packages/webcomponents/src/components/checkout/justifi-checkout.tsx
@@ -34,6 +34,8 @@ export class JustifiCheckout {
   @Prop() disablePaymentMethodGroup?: boolean = false;
   @Prop() hideBankAccountBillingForm?: boolean = false;
   @Prop() hideCardBillingForm?: boolean = false;
+  /** Passed to `justifi-google-pay` as `environment`. Omit to let the child use its default. */
+  @Prop() googlePayEnv?: 'TEST' | 'PRODUCTION';
   @Prop() preCompleteHook?: Hook<CheckoutState>;
 
   @Watch('authToken')
@@ -147,7 +149,10 @@ export class JustifiCheckout {
                     )}
                     {this.availablePaymentMethods.includes(PAYMENT_METHODS.GOOGLE_PAY) && (
                       <div class="mb-3">
-                        <justifi-google-pay ref={(el) => (this.googlePayRef = el)} />
+                        <justifi-google-pay
+                          ref={(el) => (this.googlePayRef = el)}
+                          {...(this.googlePayEnv != null ? { environment: this.googlePayEnv } : {})}
+                        />
                       </div>
                     )}
                     <justifi-saved-payment-methods />

--- a/packages/webcomponents/src/components/checkout/test/checkout.spec.tsx
+++ b/packages/webcomponents/src/components/checkout/test/checkout.spec.tsx
@@ -3,6 +3,7 @@ jest.mock('../../../utils/check-pkg-version', () => ({ checkPkgVersion: jest.fn(
 
 import { newSpecPage } from '@stencil/core/testing';
 import { JustifiCheckout } from '../justifi-checkout';
+import { JustifiGooglePay } from '../../modular-checkout/sub-components/justifi-google-pay';
 import JustifiAnalytics from '../../../api/Analytics';
 import { PAYMENT_METHODS } from '../../modular-checkout/ModularCheckout';
 import { checkoutStore } from '../../../store/checkout.store';
@@ -192,6 +193,26 @@ describe('justifi-checkout', () => {
       await page.waitForChanges();
 
       expect(page.root?.querySelector('justifi-google-pay')).not.toBeNull();
+    });
+
+    it('forwards googlePayEnv to justifi-google-pay as environment', async () => {
+      const page = await newSpecPage({
+        components: [JustifiCheckout, JustifiGooglePay],
+        html: '<justifi-checkout auth-token="t" checkout-id="chk_1" google-pay-env="TEST"></justifi-checkout>',
+      });
+      const instance = page.rootInstance as any;
+
+      const event = new CustomEvent('checkout-changed', {
+        detail: { availablePaymentMethodTypes: [PAYMENT_METHODS.GOOGLE_PAY], selectedPaymentMethod: undefined, savedPaymentMethods: [] },
+        bubbles: true,
+        composed: true,
+      } as any);
+      instance.checkoutChanged(event);
+      await page.waitForChanges();
+
+      const googlePayEl = page.root?.querySelector('justifi-google-pay') as HTMLJustifiGooglePayElement | null;
+      expect(googlePayEl).not.toBeNull();
+      expect(googlePayEl?.environment).toBe('TEST');
     });
 
     it('hides Google Pay when availablePaymentMethods excludes GOOGLE_PAY', async () => {

--- a/packages/webcomponents/src/components/modular-checkout/justifi-modular-checkout.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/justifi-modular-checkout.tsx
@@ -162,6 +162,9 @@ export class JustifiModularCheckout {
   private updateStore(checkout: ICheckout) {
     checkoutStore.accountId = checkout.account_id;
     checkoutStore.checkoutLoaded = true;
+    const rawMode = checkout.mode != null ? String(checkout.mode).toLowerCase() : '';
+    checkoutStore.checkoutMode =
+      rawMode === 'test' ? 'test' : rawMode === 'live' ? 'live' : null;
     checkoutStore.paymentMethods = checkout.payment_methods.map((paymentMethod) => new PaymentMethod(paymentMethod));
     checkoutStore.paymentMethodGroupId = checkout.payment_method_group_id;
     checkoutStore.paymentDescription = checkout.payment_description;

--- a/packages/webcomponents/src/components/modular-checkout/sub-components/justifi-google-pay.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/justifi-google-pay.tsx
@@ -31,7 +31,8 @@ enum GooglePayEventTypes {
 export class JustifiGooglePay {
   private iframeElement: HTMLIFrameElement;
 
-  @Prop() environment: "TEST" | "PRODUCTION" = "PRODUCTION";
+  /** If not provided, the environment will be determined by the account mode: 'test' or 'live'. */
+  @Prop() environment?: "TEST" | "PRODUCTION";
   @Prop() merchantDisplayName: string = "JustiFi Checkout";
 
   @State() iframeOrigin: string;
@@ -106,11 +107,18 @@ export class JustifiGooglePay {
     }
   };
 
+  private googlePayEnvironment(): "TEST" | "PRODUCTION" {
+    if (this.environment !== undefined) {
+      return this.environment;
+    }
+    return checkoutStore.checkoutMode === "test" ? "TEST" : "PRODUCTION";
+  }
+
   private sendInitialize() {
     if (!this.iframeElement?.contentWindow) return;
 
     const config = {
-      environment: this.environment,
+      environment: this.googlePayEnvironment(),
       gatewayMerchantId: checkoutStore.accountId,
       merchantName: this.merchantDisplayName,
       authToken: checkoutStore.authToken,

--- a/packages/webcomponents/src/components/modular-checkout/sub-components/test/google-pay.spec.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/test/google-pay.spec.tsx
@@ -19,6 +19,7 @@ describe('justifi-google-pay', () => {
     checkoutStore.authToken = 'auth_token';
     checkoutStore.paymentAmount = 1000;
     checkoutStore.paymentCurrency = 'USD';
+    checkoutStore.checkoutMode = null;
   });
 
   afterEach(() => {
@@ -304,6 +305,63 @@ describe('justifi-google-pay', () => {
         },
         IFRAME_ORIGIN
       );
+    });
+
+    it('sendInitialize uses TEST when environment prop unset and checkoutMode is test', async () => {
+      checkoutStore.checkoutMode = 'test';
+
+      const page = await newSpecPage({
+        components: [JustifiGooglePay],
+        template: () => <justifi-google-pay merchantDisplayName="Test Merchant" />,
+      });
+
+      const instance = page.rootInstance as any;
+      instance.iframeOrigin = IFRAME_ORIGIN;
+
+      const mockPostMessage = jest.fn();
+      instance.iframeElement = {
+        contentWindow: { postMessage: mockPostMessage },
+      };
+
+      instance.sendInitialize();
+
+      expect(mockPostMessage).toHaveBeenCalledWith(
+        {
+          eventType: 'justifi.googlePay.initialize',
+          data: {
+            environment: 'TEST',
+            gatewayMerchantId: 'acc_123',
+            merchantName: 'Test Merchant',
+            authToken: 'auth_token',
+            accountId: 'acc_123',
+          },
+        },
+        IFRAME_ORIGIN
+      );
+    });
+
+    it('sendInitialize uses PRODUCTION when environment prop unset and checkoutMode is live or null', async () => {
+      const page = await newSpecPage({
+        components: [JustifiGooglePay],
+        template: () => <justifi-google-pay merchantDisplayName="Test Merchant" />,
+      });
+
+      const instance = page.rootInstance as any;
+      instance.iframeOrigin = IFRAME_ORIGIN;
+
+      const mockPostMessage = jest.fn();
+      instance.iframeElement = {
+        contentWindow: { postMessage: mockPostMessage },
+      };
+
+      checkoutStore.checkoutMode = 'live';
+      instance.sendInitialize();
+      expect(mockPostMessage.mock.calls[0][0].data.environment).toBe('PRODUCTION');
+
+      mockPostMessage.mockClear();
+      checkoutStore.checkoutMode = null;
+      instance.sendInitialize();
+      expect(mockPostMessage.mock.calls[0][0].data.environment).toBe('PRODUCTION');
     });
 
     it('sendStartPayment sends transaction info to iframe', async () => {

--- a/packages/webcomponents/src/components/modular-checkout/test/modular-checkout.spec.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/test/modular-checkout.spec.tsx
@@ -63,6 +63,7 @@ describe('justifi-modular-checkout', () => {
   beforeEach(() => {
     checkoutStore.isSubmitting = false;
     checkoutStore.isWalletProcessing = false;
+    checkoutStore.checkoutMode = null;
   });
 
   afterAll(() => {
@@ -118,6 +119,7 @@ describe('justifi-modular-checkout', () => {
       payment_description: 'desc',
       total_amount: 1000,
       payment_amount: 1000,
+      mode: 'test',
       payment_settings: {
         bnpl_payments: false,
         insurance_payments: false,
@@ -142,6 +144,43 @@ describe('justifi-modular-checkout', () => {
 
       expect(getCheckoutSpy).toHaveBeenCalledTimes(1);
       expect(checkoutStore.checkoutLoaded).toBe(true);
+      expect(checkoutStore.checkoutMode).toBe('test');
+    });
+
+    it('maps checkout.mode live to checkoutStore.checkoutMode', async () => {
+      const getCheckoutSpy = jest.fn(({ onSuccess }: any) => {
+        onSuccess({
+          checkout: { ...mockCheckout, mode: 'live', status: ICheckoutStatus.created },
+        });
+      });
+      (checkoutActions.makeGetCheckout as jest.Mock).mockReturnValue(getCheckoutSpy);
+
+      const page = await newSpecPage({
+        components: [JustifiModularCheckout],
+        html: `<justifi-modular-checkout auth-token="tok" checkout-id="chk_1"></justifi-modular-checkout>`,
+      });
+
+      await page.waitForChanges();
+
+      expect(checkoutStore.checkoutMode).toBe('live');
+    });
+
+    it('sets checkoutStore.checkoutMode null when mode is absent or unknown', async () => {
+      const getCheckoutSpy = jest.fn(({ onSuccess }: any) => {
+        onSuccess({
+          checkout: { ...mockCheckout, mode: undefined, status: ICheckoutStatus.created },
+        });
+      });
+      (checkoutActions.makeGetCheckout as jest.Mock).mockReturnValue(getCheckoutSpy);
+
+      const page = await newSpecPage({
+        components: [JustifiModularCheckout],
+        html: `<justifi-modular-checkout auth-token="tok" checkout-id="chk_1"></justifi-modular-checkout>`,
+      });
+
+      await page.waitForChanges();
+
+      expect(checkoutStore.checkoutMode).toBeNull();
     });
 
     // Skip: insurance store subscription (insuranceValuesOn) does not trigger reliably in test env

--- a/packages/webcomponents/src/store/checkout.store.ts
+++ b/packages/webcomponents/src/store/checkout.store.ts
@@ -22,6 +22,7 @@ interface IInitialState {
   bnplProviderMode: string;
   checkoutId: string;
   checkoutLoaded: boolean;
+  checkoutMode: 'test' | 'live' | null;
   bankAccountVerification?: boolean;
   disableBankAccount: boolean;
   disableCreditCard: boolean;
@@ -74,6 +75,7 @@ const initialState: IInitialState = {
   bnplProviderMode: '',
   checkoutId: '',
   checkoutLoaded: false,
+  checkoutMode: null,
   bankAccountVerification: undefined,
   disableBankAccount: false,
   disableCreditCard: false,


### PR DESCRIPTION
## Summary

- Derives `justifi-google-pay` Google Pay environment from checkout API mode: `test` → `TEST`, `live` or unset → `PRODUCTION`.
- Keeps the optional `environment` prop as an override when set.
- Updates modular checkout, checkout store, and unit tests; includes a changeset for `@justifi/webcomponents` and `@justifi/webcomponents-docs`.

<img width="1009" height="301" alt="image" src="https://github.com/user-attachments/assets/b8e7e58b-c44a-400a-9a32-1dc7f07eb202" />

## Testing

- `pnpm --filter @justifi/webcomponents test`