### PR TITLE
fix(docs): webcomponents version getter

### DIFF
--- a/.changeset/thirty-garlics-cough.md
+++ b/.changeset/thirty-garlics-cough.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents-docs": patch
+---
+
+Fix version getter

--- a/docs/helpers/version.js
+++ b/docs/helpers/version.js
@@ -1,4 +1,1 @@
-import wcPackage from '@justifi/webcomponents/package.json';
-
-/** Exact published semver from packages/webcomponents (inlined when bundled via build:helpers). */
-export const getWebcomponentsVersion = () => wcPackage.version;
+export const getWebcomponentsVersion = () => '6.13.0';

--- a/docs/scripts/build-helpers.mjs
+++ b/docs/scripts/build-helpers.mjs
@@ -18,24 +18,12 @@ await build({
   absWorkingDir: root,
 });
 
-// 2. Bundle version.js (inlines @justifi/webcomponents version from package.json)
-await build({
-  entryPoints: ['helpers/version.js'],
-  bundle: true,
-  format: 'esm',
-  platform: 'neutral',
-  target: 'es2020',
-  outfile: 'dist/helpers/version.js',
-  allowOverwrite: true,
-  absWorkingDir: root,
-});
-
-// 3. Write cleaned package.json to dist/ (for consumers)
+// 2. Write cleaned package.json to dist/ (for consumers)
 const pkg = JSON.parse(readFileSync(resolve(root, 'package.json'), 'utf8'));
 delete pkg.scripts;
 delete pkg.devDependencies;
 mkdirSync(resolve(root, 'dist'), { recursive: true });
 writeFileSync(resolve(root, 'dist/package.json'), JSON.stringify(pkg, null, 2));
 
-// 4. Copy mocks
+// 3. Copy mocks
 cpSync(resolve(root, 'mocks'), resolve(root, 'dist/mocks'), { recursive: true });


### PR DESCRIPTION
This pull request fixes how the docs site resolves the published `@justifi/webcomponents` version.

- Simplify `docs/helpers/version.js` and the build helper wiring in `docs/scripts/build-helpers.mjs` so the displayed version matches the package consumers see.
- Add a changeset for `@justifi/webcomponents-docs` (patch).