### PR TITLE
Fix provisioning API error handling

### DIFF
--- a/.changeset/blue-terms-divide.md
+++ b/.changeset/blue-terms-divide.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix payment provisioning silently treating failed API responses as success; surface a submission-failed view when the request errors.

--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -107,10 +107,31 @@ export const Api = () => {
       signal: signal,
     });
 
-    if (response) {
-      return response.status === 204 ? {} : response.json();
+    if (!response) {
+      handleError(requestUrl);
+      return;
     }
-    handleError(requestUrl);
+
+    if (response.status === 204) {
+      return {};
+    }
+
+    const parsed = await response.json().catch(() => ({}));
+
+    if (!response.ok) {
+      const err: any = new Error(
+        parsed?.error?.message
+          || (typeof parsed?.error === 'string' ? parsed.error : null)
+          || parsed?.message
+          || `Request failed: ${response.status}`,
+      );
+      err.code = parsed?.error?.code;
+      err.status = response.status;
+      err.body = parsed;
+      throw err;
+    }
+
+    return parsed;
   }
 
   async function get(props: GetProps) {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/justifi-payment-provisioning.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/justifi-payment-provisioning.tsx
@@ -35,6 +35,7 @@ import { Business } from '../../../api/Business';
 import { PaymentProvisioningLoading } from './payment-provisioning-loading';
 import { PaymentProvisioningAlreadyProvisioned } from './payment-provisioning-already-provisioned';
 import { PaymentProvisioningSubmissionComplete } from './payment-provisioning-submission-complete';
+import { PaymentProvisioningSubmissionFailed } from './payment-provisioning-submission-failed';
 
 @Component({
   tag: 'justifi-payment-provisioning',
@@ -45,6 +46,7 @@ export class JustifiPaymentProvisioning {
   @State() businessLoading: boolean = true;
   @State() businessProvisioned: boolean = false;
   @State() formSubmitted: boolean = false;
+  @State() submissionFailed: boolean = false;
   @State() currentStep: number = 0;
   @State() errorMessage: string;
   @State() country: CountryCode = CountryCode.USA;
@@ -165,6 +167,7 @@ export class JustifiPaymentProvisioning {
         this.submitEvent.emit({ response: response });
       },
       onError: ({ error, code, severity }) => {
+        this.submissionFailed = true;
         this.submitEvent.emit({ response: { error } });
         this.errorEvent.emit({
           message: error,
@@ -232,6 +235,14 @@ export class JustifiPaymentProvisioning {
       return (
         <StyledHost>
           <PaymentProvisioningSubmissionComplete />
+        </StyledHost>
+      );
+    }
+
+    if (this.submissionFailed) {
+      return (
+        <StyledHost>
+          <PaymentProvisioningSubmissionFailed />
         </StyledHost>
       );
     }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-actions.ts
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-actions.ts
@@ -66,11 +66,12 @@ export const makePostProvisioning = ({ authToken, businessId, product, service }
     try {
       const response = await service.postProvisioning(authToken, businessId, product);
 
-      if (!response.error) {
+      if (response?.data && !response.error) {
         onSuccess(response);
       } else {
-        const responseError = getErrorMessage(response.error);
-        const code = getErrorCode(response.error?.code);
+        const rawError = response?.error ?? response?.errors?.[0] ?? 'Provisioning request failed';
+        const responseError = getErrorMessage(rawError);
+        const code = getErrorCode(response?.error?.code);
         return onError({
           error: responseError,
           code,

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-submission-failed.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/payment-provisioning-submission-failed.tsx
@@ -1,0 +1,16 @@
+import { h } from '@stencil/core';
+import { Header1 } from '../../../ui-components';
+import { text } from '../../../styles/parts';
+
+export const PaymentProvisioningSubmissionFailed = () => {
+  return (
+    <div class="row gap-3 p-5">
+      <div class="col-12">
+        <Header1 text="Something went wrong" />
+      </div>
+      <div class="col-12" part={text}>
+        <p>There was an error submitting the provisioning. Your progress has been saved — please try again later or contact the support team.</p>
+      </div>
+    </div>
+  );
+};

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/test/payment-provisioning.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/test/payment-provisioning.spec.tsx
@@ -286,6 +286,50 @@ describe('justifi-payment-provisioning', () => {
     );
   });
 
+  it('should not mark form submitted when provisioning resolves without data', async () => {
+    BusinessService.prototype.fetchBusiness = jest
+      .fn()
+      .mockResolvedValue(mockBusinessResponse);
+    ProvisionService.prototype.postProvisioning = jest
+      .fn()
+      .mockResolvedValue({ errors: ['boom'] });
+
+    const errorEvent = jest.fn();
+    const submitEvent = jest.fn();
+    const page = await newSpecPage({
+      components: [JustifiPaymentProvisioning],
+      template: () => (
+        <justifi-payment-provisioning
+          businessId="biz_123"
+          authToken={validToken}
+          onError-event={errorEvent}
+          onSubmit-event={submitEvent}
+        />
+      ),
+    });
+
+    await page.waitForChanges();
+
+    page.root.dispatchEvent(new CustomEvent('formCompleted'));
+
+    await page.waitForChanges();
+
+    expect(page.rootInstance.formSubmitted).toBe(false);
+    expect(page.root.shadowRoot?.textContent).not.toContain(
+      "You're all set for now"
+    );
+    expect(errorEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({ severity: 'error' }),
+      })
+    );
+    expect(submitEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: { response: { error: 'boom' } },
+      })
+    );
+  });
+
   describe('step orchestration', () => {
     beforeEach(() => {
       BusinessService.prototype.fetchBusiness = jest

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/test/payment-provisioning.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/test/payment-provisioning.spec.tsx
@@ -284,6 +284,12 @@ describe('justifi-payment-provisioning', () => {
         }),
       })
     );
+
+    expect(page.rootInstance.submissionFailed).toBe(true);
+    await page.waitForChanges();
+    const hostText = page.root.shadowRoot?.textContent ?? '';
+    expect(hostText).toContain('Something went wrong');
+    expect(hostText).toContain('try again later');
   });
 
   it('should not mark form submitted when provisioning resolves without data', async () => {


### PR DESCRIPTION
## Summary
- Throw on non-OK API responses so failed provisioning requests surface as errors instead of being treated as success.
- Guard `makePostProvisioning` against responses without `data` and fall back to `errors[0]` when `error` is absent.
- Render a `PaymentProvisioningSubmissionFailed` view when submission fails so the user sees a clear message.

## Test plan
- [x] `pnpm test` for `justifi-payment-provisioning` (covers failure path + new "resolves without data" case)
- [ ] Manual: trigger a failing provisioning request and confirm the failure view renders and the success view does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)