### PR TITLE
feat: add useNativePaymentRequest prop to justifi-google-pay

### DIFF
--- a/.changeset/witty-boats-deny.md
+++ b/.changeset/witty-boats-deny.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Add `useNativePaymentRequest` prop to `justifi-google-pay` for Android WebView embeds; routes Google Pay through the W3C Payment Request API instead of pay.js's `loadPaymentData` popup (blocked in WebViews, OR_BIBED_15).

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.13.4",
+  "version": "6.13.4-rc.1",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.13.4-rc.1",
+  "version": "6.13.4",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",

--- a/packages/webcomponents/src/components/modular-checkout/sub-components/justifi-google-pay.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/justifi-google-pay.tsx
@@ -34,6 +34,10 @@ export class JustifiGooglePay {
   /** If not provided, the environment will be determined by the account mode: 'test' or 'live'. */
   @Prop() environment?: "TEST" | "PRODUCTION";
   @Prop() merchantDisplayName: string = "JustiFi Checkout";
+  /** Set to true when embedding inside an Android WebView so the iframe uses the
+   * W3C Payment Request API (native Google Pay sheet) instead of pay.js's
+   * loadPaymentData popup, which Google blocks in WebViews (OR_BIBED_15). */
+  @Prop() useNativePaymentRequest: boolean = false;
 
   @State() iframeOrigin: string;
   @State() iframeReady: boolean = false;
@@ -123,6 +127,7 @@ export class JustifiGooglePay {
       merchantName: this.merchantDisplayName,
       authToken: checkoutStore.authToken,
       accountId: checkoutStore.accountId,
+      useNativePaymentRequest: this.useNativePaymentRequest,
     };
 
     this.iframeElement.contentWindow.postMessage(

--- a/packages/webcomponents/src/components/modular-checkout/sub-components/test/google-pay.spec.tsx
+++ b/packages/webcomponents/src/components/modular-checkout/sub-components/test/google-pay.spec.tsx
@@ -301,10 +301,36 @@ describe('justifi-google-pay', () => {
             merchantName: 'Test Merchant',
             authToken: 'auth_token',
             accountId: 'acc_123',
+            useNativePaymentRequest: false,
           },
         },
         IFRAME_ORIGIN
       );
+    });
+
+    it('sendInitialize forwards useNativePaymentRequest=true', async () => {
+      const page = await newSpecPage({
+        components: [JustifiGooglePay],
+        template: () => (
+          <justifi-google-pay
+            environment="TEST"
+            merchantDisplayName="Test Merchant"
+            useNativePaymentRequest
+          />
+        ),
+      });
+
+      const instance = page.rootInstance as any;
+      instance.iframeOrigin = IFRAME_ORIGIN;
+
+      const mockPostMessage = jest.fn();
+      instance.iframeElement = {
+        contentWindow: { postMessage: mockPostMessage },
+      };
+
+      instance.sendInitialize();
+
+      expect(mockPostMessage.mock.calls[0][0].data.useNativePaymentRequest).toBe(true);
     });
 
     it('sendInitialize uses TEST when environment prop unset and checkoutMode is test', async () => {
@@ -334,6 +360,7 @@ describe('justifi-google-pay', () => {
             merchantName: 'Test Merchant',
             authToken: 'auth_token',
             accountId: 'acc_123',
+            useNativePaymentRequest: false,
           },
         },
         IFRAME_ORIGIN


### PR DESCRIPTION
## Summary

- Adds `useNativePaymentRequest` boolean prop to `<justifi-google-pay>`. When `true`, the prop is forwarded to the iframe in the initialize postMessage.
- Pairs with iframe-components#130 — the iframe uses the W3C Payment Request API instead of pay.js `loadPaymentData()`, avoiding the `pay.google.com` popup that Google blocks in Android WebViews (OR_BIBED_15).
- Default `false` — existing consumers unaffected.

## Usage

```html
<justifi-google-pay
  use-native-payment-request="true"
  merchant-display-name="My Store">
</justifi-google-pay>
```

Host (Android app) sets the flag based on its WebView context.

## Test plan

- [ ] Existing tests pass (839 passed locally)
- [ ] New test verifies prop is forwarded as `useNativePaymentRequest: true` in initialize message
- [ ] Default case still posts `useNativePaymentRequest: false`
- [ ] Manual: paired with iframe-components PR, Android WebView consumer can set the prop and bypass OR_BIBED_15

🤖 Generated with [Claude Code](https://claude.com/claude-code)