### PR TITLE
fix: allow ownership percentage totals under 100%

### DIFF
--- a/.changeset/crazy-zoos-melt.md
+++ b/.changeset/crazy-zoos-melt.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+allow ownership percentage totals under 100%

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
@@ -122,9 +122,9 @@ export class BusinessOwnersFormStep {
     if (!this.allowOptionalFields) {
       const percentages = await Promise.all(this.refs.map(ref => ref.getOwnershipPercentage()));
       const total = percentages.reduce((sum, p) => sum + (parseFloat(p) || 0), 0);
-      if (total !== 100) {
+      if (total > 100) {
         await Promise.all(this.refs.map(ref =>
-          ref.setOwnershipPercentageError('Ownership percentages must total 100%')
+          ref.setOwnershipPercentageError('Ownership percentages cannot exceed 100%')
         ));
         return;
       }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/test/business-owners-form-step.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/test/business-owners-form-step.spec.tsx
@@ -282,17 +282,17 @@ describe('business-owners-form-step', () => {
       expect(mockPatch).toHaveBeenCalled();
     });
 
-    it('does not call sendData when ownership percentages do not total 100%', async () => {
+    it('does not call sendData when ownership percentages exceed 100%', async () => {
       const { page, mockPatch } = await setupComponent(MOCK_OWNERS);
-      const mockRef1 = createMockRef('30');
-      const mockRef2 = createMockRef('20');
+      const mockRef1 = createMockRef('60');
+      const mockRef2 = createMockRef('60');
       page.rootInstance.refs = [mockRef1, mockRef2];
 
       await page.rootInstance.validateAndSubmit({ onSuccess: jest.fn() });
       await page.waitForChanges();
 
-      expect(mockRef1.setOwnershipPercentageError).toHaveBeenCalledWith('Ownership percentages must total 100%');
-      expect(mockRef2.setOwnershipPercentageError).toHaveBeenCalledWith('Ownership percentages must total 100%');
+      expect(mockRef1.setOwnershipPercentageError).toHaveBeenCalledWith('Ownership percentages cannot exceed 100%');
+      expect(mockRef2.setOwnershipPercentageError).toHaveBeenCalledWith('Ownership percentages cannot exceed 100%');
       expect(mockPatch).not.toHaveBeenCalled();
     });
 
@@ -311,6 +311,25 @@ describe('business-owners-form-step', () => {
       await new Promise((r) => setTimeout(r, 0));
 
       expect(mockRef1.setOwnershipPercentageError).not.toHaveBeenCalled();
+      expect(mockPatch).toHaveBeenCalled();
+    });
+
+    it('proceeds when ownership percentages total less than 100%', async () => {
+      const { page, mockPatch } = await setupComponent(MOCK_OWNERS);
+      const mockRef1 = createMockRef('30');
+      const mockRef2 = createMockRef('20');
+      page.rootInstance.refs = [mockRef1, mockRef2];
+      mockPatch.mockImplementation(({ onSuccess, final }) => {
+        onSuccess({});
+        final?.();
+      });
+
+      await page.rootInstance.validateAndSubmit({ onSuccess: jest.fn() });
+      await page.waitForChanges();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(mockRef1.setOwnershipPercentageError).not.toHaveBeenCalled();
+      expect(mockRef2.setOwnershipPercentageError).not.toHaveBeenCalled();
       expect(mockPatch).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- Validation now only errors when ownership percentages exceed 100% (previously required exactly 100%)
- Updated error message to "Ownership percentages cannot exceed 100%"
- Updated spec tests

## Test plan
- [ ] Submit business-owners form with total ownership < 100% — submission proceeds
- [ ] Submit with total ownership > 100% — error shown on all owners
- [ ] Submit with total ownership === 100% — submission proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)