### PR TITLE
feat: require 25% min ownership and unique owner emails

### DIFF
--- a/.changeset/smart-foxes-wish.md
+++ b/.changeset/smart-foxes-wish.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Enforces minimum 25% ownership for owners and unique emails across owners on the business owners form.

--- a/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
+++ b/packages/webcomponents/src/components/business-forms/owner-form/owner-form.tsx
@@ -65,6 +65,16 @@ export class OwnerForm {
   }
 
   @Method()
+  async getEmail(): Promise<string | null> {
+    return this.formController.values.getValue()?.email || null;
+  }
+
+  @Method()
+  async setEmailError(message: string): Promise<void> {
+    this.formController.setFieldError('email', message);
+  }
+
+  @Method()
   async validate(): Promise<boolean> {
     return this.formController.validate();
   }

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
@@ -128,6 +128,21 @@ export class BusinessOwnersFormStep {
         ));
         return;
       }
+
+      const emails = await Promise.all(this.refs.map(ref => ref.getEmail()));
+      const seen = new Map<string, number>();
+      let hasDuplicateEmail = false;
+      await Promise.all(emails.map(async (raw, i) => {
+        const email = raw?.trim().toLowerCase();
+        if (!email) return;
+        if (seen.has(email)) {
+          hasDuplicateEmail = true;
+          await this.refs[i].setEmailError('This email is already in use');
+        } else {
+          seen.set(email, i);
+        }
+      }));
+      if (hasDuplicateEmail) { return; }
     }
 
     const formSubmissions = this.refs.map(ref => ref.submit());
@@ -239,6 +254,9 @@ export class BusinessOwnersFormStep {
             <form-control-tooltip helpText="For partnerships, LLCs or privately held corporations, the business is required to apply with all individuals with 25% or more ownership to the application. For charities and registered non-profits, the business is required to apply with 1 individual with substantial control over the entity, such as a board member or director." />
           </div>
           <hr class="mt-2" />
+          <div class="alert alert-info mb-3" part={alert}>
+            All owners with 25% or more ownership of the business must be registered.
+          </div>
           {shouldShowRepresentativeIsOwner && (
             <div class={`alert alert-warning mb-3`} part={alert}>
               <div class="card-body">

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/test/business-owners-form-step.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/test/business-owners-form-step.spec.tsx
@@ -40,12 +40,14 @@ async function setupComponent(
   return { page, mockGet, mockPatch };
 }
 
-function createMockRef(ownershipPercentage: string = '100') {
+function createMockRef(ownershipPercentage: string = '100', email: string | null = null) {
   return {
     validate: jest.fn().mockResolvedValue(true),
     submit: jest.fn().mockResolvedValue(true),
     getOwnershipPercentage: jest.fn().mockResolvedValue(ownershipPercentage),
     setOwnershipPercentageError: jest.fn().mockResolvedValue(undefined),
+    getEmail: jest.fn().mockResolvedValue(email),
+    setEmailError: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -227,6 +229,16 @@ describe('business-owners-form-step', () => {
     });
   });
 
+  describe('ownership info banner', () => {
+    it('renders the 25% ownership registration notice', async () => {
+      const { page } = await setupComponent([{ id: 'o1' }]);
+      await page.waitForChanges();
+
+      const banner = page.root.querySelector('.alert-info');
+      expect(banner?.textContent).toContain('All owners with 25% or more ownership of the business must be registered.');
+    });
+  });
+
   describe('Add Owner button', () => {
     it('showAddOwnerButton is true when < 4 owners and no new form open', async () => {
       const { page } = await setupComponent([{ id: 'o1' }]);
@@ -363,6 +375,59 @@ describe('business-owners-form-step', () => {
       await new Promise((r) => setTimeout(r, 0));
 
       expect(mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('does not call sendData when two owners share the same email', async () => {
+      const { page, mockPatch } = await setupComponent(MOCK_OWNERS);
+      const mockRef1 = createMockRef('30', 'dup@example.com');
+      const mockRef2 = createMockRef('30', 'DUP@example.com');
+      page.rootInstance.refs = [mockRef1, mockRef2];
+
+      await page.rootInstance.validateAndSubmit({ onSuccess: jest.fn() });
+      await page.waitForChanges();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(mockRef1.setEmailError).not.toHaveBeenCalled();
+      expect(mockRef2.setEmailError).toHaveBeenCalledWith('This email is already in use');
+      expect(mockPatch).not.toHaveBeenCalled();
+    });
+
+    it('proceeds when all owner emails are unique', async () => {
+      const { page, mockPatch } = await setupComponent(MOCK_OWNERS);
+      const mockRef1 = createMockRef('30', 'a@example.com');
+      const mockRef2 = createMockRef('30', 'b@example.com');
+      page.rootInstance.refs = [mockRef1, mockRef2];
+      mockPatch.mockImplementation(({ onSuccess, final }) => {
+        onSuccess({});
+        final?.();
+      });
+
+      await page.rootInstance.validateAndSubmit({ onSuccess: jest.fn() });
+      await page.waitForChanges();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(mockRef1.setEmailError).not.toHaveBeenCalled();
+      expect(mockRef2.setEmailError).not.toHaveBeenCalled();
+      expect(mockPatch).toHaveBeenCalled();
+    });
+
+    it('skips duplicate email validation when allowOptionalFields is true', async () => {
+      const { page, mockPatch } = await setupComponent(MOCK_OWNERS);
+      page.rootInstance.allowOptionalFields = true;
+      const mockRef1 = createMockRef('30', 'dup@example.com');
+      const mockRef2 = createMockRef('30', 'dup@example.com');
+      page.rootInstance.refs = [mockRef1, mockRef2];
+      mockPatch.mockImplementation(({ onSuccess, final }) => {
+        onSuccess({});
+        final?.();
+      });
+
+      await page.rootInstance.validateAndSubmit({ onSuccess: jest.fn() });
+      await page.waitForChanges();
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(mockRef2.setEmailError).not.toHaveBeenCalled();
+      expect(mockPatch).toHaveBeenCalled();
     });
   });
 

--- a/packages/webcomponents/src/components/business-forms/schemas/__tests__/business-identity-schema.spec.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/__tests__/business-identity-schema.spec.ts
@@ -45,6 +45,24 @@ describe('ownership_percentage requirement', () => {
       const data = { ...baseIdentity, ownership_percentage: null, address: validAddress };
       await expect(schema.isValid(data)).resolves.toBe(true);
     });
+
+    it('fails for owner when ownership_percentage is below 25', async () => {
+      const schema = identitySchemaUSA('owner', false);
+      const data = { ...baseIdentity, ownership_percentage: '10', address: validAddress };
+      await expect(schema.isValid(data)).resolves.toBe(false);
+    });
+
+    it('passes for owner when ownership_percentage is exactly 25', async () => {
+      const schema = identitySchemaUSA('owner', false);
+      const data = { ...baseIdentity, ownership_percentage: '25', address: validAddress };
+      await expect(schema.isValid(data)).resolves.toBe(true);
+    });
+
+    it('does not enforce 25% minimum on representative', async () => {
+      const schema = identitySchemaUSA('representative', false);
+      const data = { ...baseIdentity, ownership_percentage: '10', address: validAddress };
+      await expect(schema.isValid(data)).resolves.toBe(true);
+    });
   });
 
   describe('strict CAN schema', () => {

--- a/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/business-identity-schema.ts
@@ -9,6 +9,7 @@ import {
   ssnValidation,
   makeIdentityNumberValidation,
   ownershipPercentageValidation,
+  makeOwnershipPercentageValidation,
 } from './schema-validations';
 import { CountryCode } from '../../../utils/country-codes';
 
@@ -37,7 +38,7 @@ const strictSchemaUSA = (role: string) =>
     // ssn required unless last4 provided (handled inside ssnValidation)
     identification_number: ssnValidation,
     ownership_percentage: role === 'owner'
-      ? ownershipPercentageValidation.required('Enter ownership percentage')
+      ? makeOwnershipPercentageValidation(25).required('Enter ownership percentage')
       : ownershipPercentageValidation.nullable(),
     address: addressSchemaUSA(false),
   });
@@ -66,7 +67,7 @@ const strictSchemaCAN = (role: string) =>
     ssn_last4: string().nullable(),
     identification_number: makeIdentityNumberValidation(CountryCode.CAN).nullable(),
     ownership_percentage: role === 'owner'
-      ? ownershipPercentageValidation.required('Enter ownership percentage')
+      ? makeOwnershipPercentageValidation(25).required('Enter ownership percentage')
       : ownershipPercentageValidation.nullable(),
     address: addressSchemaCAN(false),
   });

--- a/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
+++ b/packages/webcomponents/src/components/business-forms/schemas/schema-validations.ts
@@ -164,19 +164,22 @@ export const ssnValidation = string()
   })
   .transform(transformEmptyString);
 
-export const ownershipPercentageValidation = string()
-  .matches(numbersOnlyRegex, 'Enter valid percentage')
-  .test('min', 'Percentage must be at least 0', (value) => {
-    if (!value) return true;
-    const num = parseFloat(value);
-    return num >= 0;
-  })
-  .test('max', 'Percentage must be at most 100', (value) => {
-    if (!value) return true;
-    const num = parseFloat(value);
-    return num <= 100;
-  })
-  .transform(transformEmptyString);
+export const makeOwnershipPercentageValidation = (min = 0) =>
+  string()
+    .matches(numbersOnlyRegex, 'Enter valid percentage')
+    .test('min', `Ownership percentage must be at least ${min}%`, (value) => {
+      if (!value) return true;
+      const num = parseFloat(value);
+      return num >= min;
+    })
+    .test('max', 'Percentage must be at most 100', (value) => {
+      if (!value) return true;
+      const num = parseFloat(value);
+      return num <= 100;
+    })
+    .transform(transformEmptyString);
+
+export const ownershipPercentageValidation = makeOwnershipPercentageValidation(0);
 
 // Address Validations
 


### PR DESCRIPTION
## Summary
Closes #2588. Enforces minimum 25% ownership for owners and unique emails across owners on the business owners form.

## Changes
- **Ownership minimum**: owners now require `ownership_percentage >= 25%` (US & CAN strict schemas). Added `makeOwnershipPercentageValidation(min)` factory in `schema-validations.ts`; existing `ownershipPercentageValidation` keeps `min=0` for non-owner roles.
- **Unique emails**: business owners step blocks submit when two owners share the same email (case-insensitive, trimmed), surfacing a field-level error via new `getEmail()`/`setEmailError()` `@Method`s on `owner-form`.
- **UX**: added an info alert on the owners step — "All owners with 25% or more ownership of the business must be registered."

## Testing
- `stencil test --spec` for `business-owners-form-step` & `business-identity-schema` — 43 passed
- lint clean on changed files