### PR TITLE
chore: add minor changeset for onboarding changes

### DIFF
--- a/.changeset/onboarding-minor.md
+++ b/.changeset/onboarding-minor.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": minor
+---
+
+Onboarding improvements: ownership percentage validation and date of establishment on the business form.

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.13.7",
+  "version": "6.14.0",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",

--- a/packages/webcomponents/package.json
+++ b/packages/webcomponents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@justifi/webcomponents",
-  "version": "6.14.0",
+  "version": "6.13.7",
   "description": "JustiFi Web Components",
   "collection": "dist/collection/collection-manifest.json",
   "main": "dist/index.cjs.js",


### PR DESCRIPTION
Adds a `minor` changeset for `@justifi/webcomponents` covering onboarding changes:

- Ownership percentage validation
- Date of establishment on the business form

The changesets release process will bump `6.13.7` → `6.14.0` (the manual version edit was reverted so versioning is handled by the release PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)