### PR TITLE
docs: payment provisioning validation rules

### DIFF
--- a/docs/entities/payment-provisioning.mdx
+++ b/docs/entities/payment-provisioning.mdx
@@ -53,6 +53,20 @@ Component to render a business onboarding form, segmented into multiple steps. Y
 
 This component does not expose any public methods. Form submission is handled automatically through the multi-step form flow.
 
+## Validation Rules
+
+The form enforces the following rules before a step can be submitted. They apply to both US and Canadian businesses.
+
+### Business Information
+
+- **Date of Registration** is required and must be a date in the past — today's date is not accepted.
+
+### Business Owners
+
+- **Ownership percentage** is required for every owner and must be at least **25%** (and at most 100%). Owners with less than 25% ownership should not be registered; the form displays an informational alert reminding that all owners with 25% or more ownership of the business must be registered.
+- **Combined ownership** across all owners cannot exceed **100%**. Totals under 100% are allowed.
+- **Email addresses** must be unique across owners. Submitting duplicate emails blocks the step and flags the offending field with an error.
+
 ## Theming & Layout
 
 <PartsMarkdownTable


### PR DESCRIPTION
## Summary
- Add Validation Rules section to payment-provisioning docs covering recent onboarding changes (Jaris integration): #1530, #1536, #1539
- Documents: registration date must be in the past; owner ownership min 25% / max 100%; combined ownership ≤100% (under 100% allowed); unique owner emails

🤖 Generated with [Claude Code](https://claude.com/claude-code)