### PR TITLE
feat: send component version header on API calls

### DIFF
--- a/.changeset/long-wings-see.md
+++ b/.changeset/long-wings-see.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Send library version in a `Justifi-Web-Component-Version` request header on all API calls.

--- a/packages/webcomponents/src/api/Api.ts
+++ b/packages/webcomponents/src/api/Api.ts
@@ -1,6 +1,7 @@
 import { waitForConfig, configState } from '../components/config-provider/config-state';
 import { generateId } from '../utils/utils';
 import { PagingInfo } from './Pagination';
+import packageJson from '../../package.json';
 
 export interface IApiResponse<T> {
   data: T;
@@ -78,6 +79,7 @@ export const Api = () => {
     if (!authToken) {
       return {
         'Content-Type': 'application/json',
+        'Justifi-Web-Component-Version': packageJson.version,
       };
     }
 
@@ -85,6 +87,7 @@ export const Api = () => {
       Authorization: `Bearer ${authToken}`,
       'Idempotency-Key': generateId(),
       'Content-Type': 'application/json',
+      'Justifi-Web-Component-Version': packageJson.version,
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `Justifi-Web-Component-Version` request header (sourced from `package.json` version) to all API calls, for both authed and unauthed requests.
- Enables payment provisioning to start rejecting requests that are missing the component version.

## Changes
- `packages/webcomponents/src/api/Api.ts`: include version header in request headers.
- Changeset (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)