### PR TITLE
chore: republish docs (3.0.1) for payment provisioning validation rules

### DIFF
--- a/.changeset/republish-docs.md
+++ b/.changeset/republish-docs.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents-docs": patch
+---
+
+Republish docs to include payment provisioning validation rules (jaris integration).


### PR DESCRIPTION
## What

Adds a changeset bumping \`@justifi/webcomponents-docs\` to **3.0.1** (patch).

## Why

The \`6.14.1\` release did not bump the docs package version, so the June 15 docs change \`bfa59c7f\` ("payment provisioning validation rules (jaris integration)") was never published to npm and never propagated to public-docs.

Republishing docs at \`3.0.1\` will:
1. Publish the latest docs content to npm.
2. Fire the \`webcomponents-docs-published\` dispatch → open a fresh PR in \`justifi-tech/public-docs\` (new branch \`update-wc-docs-3.0.1\`).

Supersedes the stale public-docs PR #284 (built from June-9 \`3.0.0\` content).

## Release

Version bump handled by the changesets release process — do **not** manually edit \`docs/package.json\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)