### PR TITLE
fix: light tooltip default for readable contrast

### DIFF
--- a/.changeset/tooltip-light-default.md
+++ b/.changeset/tooltip-light-default.md
@@ -1,0 +1,5 @@
+---
+"@justifi/webcomponents": patch
+---
+
+Fix unreadable tooltip text. Tooltips now default to a light bubble (white background, dark text, subtle border + shadow) instead of dark-on-dark. The tooltip stays themeable via `::part(tooltip)`/`::part(tooltip-inner)` and the shared `color`/`text` parts — themed text color now lands on a light background and stays readable.

--- a/apps/component-examples/css/theme.css
+++ b/apps/component-examples/css/theme.css
@@ -163,7 +163,3 @@ body {
   background-color: #f9f9f9;
   cursor: pointer;
 }
-
-::part(tooltip-inner) {
-  color: #fff;
-}

--- a/packages/webcomponents/src/components/business-details/test/__snapshots__/business-details.spec.tsx.snap
+++ b/packages/webcomponents/src/components/business-details/test/__snapshots__/business-details.spec.tsx.snap
@@ -6653,10 +6653,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -6760,7 +6760,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {

--- a/packages/webcomponents/src/components/gross-payment-chart/test/__snapshots__/justifi-gross-payment-chart.spec.tsx.snap
+++ b/packages/webcomponents/src/components/gross-payment-chart/test/__snapshots__/justifi-gross-payment-chart.spec.tsx.snap
@@ -6653,10 +6653,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -6760,7 +6760,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -20817,10 +20819,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -20924,7 +20926,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -34981,10 +34985,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -35088,7 +35092,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -49145,10 +49151,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -49252,7 +49258,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -63309,10 +63317,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -63416,7 +63424,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {

--- a/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
+++ b/packages/webcomponents/src/components/order-terminals/test/__snapshots__/order-terminals.spec.tsx.snap
@@ -6653,10 +6653,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -6760,7 +6760,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -20940,10 +20942,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -21047,7 +21049,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -35187,10 +35191,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -35294,7 +35298,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -49399,10 +49405,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -49506,7 +49512,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -63667,10 +63675,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -63774,7 +63782,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {
@@ -77954,10 +77964,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -78061,7 +78071,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {

--- a/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details.spec.tsx.snap
+++ b/packages/webcomponents/src/components/payout-details/test/__snapshots__/payout-details.spec.tsx.snap
@@ -6653,10 +6653,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -6760,7 +6760,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {

--- a/packages/webcomponents/src/ui-components/styled-host/styled-host.css
+++ b/packages/webcomponents/src/ui-components/styled-host/styled-host.css
@@ -6647,10 +6647,10 @@ fieldset:disabled .btn {
   --bs-tooltip-padding-y: 0.25rem;
   --bs-tooltip-margin: ;
   --bs-tooltip-font-size: 0.875rem;
-  --bs-tooltip-color: var(--bs-body-bg);
-  --bs-tooltip-bg: var(--bs-emphasis-color);
+  --bs-tooltip-color: var(--bs-body-color);
+  --bs-tooltip-bg: var(--bs-body-bg);
   --bs-tooltip-border-radius: var(--bs-border-radius);
-  --bs-tooltip-opacity: 0.9;
+  --bs-tooltip-opacity: 1;
   --bs-tooltip-arrow-width: 0.8rem;
   --bs-tooltip-arrow-height: 0.4rem;
   z-index: var(--bs-tooltip-zindex);
@@ -6754,7 +6754,9 @@ fieldset:disabled .btn {
   color: var(--bs-tooltip-color);
   text-align: center;
   background-color: var(--bs-tooltip-bg);
+  border: var(--bs-border-width) solid var(--bs-border-color);
   border-radius: var(--bs-tooltip-border-radius);
+  box-shadow: var(--bs-box-shadow);
 }
 
 .popover {


### PR DESCRIPTION
## Problem

Reported in justifi-tech/engineering-artifacts#2728 — Payment Provisioning tooltip text is unreadable (too dark). Reproduces on WayCool's app and in our own [docs theming example](https://docs.justifi.tech/web-components/entities/payment-provisioning#theming--layout), but looks correct on the customer dashboard and hosted onboarding.

## Root cause

The tooltip is intentionally themeable: `tooltip-inner` exposes the shared `color`/`text` parts (`parts.ts`). Consumers theme their form text dark via `::part(color)` / `::part(text)` — and that's the intended channel.

But the tooltip's **default palette was dark** (`--bs-tooltip-bg: var(--bs-emphasis-color)` → black bubble, `--bs-tooltip-color: var(--bs-body-bg)` → white text). So when a consumer themed text dark, the dark text landed on the dark bubble → dark-on-dark, unreadable. Confirmed via live reproduction: computed `color: rgb(51,51,51)` on `background: rgb(0,0,0)`. Surfaces that don't theme text color (dashboard, hosted onboarding) kept the white-on-black default and looked fine.

## Fix

Flip the **default** tooltip palette to light so themed (dark) text stays readable, without removing themeability:

- `--bs-tooltip-color: var(--bs-body-color)` — dark text by default
- `--bs-tooltip-bg: var(--bs-body-bg)` — white bubble
- `--bs-tooltip-opacity: 1` — opaque (a translucent light card looks washed out)
- `.tooltip-inner`: added `border` + `box-shadow` so the white bubble is visible on white forms

The tooltip remains fully themeable via `::part(tooltip)` / `::part(tooltip-inner)` and the shared `color`/`text` parts; themed text now lands on a light background.

## Heads-up (visual change)

This changes the tooltip's appearance on **all** surfaces — including the dashboard and hosted onboarding, which currently render the old dark bubble correctly. That's intentional, but flagging it for design awareness.

## Verification

- Reproduced and verified the fix on the live docs page with Playwright (themed `::part(color)` → readable dark text on a white bubble with border/shadow).
- Full spec suite: 847 passed / 87 snapshots / 98 suites. `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)