### PR TITLE
fix: name missing prop(s) in MISSING_PROPS error

### DIFF
--- a/.changeset/fancy-donuts-love.md
+++ b/.changeset/fancy-donuts-love.md
@@ -1,0 +1,6 @@
+---
+"@justifi/webcomponents": patch
+"@justifi/webcomponents-docs": patch
+---
+
+Payment provisioning form steps now name the specific missing prop(s) in the MISSING_PROPS error (e.g. Missing required props: auth-token, business-id) instead of the generic Missing required props.

--- a/packages/webcomponents/src/api/ComponentEvents.ts
+++ b/packages/webcomponents/src/api/ComponentEvents.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "@stencil/core";
 import { BusinessFormClickActions, BusinessFormStep } from "../components/business-forms/utils/event-types";
 import { DisputeManagementClickActions, DisputeResponseFormStep } from "../components/dispute-management/event-types";
 import { TableClickActions } from "../ui-components/table/event-types";
@@ -32,6 +33,27 @@ export interface ComponentErrorEvent {
   message: string; // A descriptive message about the error
   severity?: ComponentErrorSeverity; // Optional severity level
   data?: any; // Additional data pertinent to the error (optional)
+}
+
+// Emits a MISSING_PROPS error naming each falsy prop. Returns true when all props are present.
+// `props` keys are the public attribute names, e.g. { 'auth-token': this.authToken }.
+export function validateRequiredProps(
+  errorEvent: EventEmitter<ComponentErrorEvent>,
+  props: Record<string, unknown>,
+): boolean {
+  const missingProps = Object.entries(props)
+    .filter(([, value]) => !value)
+    .map(([name]) => name);
+
+  if (missingProps.length) {
+    errorEvent.emit({
+      message: `Missing required props: ${missingProps.join(', ')}`,
+      errorCode: ComponentErrorCodes.MISSING_PROPS,
+      severity: ComponentErrorSeverity.ERROR,
+    });
+    return false;
+  }
+  return true;
 }
 export interface RecordClickEvent {
   id: string;

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/additional-questions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/additional-questions-form-step.tsx
@@ -1,6 +1,5 @@
 import { Component, h, Prop, State, Event, EventEmitter, Watch, Method } from '@stencil/core';
-import { ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
-import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
+import { ComponentErrorEvent, ComponentFormStepCompleteEvent, validateRequiredProps } from '../../../../api/ComponentEvents';
 import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
 import { BusinessService } from '../../../../api/services/business.service';
 import { additionalQuestionsSchema } from '../../schemas/business-additional-questions-schema';
@@ -69,28 +68,23 @@ export class AdditionalQuestionsFormStep {
   }
 
   private initializeApi() {
-    if (this.authToken && this.businessId) {
-      this.getBusiness = makeGetBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-      this.patchBusiness = makePatchBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-    } else {
-      const missingProps = [
-        !this.authToken && 'auth-token',
-        !this.businessId && 'business-id',
-      ].filter(Boolean);
-      this.errorEvent.emit({
-        message: `Missing required props: ${missingProps.join(', ')}`,
-        errorCode: ComponentErrorCodes.MISSING_PROPS,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+    if (!validateRequiredProps(this.errorEvent, {
+      'auth-token': this.authToken,
+      'business-id': this.businessId,
+    })) {
+      return;
     }
+
+    this.getBusiness = makeGetBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
+    this.patchBusiness = makePatchBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
   }
 
   private getData = () => {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/additional-questions-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/additional-questions-form-step.tsx
@@ -81,8 +81,12 @@ export class AdditionalQuestionsFormStep {
         service: new BusinessService()
       });
     } else {
+      const missingProps = [
+        !this.authToken && 'auth-token',
+        !this.businessId && 'business-id',
+      ].filter(Boolean);
       this.errorEvent.emit({
-        message: 'Missing required props',
+        message: `Missing required props: ${missingProps.join(', ')}`,
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         severity: ComponentErrorSeverity.ERROR,
       });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/test/business-additional-questions-form-step.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/additional-questions/test/business-additional-questions-form-step.spec.tsx
@@ -65,7 +65,7 @@ describe('additional-questions-form-step', () => {
       expect(captured).toContainEqual(
         expect.objectContaining({
           errorCode: ComponentErrorCodes.MISSING_PROPS,
-          message: 'Missing required props',
+          message: 'Missing required props: auth-token, business-id',
         })
       );
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -1,5 +1,5 @@
 import { Component, h, Prop, State, Event, EventEmitter, Watch, Method } from '@stencil/core';
-import { ComponentErrorEvent, ComponentErrorCodes, ComponentErrorSeverity, ComponentFormStepCompleteEvent, BankAccount, IBankAccount } from '../../../../api';
+import { ComponentErrorEvent, ComponentErrorCodes, ComponentErrorSeverity, ComponentFormStepCompleteEvent, BankAccount, IBankAccount, validateRequiredProps } from '../../../../api';
 import { makeGetBusiness, makePostBankAccount } from '../payment-provisioning-actions';
 import { BusinessService, BusinessBankAccountService } from '../../../../api/services/business.service';
 import { CountryCode } from '../../../../utils/country-codes';
@@ -68,27 +68,22 @@ export class BusinessBankAccountFormStep {
   }
 
   private initializeApi() {
-    if (this.authToken && this.businessId) {
-      this.getBusiness = makeGetBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-      this.postBankAccount = makePostBankAccount({
-        authToken: this.authToken,
-        service: new BusinessBankAccountService()
-      });
-    } else {
-      const missingProps = [
-        !this.authToken && 'auth-token',
-        !this.businessId && 'business-id',
-      ].filter(Boolean);
-      this.errorEvent.emit({
-        message: `Missing required props: ${missingProps.join(', ')}`,
-        errorCode: ComponentErrorCodes.MISSING_PROPS,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+    if (!validateRequiredProps(this.errorEvent, {
+      'auth-token': this.authToken,
+      'business-id': this.businessId,
+    })) {
+      return;
     }
+
+    this.getBusiness = makeGetBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
+    this.postBankAccount = makePostBankAccount({
+      authToken: this.authToken,
+      service: new BusinessBankAccountService()
+    });
   }
 
   private getSchema = () => {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/bank-account/business-bank-account-form-step.tsx
@@ -79,8 +79,12 @@ export class BusinessBankAccountFormStep {
         service: new BusinessBankAccountService()
       });
     } else {
+      const missingProps = [
+        !this.authToken && 'auth-token',
+        !this.businessId && 'business-id',
+      ].filter(Boolean);
       this.errorEvent.emit({
-        message: 'Missing required props',
+        message: `Missing required props: ${missingProps.join(', ')}`,
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         severity: ComponentErrorSeverity.ERROR,
       });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -1,8 +1,7 @@
 import { Component, h, Prop, State, Event, EventEmitter, Watch, Method } from '@stencil/core';
-import { ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
 import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
 import { BusinessService } from '../../../../api/services/business.service';
-import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
+import { ComponentErrorEvent, ComponentFormStepCompleteEvent, validateRequiredProps } from '../../../../api/ComponentEvents';
 import { CountryCode } from '../../../../utils/country-codes';
 import { businessCoreInfoSchemaUSA, businessCoreInfoSchemaCAN } from '../../schemas/business-core-info-schema';
 import { FormController } from '../../../../ui-components/form/form';
@@ -66,28 +65,23 @@ export class BusinessCoreInfoFormStep {
   }
 
   private initializeApi() {
-    if (this.authToken && this.businessId) {
-      this.getBusiness = makeGetBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-      this.patchBusiness = makePatchBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-    } else {
-      const missingProps = [
-        !this.authToken && 'auth-token',
-        !this.businessId && 'business-id',
-      ].filter(Boolean);
-      this.errorEvent.emit({
-        message: `Missing required props: ${missingProps.join(', ')}`,
-        errorCode: ComponentErrorCodes.MISSING_PROPS,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+    if (!validateRequiredProps(this.errorEvent, {
+      'auth-token': this.authToken,
+      'business-id': this.businessId,
+    })) {
+      return;
     }
+
+    this.getBusiness = makeGetBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
+    this.patchBusiness = makePatchBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
   }
 
   private getData = () => {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/business-core-info-form-step.tsx
@@ -78,8 +78,12 @@ export class BusinessCoreInfoFormStep {
         service: new BusinessService()
       });
     } else {
+      const missingProps = [
+        !this.authToken && 'auth-token',
+        !this.businessId && 'business-id',
+      ].filter(Boolean);
       this.errorEvent.emit({
-        message: 'Missing required props',
+        message: `Missing required props: ${missingProps.join(', ')}`,
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         severity: ComponentErrorSeverity.ERROR,
       });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/test/business-core-info-form-step.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-core-info/test/business-core-info-form-step.spec.tsx
@@ -402,7 +402,7 @@ describe('business-core-info-form-step', () => {
       expect(captured).toContainEqual(
         expect.objectContaining({
           errorCode: ComponentErrorCodes.MISSING_PROPS,
-          message: 'Missing required props',
+          message: 'Missing required props: auth-token, business-id',
         })
       );
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
@@ -172,8 +172,12 @@ export class BusinessOwnersFormStep {
         service: new BusinessService()
       });
     } else {
+      const missingProps = [
+        !this.authToken && 'auth-token',
+        !this.businessId && 'business-id',
+      ].filter(Boolean);
       this.errorEvent.emit({
-        message: 'Missing required props',
+        message: `Missing required props: ${missingProps.join(', ')}`,
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         severity: ComponentErrorSeverity.ERROR,
       });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/business-owners-form-step.tsx
@@ -1,8 +1,7 @@
 import { Component, Host, h, Prop, State, Event, EventEmitter, Method, Watch, Listen } from '@stencil/core';
-import { ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
 import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
 import { BusinessService } from '../../../../api/services/business.service';
-import { ComponentErrorEvent, ComponentClickEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
+import { ComponentErrorEvent, ComponentClickEvent, ComponentFormStepCompleteEvent, validateRequiredProps } from '../../../../api/ComponentEvents';
 import { Button } from '../../../../ui-components';
 import { heading2, alert } from '../../../../styles/parts';
 import { PaymentProvisioningLoading } from '../payment-provisioning-loading';
@@ -160,28 +159,23 @@ export class BusinessOwnersFormStep {
   }
 
   private initializeApi() {
-    if (this.authToken && this.businessId) {
-      this.getBusiness = makeGetBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-      this.patchBusiness = makePatchBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-    } else {
-      const missingProps = [
-        !this.authToken && 'auth-token',
-        !this.businessId && 'business-id',
-      ].filter(Boolean);
-      this.errorEvent.emit({
-        message: `Missing required props: ${missingProps.join(', ')}`,
-        errorCode: ComponentErrorCodes.MISSING_PROPS,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+    if (!validateRequiredProps(this.errorEvent, {
+      'auth-token': this.authToken,
+      'business-id': this.businessId,
+    })) {
+      return;
     }
+
+    this.getBusiness = makeGetBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
+    this.patchBusiness = makePatchBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
   }
 
   private addOwnerForm = (fireClick?: boolean) => {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/test/business-owners-form-step.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-owners/test/business-owners-form-step.spec.tsx
@@ -77,7 +77,7 @@ describe('business-owners-form-step', () => {
       expect(captured).toContainEqual(
         expect.objectContaining({
           errorCode: ComponentErrorCodes.MISSING_PROPS,
-          message: 'Missing required props',
+          message: 'Missing required props: auth-token, business-id',
         })
       );
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -4,7 +4,7 @@ import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-acti
 import { BusinessService } from '../../../../api/services/business.service';
 import { Identity, Representative } from '../../../../api/Identity';
 import { FormController } from '../../../../ui-components/form/form';
-import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
+import { ComponentErrorEvent, ComponentFormStepCompleteEvent, validateRequiredProps } from '../../../../api/ComponentEvents';
 import { identitySchemaByCountry } from '../../schemas/business-identity-schema';
 import { CountryCode } from '../../../../utils/country-codes';
 import { PaymentProvisioningLoading } from '../payment-provisioning-loading';
@@ -49,28 +49,23 @@ export class BusinessRepresentativeFormStep {
   }
 
   private initializeApi() {
-    if (this.authToken && this.businessId) {
-      this.getBusiness = makeGetBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-      this.patchBusiness = makePatchBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-    } else {
-      const missingProps = [
-        !this.authToken && 'auth-token',
-        !this.businessId && 'business-id',
-      ].filter(Boolean);
-      this.errorEvent.emit({
-        message: `Missing required props: ${missingProps.join(', ')}`,
-        errorCode: ComponentErrorCodes.MISSING_PROPS,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+    if (!validateRequiredProps(this.errorEvent, {
+      'auth-token': this.authToken,
+      'business-id': this.businessId,
+    })) {
+      return;
     }
+
+    this.getBusiness = makeGetBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
+    this.patchBusiness = makePatchBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
   }
 
   private initializeForm() {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/business-representative-form-step.tsx
@@ -61,8 +61,12 @@ export class BusinessRepresentativeFormStep {
         service: new BusinessService()
       });
     } else {
+      const missingProps = [
+        !this.authToken && 'auth-token',
+        !this.businessId && 'business-id',
+      ].filter(Boolean);
       this.errorEvent.emit({
-        message: 'Missing required props',
+        message: `Missing required props: ${missingProps.join(', ')}`,
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         severity: ComponentErrorSeverity.ERROR,
       });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/test/business-representative-form-step.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/business-representative/test/business-representative-form-step.spec.tsx
@@ -79,7 +79,7 @@ describe('business-representative-form-step', () => {
       expect(captured).toContainEqual(
         expect.objectContaining({
           errorCode: ComponentErrorCodes.MISSING_PROPS,
-          message: 'Missing required props',
+          message: 'Missing required props: auth-token, business-id',
         })
       );
     });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-upload/document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-upload/document-upload-form-step.tsx
@@ -4,6 +4,7 @@ import {
   ComponentErrorCodes,
   ComponentErrorSeverity,
   ComponentFormStepCompleteEvent,
+  validateRequiredProps,
   EntityDocument,
   EntityDocumentType,
   FileSelectEvent,
@@ -82,27 +83,22 @@ export class DocumentUploadFormStep {
   }
 
   private initializeApi() {
-    if (this.authToken && this.businessId) {
-      this.getBusiness = makeGetBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-      this.postDocumentRecord = makePostDocumentRecord({
-        authToken: this.authToken,
-        service: new DocumentRecordService()
-      });
-    } else {
-      const missingProps = [
-        !this.authToken && 'auth-token',
-        !this.businessId && 'business-id',
-      ].filter(Boolean);
-      this.errorEvent.emit({
-        message: `Missing required props: ${missingProps.join(', ')}`,
-        errorCode: ComponentErrorCodes.MISSING_PROPS,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+    if (!validateRequiredProps(this.errorEvent, {
+      'auth-token': this.authToken,
+      'business-id': this.businessId,
+    })) {
+      return;
     }
+
+    this.getBusiness = makeGetBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
+    this.postDocumentRecord = makePostDocumentRecord({
+      authToken: this.authToken,
+      service: new DocumentRecordService()
+    });
   }
 
   private getData = () => {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/document-upload/document-upload-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/document-upload/document-upload-form-step.tsx
@@ -93,8 +93,12 @@ export class DocumentUploadFormStep {
         service: new DocumentRecordService()
       });
     } else {
+      const missingProps = [
+        !this.authToken && 'auth-token',
+        !this.businessId && 'business-id',
+      ].filter(Boolean);
       this.errorEvent.emit({
-        message: 'Missing required props',
+        message: `Missing required props: ${missingProps.join(', ')}`,
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         severity: ComponentErrorSeverity.ERROR,
       });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step.tsx
@@ -1,8 +1,7 @@
 import { Component, Method, Prop, State, h, Event, EventEmitter, Watch } from '@stencil/core';
-import { ComponentErrorCodes, ComponentErrorSeverity } from '../../../../api/ComponentError';
 import { makeGetBusiness, makePatchBusiness } from '../payment-provisioning-actions';
 import { BusinessService } from '../../../../api/services/business.service';
-import { ComponentErrorEvent, ComponentFormStepCompleteEvent } from '../../../../api/ComponentEvents';
+import { ComponentErrorEvent, ComponentFormStepCompleteEvent, validateRequiredProps } from '../../../../api/ComponentEvents';
 import { CountryCode } from '../../../../utils/country-codes';
 import { addressSchemaByCountry } from '../../schemas/business-address-schema';
 import { FormController } from '../../../../ui-components/form/form';
@@ -62,28 +61,23 @@ export class LegalAddressFormStep {
   }
 
   private initializeApi() {
-    if (this.authToken && this.businessId) {
-      this.getBusiness = makeGetBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-      this.patchBusiness = makePatchBusiness({
-        authToken: this.authToken,
-        businessId: this.businessId,
-        service: new BusinessService()
-      });
-    } else {
-      const missingProps = [
-        !this.authToken && 'auth-token',
-        !this.businessId && 'business-id',
-      ].filter(Boolean);
-      this.errorEvent.emit({
-        message: `Missing required props: ${missingProps.join(', ')}`,
-        errorCode: ComponentErrorCodes.MISSING_PROPS,
-        severity: ComponentErrorSeverity.ERROR,
-      });
+    if (!validateRequiredProps(this.errorEvent, {
+      'auth-token': this.authToken,
+      'business-id': this.businessId,
+    })) {
+      return;
     }
+
+    this.getBusiness = makeGetBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
+    this.patchBusiness = makePatchBusiness({
+      authToken: this.authToken,
+      businessId: this.businessId,
+      service: new BusinessService()
+    });
   }
 
   private getData = () => {

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/legal-address-form-step.tsx
@@ -74,8 +74,12 @@ export class LegalAddressFormStep {
         service: new BusinessService()
       });
     } else {
+      const missingProps = [
+        !this.authToken && 'auth-token',
+        !this.businessId && 'business-id',
+      ].filter(Boolean);
       this.errorEvent.emit({
-        message: 'Missing required props',
+        message: `Missing required props: ${missingProps.join(', ')}`,
         errorCode: ComponentErrorCodes.MISSING_PROPS,
         severity: ComponentErrorSeverity.ERROR,
       });

--- a/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/test/legal-address-form-step.spec.tsx
+++ b/packages/webcomponents/src/components/business-forms/payment-provisioning/legal-address-form/test/legal-address-form-step.spec.tsx
@@ -68,7 +68,7 @@ describe('legal-address-form-step', () => {
       expect(captured).toContainEqual(
         expect.objectContaining({
           errorCode: ComponentErrorCodes.MISSING_PROPS,
-          message: 'Missing required props',
+          message: 'Missing required props: auth-token, business-id',
         })
       );
     });


### PR DESCRIPTION
## Summary

Payment provisioning form steps now name the specific missing prop(s) in the `MISSING_PROPS` error instead of emitting a generic `Missing required props` message.

Before: `Missing required props`
After: `Missing required props: auth-token, business-id`

Each affected form step computes the list of absent props (`auth-token`, `business-id`, etc.) and includes them in the emitted error message.

## Steps updated

- additional-questions
- bank-account
- business-core-info
- business-owners
- business-representative
- document-upload
- legal-address-form

## Test plan

- [x] Updated unit specs assert the prop-specific error message
- [x] `lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
